### PR TITLE
EX8 Purple Cards

### DIFF
--- a/Assets/CardEffect/EX8/Purple/BarbamonXAntibody_EX8_063.cs
+++ b/Assets/CardEffect/EX8/Purple/BarbamonXAntibody_EX8_063.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class BarbamonXAntibody_EX8_063 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Digivolution Condition
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.CardNames.Contains("Barbamon");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition,
+                    digivolutionCost: 1,
+                    ignoreDigivolutionRequirement: false,
+                    card: card,
+                    condition: null));
+            }
+            #endregion
+
+            #region When Digivolving/When Attacking Shared
+        
+            bool CanSelectCardOpponentsCardCondition(CardSource cardSource)
+            {
+                return cardSource.Owner == card.Owner.Enemy;
+            }
+            
+            #endregion
+
+            #region When Digivolving
+            
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Opponent trashes 1 card, or you play a fallen angel", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectSharedDiscription());
+                activateClass.SetHashString("TrashOrPlay_EX8_063");
+                cardEffects.Add(activateClass);
+
+                string EffectSharedDiscription()
+                {
+                    return "[When Digivolving] [Once Per Turn] Your opponent may trash 1 card in their hand. If this effect didn't trash, you may play 1 [Fallen Angel] trait Digimon card with a play cost of 7 or less from your trash without paying the cost.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleArea(card))
+                    {
+                        if (card.Owner.Enemy.HandCards.Count >= 1)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+                
+                bool CanSelectCardInTrash(CardSource cardSource)
+                {
+                    if (CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass))
+                    {
+                        if (cardSource.IsDigimon)
+                        {
+                            if (cardSource.GetCostItself == 7)
+                            {
+                                if (cardSource.EqualsTraits("Fallen Angel") || cardSource.EqualsTraits("FallenAngel"))
+                                {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    bool discarded = false;
+
+                    if (card.Owner.Enemy.HandCards.Count >= 1)
+                    {
+                        int discardCount = 1;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner.Enemy,
+                            canTargetCondition: CanSelectCardOpponentsCardCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: discardCount,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+
+                        IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                        {
+                            if (cardSources.Count >= 1)
+                            {
+                                discarded = true;
+
+                                yield return null;
+                            }
+                        }
+                    }
+
+                    if (!discarded)
+                    {
+                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardInTrash))
+                        {
+                            int maxCount = Math.Min(1, card.Owner.TrashCards.Count(CanSelectCardInTrash));
+
+                            List<CardSource> selectedCards = new List<CardSource>();
+
+                            SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                            selectCardEffect.SetUp(
+                                        canTargetCondition: CanSelectCardInTrash,
+                                        canTargetCondition_ByPreSelecetedList: null,
+                                        canEndSelectCondition: null,
+                                        canNoSelect: () => true,
+                                        selectCardCoroutine: SelectCardCoroutine,
+                                        afterSelectCardCoroutine: null,
+                                        message: "Select 1 card to play.",
+                                        maxCount: maxCount,
+                                        canEndNotMax: false,
+                                        isShowOpponent: true,
+                                        mode: SelectCardEffect.Mode.Custom,
+                                        root: SelectCardEffect.Root.Trash,
+                                        customRootCardList: null,
+                                        canLookReverseCard: true,
+                                        selectPlayer: card.Owner,
+                                        cardEffect: activateClass);
+
+                            selectCardEffect.SetUpCustomMessage("Select 1 card to play.", "The opponent is selecting 1 card to play.");
+                            selectCardEffect.SetUpCustomMessage_ShowCard("Played Card");
+
+                            yield return StartCoroutine(selectCardEffect.Activate());
+
+                            IEnumerator SelectCardCoroutine(CardSource cardSource)
+                            {
+                                selectedCards.Add(cardSource);
+
+                                yield return null;
+                            }
+
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                                cardSources: selectedCards,
+                                activateClass: activateClass,
+                                payCost: false,
+                                isTapped: false,
+                                root: SelectCardEffect.Root.Trash,
+                                activateETB: true));
+                        }
+                    
+                    }
+                }
+            }
+            
+            #endregion
+            
+            #region When Attacking
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Opponent trashes 1 card, or you play a fallen angel", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectSharedDiscription());
+                activateClass.SetHashString("TrashOrPlay_EX8_063");
+                cardEffects.Add(activateClass);
+
+                string EffectSharedDiscription()
+                {
+                    return "[When Attacking] [Once Per Turn] Your opponent may trash 1 card in their hand. If this effect didn't trash, you may play 1 [Fallen Angel] trait Digimon card with a play cost of 7 or less from your trash without paying the cost.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        if (CardEffectCommons.CanTriggerOnAttack(hashtable, card))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleArea(card))
+                    {
+                        if (card.Owner.Enemy.HandCards.Count >= 1)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+                
+                bool CanSelectCardInTrash(CardSource cardSource)
+                {
+                    if (CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass))
+                    {
+                        if (cardSource.IsDigimon)
+                        {
+                            if (cardSource.GetCostItself == 7)
+                            {
+                                if (cardSource.EqualsTraits("Fallen Angel") || cardSource.EqualsTraits("FallenAngel"))
+                                {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    bool discarded = false;
+
+                    if (card.Owner.Enemy.HandCards.Count >= 1)
+                    {
+                        int discardCount = 1;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner.Enemy,
+                            canTargetCondition: CanSelectCardOpponentsCardCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: discardCount,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+
+                        IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                        {
+                            if (cardSources.Count >= 1)
+                            {
+                                discarded = true;
+
+                                yield return null;
+                            }
+                        }
+                    }
+
+                    if (!discarded)
+                    {
+                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardInTrash))
+                        {
+                            int maxCount = Math.Min(1, card.Owner.TrashCards.Count(CanSelectCardInTrash));
+
+                            List<CardSource> selectedCards = new List<CardSource>();
+
+                            SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                            selectCardEffect.SetUp(
+                                        canTargetCondition: CanSelectCardInTrash,
+                                        canTargetCondition_ByPreSelecetedList: null,
+                                        canEndSelectCondition: null,
+                                        canNoSelect: () => true,
+                                        selectCardCoroutine: SelectCardCoroutine,
+                                        afterSelectCardCoroutine: null,
+                                        message: "Select 1 card to play.",
+                                        maxCount: maxCount,
+                                        canEndNotMax: false,
+                                        isShowOpponent: true,
+                                        mode: SelectCardEffect.Mode.Custom,
+                                        root: SelectCardEffect.Root.Trash,
+                                        customRootCardList: null,
+                                        canLookReverseCard: true,
+                                        selectPlayer: card.Owner,
+                                        cardEffect: activateClass);
+
+                            selectCardEffect.SetUpCustomMessage("Select 1 card to play.", "The opponent is selecting 1 card to play.");
+                            selectCardEffect.SetUpCustomMessage_ShowCard("Played Card");
+
+                            yield return StartCoroutine(selectCardEffect.Activate());
+
+                            IEnumerator SelectCardCoroutine(CardSource cardSource)
+                            {
+                                selectedCards.Add(cardSource);
+
+                                yield return null;
+                            }
+
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                                cardSources: selectedCards,
+                                activateClass: activateClass,
+                                payCost: false,
+                                isTapped: false,
+                                root: SelectCardEffect.Root.Trash,
+                                activateETB: true));
+                        }
+                    
+                    }
+                }
+            }
+            
+            #endregion
+
+            #region All Turns
+            if (timing == EffectTiming.OnDiscardHand)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Trash opponent's security", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetHashString("TrashSecurity_EX8_063");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[All Turns] [Once Per Turn] When your opponent's hand is trashed from, if [Barbamon] or [X Antibody] is in this Digimon's digivolution cards, trash their top security card.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        if (CardEffectCommons.CanTriggerOnTrashHand(hashtable, cardEffect => true, cardSource => cardSource.Owner == card.Owner.Enemy))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        if (card.PermanentOfThisCard().DigivolutionCards.Count((cardSource) => cardSource.EqualsCardName("Barbamon") || cardSource.EqualsCardName("X Antibody")) >= 1)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new IDestroySecurity(
+                        player: card.Owner.Enemy,
+                        destroySecurityCount: 1,
+                        cardEffect: activateClass,
+                        fromTop: true).DestroySecurity());
+
+                }
+            }
+            #endregion
+            
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/BarbamonXAntibody_EX8_063.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/BarbamonXAntibody_EX8_063.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 785a01f482f7e9048962899dd1d4755e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/Boltboutamon_EX8_064.cs
+++ b/Assets/CardEffect/EX8/Purple/Boltboutamon_EX8_064.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class Boltboutamon_EX8_064 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region DNA Digivolution - Colors
+
+            if (timing == EffectTiming.None)
+            {
+                AddJogressConditionClass addJogressConditionClass = new AddJogressConditionClass();
+                addJogressConditionClass.SetUpICardEffect($"DNA Digivolution", CanUseCondition, card);
+                addJogressConditionClass.SetUpAddJogressConditionClass(getJogressCondition: GetJogress);
+                addJogressConditionClass.SetNotShowUI(true);
+                cardEffects.Add(addJogressConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return true;
+                }
+
+                JogressCondition GetJogress(CardSource cardSource)
+                {
+                    if (cardSource == card)
+                    {
+                        bool PermanentConditionPurpleBlack(Permanent permanent)
+                        {
+                            if (permanent != null)
+                            {
+                                if (permanent.TopCard != null)
+                                {
+                                    if (permanent.TopCard.Owner == card.Owner)
+                                    {
+                                        if (permanent.IsDigimon)
+                                        {
+                                            if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent,
+                                                    card))
+                                            {
+                                                if (permanent.TopCard.CardColors.Contains(CardColor.Purple) ||
+                                                    permanent.TopCard.CardColors.Contains(CardColor.Black))
+                                                {
+                                                    if (permanent.Levels_ForJogress(card).Contains(6))
+                                                    {
+                                                        return true;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            return false;
+                        }
+
+                        bool PermanentConditionYellowGreen(Permanent permanent)
+                        {
+                            if (permanent != null)
+                            {
+                                if (permanent.TopCard != null)
+                                {
+                                    if (permanent.TopCard.Owner == card.Owner)
+                                    {
+                                        if (permanent.IsDigimon)
+                                        {
+                                            if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent,
+                                                    card))
+                                            {
+                                                if (permanent.TopCard.CardColors.Contains(CardColor.Yellow) ||
+                                                    permanent.TopCard.CardColors.Contains(CardColor.Green))
+                                                {
+                                                    if (permanent.Levels_ForJogress(card).Contains(6))
+                                                    {
+                                                        return true;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            return false;
+                        }
+
+                        JogressConditionElement[] elements =
+                        {
+                            new(PermanentConditionPurpleBlack, "a level 5 Purple or Black Digimon"),
+                            new(PermanentConditionYellowGreen, "a level 5 Yellow or Green Digimon")
+                        };
+
+                        JogressCondition jogressCondition = new JogressCondition(elements, 0);
+
+                        return jogressCondition;
+                    }
+
+                    return null;
+                }
+            }
+
+            #endregion
+            
+            #region DNA Digivolution - Names
+
+            if (timing == EffectTiming.None)
+            {
+                AddJogressConditionClass addJogressConditionClass = new AddJogressConditionClass();
+                addJogressConditionClass.SetUpICardEffect($"DNA Digivolution", CanUseCondition, card);
+                addJogressConditionClass.SetUpAddJogressConditionClass(getJogressCondition: GetJogress);
+                addJogressConditionClass.SetNotShowUI(true);
+                cardEffects.Add(addJogressConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return true;
+                }
+
+                JogressCondition GetJogress(CardSource cardSource)
+                {
+                    if (cardSource == card)
+                    {
+                        bool PermanentConditionPiedmon(Permanent permanent)
+                        {
+                            if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
+                            {
+                                if (permanent.TopCard.CardNames.Contains("Piedmon"))
+                                {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        }
+
+                        bool PermanentConditionMyotismon(Permanent permanent)
+                        {
+                            if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
+                            {
+                                if (permanent.TopCard.CardNames.Contains("Myotismon"))
+                                {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        }
+
+                        JogressConditionElement[] elements = new JogressConditionElement[]
+                        {
+                        new JogressConditionElement(PermanentConditionPiedmon, "Piedmon"),
+
+                        new JogressConditionElement(PermanentConditionMyotismon, "Myotismon"),
+                        };
+
+                        JogressCondition jogressCondition = new JogressCondition(elements, 0);
+
+                        return jogressCondition;
+                    }
+
+                    return null;
+                }
+            }
+
+            #endregion
+            
+            #region When Digivolving
+            
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("De-Digivolve 3 on 1 Digimon and DP reduce. Then play digimon from the trash.", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Digivolving] <De-Digivolve 3> 1 of your opponent's Digimon and, for the turn, all of their Digimon get -6000 DP. Then, if DNA digivolving, you may play 10 cost's total worth of [NSo] trait Digimon cards from your trash without paying the cost.";
+                }
+
+                bool CanSelectPermanentForDeDigivolveCondition(Permanent permanent)
+                {
+                    return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleArea(card))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentForDeDigivolveCondition))
+                    {
+                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentForDeDigivolveCondition));
+
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectPermanentForDeDigivolveCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: maxCount,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to De-Digivolve.", "The opponent is selecting 1 Digimon to De-Digivolve.");
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            Permanent selectedPermanent = permanent;
+
+                            yield return ContinuousController.instance.StartCoroutine(new IDegeneration(selectedPermanent, 3, activateClass).Degeneration());
+                        }
+                    }
+                    
+                    bool PermanentCondition(Permanent permanent)
+                    {
+                        return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDPPlayerEffect(
+                        permanentCondition: PermanentCondition,
+                        changeValue: -6000,
+                        effectDuration: EffectDuration.UntilEachTurnEnd,
+                        activateClass: activateClass));
+
+                    if (CardEffectCommons.IsJogress(_hashtable))
+                    {
+                        const int maxCost = 10;
+
+                        bool CanSelectNSoDigimonCondition(CardSource cardSource)
+                        {
+                            return CardEffectCommons.CanPlayAsNewPermanent(
+                                       cardSource: cardSource,
+                                       payCost: false,
+                                       cardEffect: activateClass) &&
+                                   cardSource.GetCostItself <= maxCost &&
+                                   cardSource.ContainsTraits("NSo");
+                        }
+
+                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectNSoDigimonCondition))
+                        {
+                            List<CardSource> selectedCards = new List<CardSource>();
+
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                                cardSources: selectedCards,
+                                activateClass: activateClass,
+                                payCost: false,
+                                isTapped: false,
+                                root: SelectCardEffect.Root.Trash,
+                                activateETB: true));
+                            
+                        }
+                    }
+                }
+            }
+            
+            #endregion
+            
+            #region All Turns
+            
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Trash your opponent's top security card", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDiscription());
+                activateClass.SetHashString("TrashSecurity_EX8_064");
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                {
+                    return "[All Turns] [Once Per Turn] When other Digimon are deleted, trash your opponent's top security card.";
+                }
+
+                bool PermanentCondition(Permanent permanent)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(permanent))
+                    {
+                        if (permanent.IsDigimon)
+                        {
+                            if (permanent != card.PermanentOfThisCard())
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        if (CardEffectCommons.CanTriggerOnPermanentDeleted(hashtable, PermanentCondition))
+                        {
+                            return true;
+                        }
+                    }
+                    
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        return true;
+                    }
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new IDestroySecurity(
+                   player: card.Owner.Enemy,
+                   destroySecurityCount: 1,
+                   cardEffect: activateClass,
+                   fromTop: true).DestroySecurity());
+                }
+            }
+            
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/Boltboutamon_EX8_064.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/Boltboutamon_EX8_064.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1122ba0febc3e0648a493edacf8c09ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/DemiDevimon_EX8_057.cs
+++ b/Assets/CardEffect/EX8/Purple/DemiDevimon_EX8_057.cs
@@ -1,0 +1,163 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class DemiDevimon_EX8_057 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution
+
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.IsLevel2 && targetPermanent.TopCard.EqualsTraits("NSo");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition,
+                    digivolutionCost: 0,
+                    ignoreDigivolutionRequirement: false,
+                    card: card,
+                    condition: null)
+                );
+            }
+
+            #endregion
+            
+            #region On Play
+
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Reveal the top 3 cards of deck", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false,
+                    EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return
+                        "[On Play] Reveal the top 3 cards of your deck. Add 1 card with the [NSo] trait and 1 card with the [Fallen Angel] trait among them to the hand. Return the rest to the bottom of the deck.";
+                }
+
+                bool CanSelectNightmareSoldierCardCondition(CardSource cardSource)
+                {
+                    return cardSource.EqualsTraits("NSo");
+                }
+
+                bool CanSelectFallenAngelCardCondition(CardSource cardSource)
+                {
+                    return cardSource.ContainsTraits("Fallen Angel") || cardSource.ContainsTraits("FallenAngel");
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) &&
+                           card.Owner.LibraryCards.Count >= 1;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(
+                        CardEffectCommons.SimplifiedRevealDeckTopCardsAndSelect(
+                            revealCount: 3,
+                            simplifiedSelectCardConditions:
+                            new SimplifiedSelectCardConditionClass[]
+                            {
+                                new(
+                                    canTargetCondition: CanSelectNightmareSoldierCardCondition,
+                                    message: "Select 1 card with the [NSo] trait.",
+                                    mode: SelectCardEffect.Mode.AddHand,
+                                    maxCount: 1,
+                                    selectCardCoroutine: null),
+                                new(
+                                    canTargetCondition: CanSelectFallenAngelCardCondition,
+                                    message: "Select 1 card with the [Fallen Angel] trait.",
+                                    mode: SelectCardEffect.Mode.AddHand,
+                                    maxCount: 1,
+                                    selectCardCoroutine: null),
+                            },
+                            remainingCardsPlace: RemainingCardsPlace.DeckBottom,
+                            activateClass: activateClass
+                        ));
+                }
+            }
+
+            #endregion
+            
+            #region ESS - When Attacking
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Draw 1 and trash 1 card from hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDiscription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("Draw_EX8_057");
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                {
+                    return "[When Attacking] [Once Per Turn] <Draw 1> and trash 1 card in your hand.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleArea(card))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 1, activateClass).Draw());
+
+                    if (card.Owner.HandCards.Count >= 1)
+                    {
+                        int discardCount = 1;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: (cardSource) => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: discardCount,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+                    }
+                }
+            }
+            
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/DemiDevimon_EX8_057.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/DemiDevimon_EX8_057.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb88b5258ded3f94186bb4d8679b90aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/DemiMeramon_EX8_006.cs
+++ b/Assets/CardEffect/EX8/Purple/DemiMeramon_EX8_006.cs
@@ -1,0 +1,118 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class DemiMeramon_EX8_006 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region When Attacking - ESS
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("By trashing 1 card in hand, Delete opponents level 3 Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("WhenAttacking_EX8_006");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] [Once Per Turn] If this Digimon has the [NSo] trait, by trashing 1 card in your hand, delete 1 of your opponent's level 3 Digimon.";
+                }
+
+                bool SelectOpponentsLevel3Digimon(Permanent permanent)
+                {
+                    if(CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
+                    {
+                        if(permanent.Level == 3)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        if (card.PermanentOfThisCard().TopCard.ContainsTraits("NSo"))
+                        {
+                            if (card.Owner.HandCards.Count > 0)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool discarded = false;
+
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: (cardSource) => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                        mode: SelectHandEffect.Mode.Discard,
+                        cardEffect: activateClass);
+
+                    yield return StartCoroutine(selectHandEffect.Activate());
+                    
+                    IEnumerator AfterSelectCardCoroutine(List<CardSource> selectedCards)
+                    {
+                        if(selectedCards.Count > 0)
+                            discarded = true;
+
+                        yield return null;
+                    }
+
+                    if (discarded)
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: SelectOpponentsLevel3Digimon,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+                }
+            }
+            
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/DemiMeramon_EX8_006.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/DemiMeramon_EX8_006.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cae3ddf61efa3144bb25ddb4b4ad16bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/Devimon_EX8_059.cs
+++ b/Assets/CardEffect/EX8/Purple/Devimon_EX8_059.cs
@@ -1,0 +1,469 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class Devimon_EX8_059 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution
+
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.IsLevel2 && targetPermanent.TopCard.EqualsTraits("NSo");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition,
+                    digivolutionCost: 2,
+                    ignoreDigivolutionRequirement: false,
+                    card: card,
+                    condition: null)
+                );
+            }
+
+            #endregion
+
+            #region Shared On Play/When Digivolving
+            bool CanSelectPermanentCondition(Permanent permanent)
+            {
+                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+            }
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Give effects to opponent's Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Play] By trashing 1 card in your hand, 1 of your opponent's Digimon gains \"[On Deletion] Trash 1 card in your hand.\" until the end of their turn.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                        return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (card.Owner.HandCards.Count >= 1)
+                    {
+                        bool discarded = false;
+
+                        int discardCount = 1;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: cardSource => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: discardCount,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+
+                        IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                        {
+                            if (cardSources.Count == 1)
+                            {
+                                discarded = true;
+
+                                yield return null;
+                            }
+                        }
+
+                        if (discarded)
+                        {
+                            if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
+                            {
+                                int maxCount = Math.Min(1,
+                                    CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
+
+                                SelectPermanentEffect selectPermanentEffect =
+                                    GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                                selectPermanentEffect.SetUp(
+                                    selectPlayer: card.Owner,
+                                    canTargetCondition: CanSelectPermanentCondition,
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    maxCount: maxCount,
+                                    canNoSelect: false,
+                                    canEndNotMax: false,
+                                    selectPermanentCoroutine: SelectPermanentCoroutine,
+                                    afterSelectPermanentCoroutine: null,
+                                    mode: SelectPermanentEffect.Mode.Custom,
+                                    cardEffect: activateClass);
+
+                                selectPermanentEffect.SetUpCustomMessage(
+                                    "Select 1 Digimon that will get [On Deletion] Trash 1 card in your hand.",
+                                    "The opponent is selecting 1 Digimon that will get [On Deletion] Trash 1 card in your hand.");
+
+                                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                                IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                                {
+                                    if (permanent != null)
+                                    {
+                                        yield return ContinuousController.instance.StartCoroutine(GManager.instance
+                                            .GetComponent<Effects>().CreateDebuffEffect(permanent));
+                                        ActivateClass activateClass1 = new ActivateClass();
+                                        activateClass1.SetUpICardEffect("Trash 1 card in your hand.", GivenEffectCanUseCondition,
+                                            permanent.TopCard);
+                                        activateClass1.SetUpActivateClass(
+                                            GivenEffectCanActivateCondition,
+                                            GivenEffectActivateCoroutine,
+                                            -1,
+                                            false, GivenEffectDescription());
+                                        activateClass1.SetEffectSourcePermanent(permanent);
+                                        permanent.UntilOwnerTurnEndEffects.Add(GetCardEffect);
+
+                                        if (!permanent.TopCard.CanNotBeAffected(activateClass))
+                                        {
+                                            yield return ContinuousController.instance.StartCoroutine(GManager.instance
+                                                .GetComponent<Effects>().CreateDebuffEffect(permanent));
+                                        }
+
+                                        string GivenEffectDescription()
+                                        {
+                                            return "[On Deletion] Trash 1 card in your hand.";
+                                        }
+
+                                        bool GivenEffectCanUseCondition(Hashtable hashtable)
+                                        {
+                                            return CardEffectCommons.CanTriggerOnDeletion(hashtable, card);
+                                        }
+
+                                        bool GivenEffectCanActivateCondition(Hashtable hashtable1)
+                                        {
+                                            if (CardEffectCommons.IsPermanentExistsOnBattleArea(permanent))
+                                            {
+                                                if (!permanent.TopCard.CanNotBeAffected(activateClass))
+                                                {
+                                                    return true;
+                                                }
+                                            }
+
+                                            return false;
+                                        }
+                                        
+                                        IEnumerator GivenEffectActivateCoroutine(Hashtable _hashtable)
+                                        {
+                                            if (card.Owner.HandCards.Count >= 1)
+                                            {
+                                                int discardCount = 1;
+
+                                                SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                                                selectHandEffect.SetUp(
+                                                    selectPlayer: card.Owner,
+                                                    canTargetCondition: (cardSource) => true,
+                                                    canTargetCondition_ByPreSelecetedList: null,
+                                                    canEndSelectCondition: null,
+                                                    maxCount: discardCount,
+                                                    canNoSelect: false,
+                                                    canEndNotMax: false,
+                                                    isShowOpponent: true,
+                                                    selectCardCoroutine: null,
+                                                    afterSelectCardCoroutine: null,
+                                                    mode: SelectHandEffect.Mode.Discard,
+                                                    cardEffect: activateClass);
+
+                                                yield return StartCoroutine(selectHandEffect.Activate());
+                                            }
+                                        }
+
+                                        ICardEffect GetCardEffect(EffectTiming _timing)
+                                        {
+                                            if (_timing == EffectTiming.OnDestroyedAnyone)
+                                            {
+                                                return activateClass1;
+                                            }
+
+                                            return null;
+                                        }
+
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Give effects to opponent's Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Digivolving] By trashing 1 card in your hand, 1 of your opponent's Digimon gains \"[On Deletion] Trash 1 card in your hand.\" until the end of their turn.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                        return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (card.Owner.HandCards.Count >= 1)
+                    {
+                        bool discarded = false;
+
+                        int discardCount = 1;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: cardSource => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: discardCount,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+
+                        IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                        {
+                            if (cardSources.Count == 1)
+                            {
+                                discarded = true;
+
+                                yield return null;
+                            }
+                        }
+
+                        if (discarded)
+                        {
+                            if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
+                            {
+                                int maxCount = Math.Min(1,
+                                    CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
+
+                                SelectPermanentEffect selectPermanentEffect =
+                                    GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                                selectPermanentEffect.SetUp(
+                                    selectPlayer: card.Owner,
+                                    canTargetCondition: CanSelectPermanentCondition,
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    maxCount: maxCount,
+                                    canNoSelect: false,
+                                    canEndNotMax: false,
+                                    selectPermanentCoroutine: SelectPermanentCoroutine,
+                                    afterSelectPermanentCoroutine: null,
+                                    mode: SelectPermanentEffect.Mode.Custom,
+                                    cardEffect: activateClass);
+
+                                selectPermanentEffect.SetUpCustomMessage(
+                                    "Select 1 Digimon that will get [On Deletion] Trash 1 card in your hand.",
+                                    "The opponent is selecting 1 Digimon that will get [On Deletion] Trash 1 card in your hand.");
+
+                                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                                IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                                {
+                                    if (permanent != null)
+                                    {
+                                        yield return ContinuousController.instance.StartCoroutine(GManager.instance
+                                            .GetComponent<Effects>().CreateDebuffEffect(permanent));
+                                        ActivateClass activateClass1 = new ActivateClass();
+                                        activateClass1.SetUpICardEffect("Trash 1 card in your hand.", GivenEffectCanUseCondition,
+                                            permanent.TopCard);
+                                        activateClass1.SetUpActivateClass(
+                                            GivenEffectCanActivateCondition,
+                                            GivenEffectActivateCoroutine,
+                                            -1,
+                                            false, GivenEffectDescription());
+                                        activateClass1.SetEffectSourcePermanent(permanent);
+                                        permanent.UntilOwnerTurnEndEffects.Add(GetCardEffect);
+
+                                        if (!permanent.TopCard.CanNotBeAffected(activateClass))
+                                        {
+                                            yield return ContinuousController.instance.StartCoroutine(GManager.instance
+                                                .GetComponent<Effects>().CreateDebuffEffect(permanent));
+                                        }
+
+                                        string GivenEffectDescription()
+                                        {
+                                            return "[On Deletion] Trash 1 card in your hand.";
+                                        }
+
+                                        bool GivenEffectCanUseCondition(Hashtable hashtable)
+                                        {
+                                            return CardEffectCommons.CanTriggerOnDeletion(hashtable, card);
+                                        }
+
+                                        bool GivenEffectCanActivateCondition(Hashtable hashtable1)
+                                        {
+                                            if (CardEffectCommons.IsPermanentExistsOnBattleArea(permanent))
+                                            {
+                                                if (!permanent.TopCard.CanNotBeAffected(activateClass))
+                                                {
+                                                    return true;
+                                                }
+                                            }
+
+                                            return false;
+                                        }
+                                        
+                                        IEnumerator GivenEffectActivateCoroutine(Hashtable _hashtable)
+                                        {
+                                            if (card.Owner.HandCards.Count >= 1)
+                                            {
+                                                int discardCount = 1;
+
+                                                SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                                                selectHandEffect.SetUp(
+                                                    selectPlayer: card.Owner,
+                                                    canTargetCondition: (cardSource) => true,
+                                                    canTargetCondition_ByPreSelecetedList: null,
+                                                    canEndSelectCondition: null,
+                                                    maxCount: discardCount,
+                                                    canNoSelect: false,
+                                                    canEndNotMax: false,
+                                                    isShowOpponent: true,
+                                                    selectCardCoroutine: null,
+                                                    afterSelectCardCoroutine: null,
+                                                    mode: SelectHandEffect.Mode.Discard,
+                                                    cardEffect: activateClass);
+
+                                                yield return StartCoroutine(selectHandEffect.Activate());
+                                            }
+                                        }
+
+                                        ICardEffect GetCardEffect(EffectTiming _timing)
+                                        {
+                                            if (_timing == EffectTiming.OnDestroyedAnyone)
+                                            {
+                                                return activateClass1;
+                                            }
+
+                                            return null;
+                                        }
+
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            #endregion
+            
+            #region ESS - When Attacking
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Draw 1 and trash 1 card from hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDiscription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("Draw_EX8_059");
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                {
+                    return "[When Attacking] [Once Per Turn] <Draw 1> and trash 1 card in your hand.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleArea(card))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 1, activateClass).Draw());
+
+                    if (card.Owner.HandCards.Count >= 1)
+                    {
+                        int discardCount = 1;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: (cardSource) => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: discardCount,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+                    }
+                }
+            }
+            
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/Devimon_EX8_059.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/Devimon_EX8_059.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c0e786ff74aac84188a56e87fbe02c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/Gesomon_EX8_058.cs
+++ b/Assets/CardEffect/EX8/Purple/Gesomon_EX8_058.cs
@@ -1,0 +1,172 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class Gesomon_EX8_058 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution
+
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.IsLevel3 && targetPermanent.TopCard.EqualsTraits("DS");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition,
+                    digivolutionCost: 2,
+                    ignoreDigivolutionRequirement: false,
+                    card: card,
+                    condition: null)
+                );
+            }
+
+            #endregion
+
+            #region On Deletion
+            
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Memory +1", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Deletion] Gain 1 memory.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnDeletion(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    {
+                        if (card.Owner.CanAddMemory(activateClass))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(card.Owner.AddMemory(1, activateClass));
+                }
+            }
+            
+            #endregion
+            
+            #region When Attacking - ESS
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Delete opponents level 3 Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("WhenAttacking_EX8_058");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] [Once Per Turn] Delete 1 of your opponent's level 3 Digimon.";
+                }
+
+                bool SelectOpponentsLevel3Digimon(Permanent permanent)
+                {
+                    if(CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
+                    {
+                        if(permanent.Level == 3)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        return true;
+                    }
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool discarded = false;
+
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: (cardSource) => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                        mode: SelectHandEffect.Mode.Discard,
+                        cardEffect: activateClass);
+
+                    yield return StartCoroutine(selectHandEffect.Activate());
+                    
+                    IEnumerator AfterSelectCardCoroutine(List<CardSource> selectedCards)
+                    {
+                        if(selectedCards.Count > 0)
+                            discarded = true;
+
+                        yield return null;
+                    }
+
+                    if (discarded)
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: SelectOpponentsLevel3Digimon,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+                }
+            }
+            
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/Gesomon_EX8_058.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/Gesomon_EX8_058.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c00f13534259d5142903ddf110036cc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/MarineDevimon_EX8_061.cs
+++ b/Assets/CardEffect/EX8/Purple/MarineDevimon_EX8_061.cs
@@ -1,0 +1,230 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class MarineDevimon_EX8_061 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution
+
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.IsLevel4 && targetPermanent.TopCard.EqualsTraits("DS");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition,
+                    digivolutionCost: 3,
+                    ignoreDigivolutionRequirement: false,
+                    card: card,
+                    condition: null)
+                );
+            }
+
+            #endregion
+
+            #region Scapegoat
+            
+            if(timing == EffectTiming.WhenPermanentWouldBeDeleted)
+            {
+
+                string EffectDiscription()
+                {
+                    return "<Scapegoat> (When this Digimon would be deleted other than by your own effects, by deleting 1 of your other Digimon, prevent that deletion.)";
+                }
+
+                cardEffects.Add(CardEffectFactory.ScapegoatSelfEffect(isInheritedEffect: false, card: card, condition: null, effectName: "<Scapegoat>", effectDiscription: EffectDiscription()));
+            }
+            
+            #endregion
+
+            #region When Attacking
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("You may play 1 level 4 or lower Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetHashString("PlayDigimon_EX8_061");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] [Once Per Turn] If you have 1 or more memory, you may play 1 level 4 or lower Digimon card with the [DS], [Mollusk], or [Crustacean] trait from your trash without paying the cost.";
+                }
+
+                bool DigimonToPlay(CardSource cardSource)
+                {
+                    return CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass, SelectCardEffect.Root.Trash) &&
+                           cardSource.IsDigimon &&
+                           cardSource.HasLevel &&
+                           cardSource.Level <= 4 &&
+                           (cardSource.EqualsTraits("DS") || cardSource.EqualsTraits("Mollusk") || cardSource.EqualsTraits("Crustacean"));
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if(CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                        return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) &&
+                           CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, DigimonToPlay) &&
+                           card.Owner.MemoryForPlayer >= 1;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    List<CardSource> selectedCards = new List<CardSource>();
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: DigimonToPlay,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: SelectCardCoroutine,
+                        message: "Select 1 level 4 or lower Digimon card to play.",
+                        maxCount: 1,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Custom,
+                        root: SelectCardEffect.Root.Trash,
+                        customRootCardList: null,
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    selectCardEffect.SetUpCustomMessage(
+                        "Select 1 level 4 or lower Digimon card to play.",
+                        "The opponent is selecting 1 level 4 or lower Digimon card to play.");
+                    selectCardEffect.SetUpCustomMessage_ShowCard("Play Card");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+
+                    IEnumerator SelectCardCoroutine(List<CardSource> sources)
+                    {
+                        selectedCards = sources;
+                        yield return null;
+                    }
+                    
+                    if (selectedCards.Count > 0)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                            cardSources: selectedCards,
+                            activateClass: activateClass,
+                            payCost: false,
+                            isTapped: false,
+                            root: SelectCardEffect.Root.Trash,
+                            activateETB: true));
+                    }
+                }
+            }
+            
+            #endregion
+
+            #region On Deletion - ESS
+            
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play 1 level 4 or lower Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Deletion] You may play 1 level 4 or lower Digimon card with the [DS], [Mollusk], or [Crustacean] trait from your trash without paying the cost.";
+                }
+
+                bool HasCorrectTrait(CardSource cardSource)
+                {
+                    if (cardSource.EqualsTraits("DS") || cardSource.EqualsTraits("Mollusk") || cardSource.EqualsTraits("Crustacean"))
+                    {
+                        if (cardSource.HasLevel && cardSource.Level <= 4)
+                        {
+                            if (CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnDeletion(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                           CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    List<CardSource> selectedCards = new List<CardSource>();
+
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: HasCorrectTrait,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        message: "Select 1 digivolution card to play.",
+                        maxCount: 1,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Custom,
+                        root: SelectCardEffect.Root.Trash,
+                        customRootCardList: null,
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    selectCardEffect.SetUpCustomMessage("Select 1 digivolution card to play.", "The opponent is selecting 1 digivolution card to play.");
+                    selectCardEffect.SetUpCustomMessage_ShowCard("Played Card");
+
+                    yield return StartCoroutine(selectCardEffect.Activate());
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
+                    {
+                        selectedCards.Add(cardSource);
+
+                        yield return null;
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                        cardSources: selectedCards,
+                        activateClass: activateClass,
+                        payCost: false,
+                        isTapped: false,
+                        root: SelectCardEffect.Root.Trash,
+                        activateETB: true));
+                }
+            }
+            
+            #endregion
+            
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/MarineDevimon_EX8_061.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/MarineDevimon_EX8_061.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b690c5848d47be41a27f00e47b48492
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/Myotismon_EX8_060.cs
+++ b/Assets/CardEffect/EX8/Purple/Myotismon_EX8_060.cs
@@ -1,0 +1,474 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Photon.Pun;
+using UnityEngine;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class Myotismon_EX8_060 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution
+
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.IsLevel4 && targetPermanent.TopCard.EqualsTraits("NSo");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition,
+                    digivolutionCost: 3,
+                    ignoreDigivolutionRequirement: false,
+                    card: card,
+                    condition: null)
+                );
+            }
+
+            #endregion
+
+            #region When Attacking
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("You may play 1 3 cost or less NSo Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] You may play 1 [NSo] trait Digimon card with a play cost of 3 or less from your trash without paying the cost.";
+                }
+
+                bool DigimonToPlay(CardSource cardSource)
+                {
+                    return CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass, SelectCardEffect.Root.Trash) &&
+                           cardSource.IsDigimon &&
+                           cardSource.HasPlayCost &&
+                           cardSource.GetCostItself <= 3 &&
+                           cardSource.EqualsTraits("NSo");
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if(CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                        return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) &&
+                           CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, DigimonToPlay) &&
+                           card.Owner.MemoryForPlayer >= 1;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    List<CardSource> selectedCards = new List<CardSource>();
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: DigimonToPlay,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: SelectCardCoroutine,
+                        message: "Select 1 level 4 or lower Digimon card to play.",
+                        maxCount: 1,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Custom,
+                        root: SelectCardEffect.Root.Trash,
+                        customRootCardList: null,
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    selectCardEffect.SetUpCustomMessage(
+                        "Select 1 level 4 or lower Digimon card to play.",
+                        "The opponent is selecting 1 level 4 or lower Digimon card to play.");
+                    selectCardEffect.SetUpCustomMessage_ShowCard("Play Card");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+
+                    IEnumerator SelectCardCoroutine(List<CardSource> sources)
+                    {
+                        selectedCards = sources;
+                        yield return null;
+                    }
+                    
+                    if (selectedCards.Count > 0)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                            cardSources: selectedCards,
+                            activateClass: activateClass,
+                            payCost: false,
+                            isTapped: false,
+                            root: SelectCardEffect.Root.Trash,
+                            activateETB: true));
+                    }
+                }
+            }
+            
+            #endregion
+
+            #region Your Turn
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("DNA Digivolve.", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("DNADigivolve_EX8_060");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[Your Turn] [Once Per Turn] When your Digimon are played or digivolve, if any of them have the [NSo] trait, 2 of your Digimon may DNA digivolve into a Digimon card with the [NSo] trait in the hand. Then, that DNA digivolved Digimon may attack.";
+                }
+
+                bool PermanentCondition(Permanent permanent)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
+                    {
+                        if (permanent.IsDigimon)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool PermanentConditionNSoEnterField(Permanent permanent)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
+                    {
+                        if (permanent.TopCard.CardTraits.Contains("NSo"))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleArea(card))
+                    {
+                        if (CardEffectCommons.IsOwnerTurn(card))
+                        {
+                            if (CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, PermanentConditionNSoEnterField))
+                            {
+                                return true;
+                            }
+
+                            if (CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, PermanentConditionNSoEnterField))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleArea(card))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                bool CanSelectDNACardCondition(CardSource cardSource)
+                {
+                    return cardSource.IsDigimon &&
+                           cardSource.CanPlayJogress(true) &&
+                           cardSource.ContainsTraits("NSo");
+                }
+                
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    List<CardSource> selectedCards = new List<CardSource>();
+                    
+                    bool DNADigivolved = false;
+                    int maxCount = 1;
+
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectDNACardCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: maxCount,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectHandEffect.SetUpCustomMessage("Select 1 card to DNA digivolve.",
+                        "The opponent is selecting 1 card to DNA digivolve.");
+                    selectHandEffect.SetNotShowCard();
+
+                    yield return StartCoroutine(selectHandEffect.Activate());
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
+                    {
+                        selectedCards.Add(cardSource);
+
+                        yield return null;
+                    }
+
+                    if (selectedCards.Count >= 1)
+                    {
+                        foreach (CardSource selectedCard in selectedCards)
+                        {
+                            if (selectedCard.CanPlayJogress(true))
+                            {
+                                _jogressEvoRootsFrameIDs = Array.Empty<int>();
+
+                                yield return GManager.instance.photonWaitController.StartWait("Myotismon_EX8_060");
+
+                                if (card.Owner.isYou || GManager.instance.IsAI)
+                                {
+                                    GManager.instance.selectJogressEffect.SetUp_SelectDigivolutionRoots
+                                    (card: selectedCard,
+                                        isLocal: true,
+                                        isPayCost: true,
+                                        canNoSelect: true,
+                                        endSelectCoroutine_SelectDigivolutionRoots: EndSelectCoroutineSelectDigivolutionRoots,
+                                        noSelectCoroutine: null);
+
+                                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.selectJogressEffect
+                                        .SelectDigivolutionRoots());
+
+                                    IEnumerator EndSelectCoroutineSelectDigivolutionRoots(List<Permanent> permanents)
+                                    {
+                                        if (permanents.Count == 2)
+                                        {
+                                            _jogressEvoRootsFrameIDs = permanents.Distinct().ToArray()
+                                                .Map(permanent => permanent.PermanentFrame.FrameID);
+                                        }
+
+                                        yield return null;
+                                    }
+
+                                    photonView.RPC("SetJogressEvoRootsFrameIDs", RpcTarget.All, _jogressEvoRootsFrameIDs);
+                                }
+
+                                else
+                                {
+                                    GManager.instance.commandText.OpenCommandText("The opponent is choosing a card to DNA digivolve.");
+                                }
+
+                                yield return new WaitWhile(() => !_endSelect);
+                                _endSelect = false;
+
+                                GManager.instance.commandText.CloseCommandText();
+                                yield return new WaitWhile(() => GManager.instance.commandText.gameObject.activeSelf);
+
+                                if (_jogressEvoRootsFrameIDs.Length == 2)
+                                {
+                                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>()
+                                        .ShowCardEffect(new List<CardSource>() { selectedCard }, "Played Card", true, true));
+
+                                    PlayCardClass playCard = new PlayCardClass(
+                                        cardSources: new List<CardSource>() { selectedCard },
+                                        hashtable: CardEffectCommons.CardEffectHashtable(activateClass),
+                                        payCost: true,
+                                        targetPermanent: null,
+                                        isTapped: false,
+                                        root: SelectCardEffect.Root.Hand,
+                                        activateETB: true);
+
+                                    playCard.SetJogress(_jogressEvoRootsFrameIDs);
+                                    DNADigivolved = true;
+                                    yield return ContinuousController.instance.StartCoroutine(playCard.PlayCard());
+                                }
+                                
+                                if (DNADigivolved)
+                                {
+                                    List<SelectionElement<bool>> selectionElements = new List<SelectionElement<bool>>()
+                                    {
+                                        new SelectionElement<bool>(message: $"Yes", value: true, spriteIndex: 0),
+                                        new SelectionElement<bool>(message: $"No", value: false, spriteIndex: 1),
+                                    };
+
+                                    string selectPlayerMessage = "Attack?";
+                                    string notSelectPlayerMessage = "The opponent is choosing effects.";
+
+                                    GManager.instance.userSelectionManager.SetBoolSelection(
+                                        selectionElements: selectionElements, selectPlayer: card.Owner,
+                                        selectPlayerMessage: selectPlayerMessage,
+                                        notSelectPlayerMessage: notSelectPlayerMessage);
+
+                                    yield return ContinuousController.instance.StartCoroutine(GManager.instance
+                                        .userSelectionManager.WaitForEndSelect());
+
+                                    bool willAttack = GManager.instance.userSelectionManager.SelectedBoolValue;
+
+                                    if (willAttack)
+                                    {
+                                        yield return ContinuousController.instance.StartCoroutine(
+                                            CardEffectCommons.ChangeDigimonSAttack(selectedCard.PermanentOfThisCard(), 1,
+                                                EffectDuration.UntilEachTurnEnd, activateClass));
+
+                                        if (selectedCard.PermanentOfThisCard() != null)
+                                        {
+                                            if (selectedCard.PermanentOfThisCard().CanAttack(activateClass))
+                                            {
+                                                SelectAttackEffect selectAttackEffect =
+                                                    GManager.instance.GetComponent<SelectAttackEffect>();
+
+                                                selectAttackEffect.SetUp(
+                                                    attacker: selectedCard.PermanentOfThisCard(),
+                                                    canAttackPlayerCondition: () => true,
+                                                    defenderCondition: (permanent) => true,
+                                                    cardEffect: activateClass);
+
+                                                selectAttackEffect.SetCanNotSelectNotAttack();
+
+                                                yield return ContinuousController.instance.StartCoroutine(selectAttackEffect
+                                                    .Activate());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            #endregion
+            
+            #region Inherited Effect
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Delete your another Digimon to unsuspend this Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("Unsuspend_EX8_060");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] [Once Per Turn] By deleting 1 of your other Digimon, this Digimon unsuspends.";
+                }
+
+                bool CanSelectPermanentCondition(Permanent permanent)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
+                    {
+                        if (permanent != card.PermanentOfThisCard())
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleArea(card))
+                    {
+                        if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
+                    {
+                        int maxCount = Math.Min(1, card.Owner.GetBattleAreaDigimons().Count(CanSelectPermanentCondition));
+
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectPermanentCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: maxCount,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to delete.", "The opponent is selecting 1 Digimon to delete.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            Permanent thisCardPermanent = card.PermanentOfThisCard();
+
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DeletePeremanentAndProcessAccordingToResult(targetPermanents: new List<Permanent>() { permanent },
+                            activateClass: activateClass,
+                            successProcess: permanents => SuccessProcess(),
+                            failureProcess: null));
+
+                            IEnumerator SuccessProcess()
+                            {
+                                if (thisCardPermanent.TopCard != null)
+                                {
+                                    yield return ContinuousController.instance.StartCoroutine(new IUnsuspendPermanents(new List<Permanent>() { thisCardPermanent }, activateClass).Unsuspend());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            
+            #endregion
+
+            return cardEffects;
+        }
+            
+        #region Photon DNA
+
+        bool _endSelect;
+        int[] _jogressEvoRootsFrameIDs = Array.Empty<int>();
+
+        [PunRPC]
+        public void SetJogressEvoRootsFrameIDs(int[] jogressEvoRootsFrameIDs)
+        {
+            this._jogressEvoRootsFrameIDs = jogressEvoRootsFrameIDs;
+            _endSelect = true;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/Myotismon_EX8_060.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/Myotismon_EX8_060.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 14d7da069c2f6074e8b197dfa3d0cd8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/NightmareSoldiers_EX8_071.cs
+++ b/Assets/CardEffect/EX8/Purple/NightmareSoldiers_EX8_071.cs
@@ -1,0 +1,173 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class NightmareSoldiers_EX8_071 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Ignore Color Requirement
+
+            if (timing == EffectTiming.None)
+            {
+                IgnoreColorConditionClass ignoreColorConditionClass = new IgnoreColorConditionClass();
+                ignoreColorConditionClass.SetUpICardEffect("Ignore color requirements", CanUseCondition, card);
+                ignoreColorConditionClass.SetUpIgnoreColorConditionClass(cardCondition: CardCondition);
+                cardEffects.Add(ignoreColorConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return card.Owner.SecurityCards.Count(cardSource => !cardSource.IsFlipped) == 0;
+                }
+
+                bool CardCondition(CardSource cardSource)
+                {
+                    return cardSource == card;
+                }
+            }
+
+            #endregion
+
+            #region All Turns - Security
+
+            if (timing == EffectTiming.None)
+            {
+                bool CanUseCondition()
+                {
+                    return CardEffectCommons.IsExistInSecurity(card, false);
+                }
+
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card) &&
+                           permanent.TopCard.EqualsTraits("NSo");
+                }
+
+                // TODO: Apply Scapegoat to all NSo Digimon
+            }
+
+            #endregion
+
+            #region Main Effect
+
+            if (timing == EffectTiming.OptionSkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Replace your bottom security card with this face-up card", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[Main] Add your bottom security card to the hand. Then, place this card face up as the bottom security card.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    // Add your bottom security card to the hand
+                    CardSource bottomCard = card.Owner.SecurityCards[^1];
+
+                    yield return ContinuousController.instance.StartCoroutine(
+                        CardObjectController.AddHandCards(new List<CardSource>() { bottomCard }, false, activateClass));
+
+                    yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
+                        player: card.Owner,
+                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+
+                    // Place this card face up as the bottom security card
+                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddSecurityCard(
+                        card, toTop: false, faceUp: true));
+
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>()
+                        .CreateRecoveryEffect(card.Owner));
+
+                    yield return ContinuousController.instance.StartCoroutine(new IAddSecurity(card.Owner).AddSecurity());
+                }
+            }
+
+            #endregion
+
+            #region Security Effect
+
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect($"Play 1 [NSo] Digimon card from hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSecurityEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return
+                        "[Security] You may play 1 level 5 or lower Digimon with the [NSo] trait from your hand without paying the cost.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerSecurityEffect(hashtable, card);
+                }
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                {
+                    return cardSource.IsDigimon && cardSource.HasLevel && cardSource.Level <= 5 &&
+                           cardSource.EqualsTraits("NSo") &&
+                           CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition))
+                    {
+                        List<CardSource> selectedCards = new List<CardSource>();
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectCardCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: SelectCardCoroutine,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectHandEffect.SetUpCustomMessage("Select 1 card to play.", "The opponent is selecting 1 card to play.");
+                        selectHandEffect.SetUpCustomMessage_ShowCard("Played Card");
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+
+                        IEnumerator SelectCardCoroutine(CardSource cardSource)
+                        {
+                            selectedCards.Add(cardSource);
+
+                            yield return null;
+                        }
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                            cardSources: selectedCards, activateClass: activateClass, payCost: false, isTapped: false,
+                            root: SelectCardEffect.Root.Hand, activateETB: true));
+                    }
+                }
+            }
+
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/NightmareSoldiers_EX8_071.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/NightmareSoldiers_EX8_071.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c300975037d02043bb265119c11d886
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/Piedmon_EX8_062.cs
+++ b/Assets/CardEffect/EX8/Purple/Piedmon_EX8_062.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class Piedmon_EX8_062 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution
+
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.IsLevel5 && targetPermanent.TopCard.EqualsTraits("NSo");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition,
+                    digivolutionCost: 3,
+                    ignoreDigivolutionRequirement: false,
+                    card: card,
+                    condition: null)
+                );
+            }
+
+            #endregion
+
+            #region Ace - Blast Digivolve
+
+            if (timing == EffectTiming.OnCounterTiming)
+            {
+                cardEffects.Add(CardEffectFactory.BlastDigivolveEffect(card: card, condition: null));
+            }
+
+            #endregion
+
+            #region On Play/When Digivolving Shared
+            
+            bool CanSelectPermanentConditionOnPlayWhenDigivolving(Permanent permanent)
+            {
+                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+            }
+
+            bool CanActivateConditionOnPlayWhenDigivolving(Hashtable hashtable)
+            {
+                return CardEffectCommons.IsExistOnBattleArea(card);
+            }
+            
+            #endregion
+            
+            #region On Play
+            
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Apply -2000 DP 4 times", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateConditionOnPlayWhenDigivolving, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Play] Activate the effect below 4 times: • 1 of your opponent's Digimon gets -2000 DP for the turn.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentConditionOnPlayWhenDigivolving))
+                        {
+                            int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentConditionOnPlayWhenDigivolving));
+
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: CanSelectPermanentConditionOnPlayWhenDigivolving,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: maxCount,
+                                canNoSelect: false,
+                                canEndNotMax: false,
+                                selectPermanentCoroutine: SelectPermanentCoroutine,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -2000.", "The opponent is selecting 1 Digimon that will get DP -2000.");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                            IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -2000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                            }
+                        }
+                    }
+
+                }
+            }
+            
+            #endregion
+            
+            #region When Digivolving
+            
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Apply -2000 DP 4 times", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateConditionOnPlayWhenDigivolving, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Digivolving] Activate the effect below 4 times: • 1 of your opponent's Digimon gets -2000 DP for the turn.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    for (int i = 0; i < 4; i++)
+                    {
+                        if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentConditionOnPlayWhenDigivolving))
+                        {
+                            int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentConditionOnPlayWhenDigivolving));
+
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: CanSelectPermanentConditionOnPlayWhenDigivolving,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: maxCount,
+                                canNoSelect: false,
+                                canEndNotMax: false,
+                                selectPermanentCoroutine: SelectPermanentCoroutine,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -2000.", "The opponent is selecting 1 Digimon that will get DP -2000.");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                            IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -2000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                            }
+                        }
+                    }
+
+                }
+            }
+            
+            #endregion
+
+            #region All Turns
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play 1 [NSo] Digimon from the trash", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetHashString("PlayDigimon_EX8_062");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[All Turns] [Once Per Turn] When other Digimon are deleted, you may play 1 level 4 or lower [NSo] trait Digimon card from your trash without paying the cost.";
+                }
+
+                bool PermanentCondition(Permanent permanent)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(permanent))
+                    {
+                        if (permanent.IsDigimon)
+                        {
+                            if (permanent != card.PermanentOfThisCard())
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        if (CardEffectCommons.CanTriggerOnPermanentDeleted(hashtable, PermanentCondition))
+                        {
+                            return true;
+                        }
+                    }
+                    
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        if (card.Owner.TrashCards.Count >= 1)
+                        {
+                            if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardInTrash))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+
+                bool CanSelectCardInTrash(CardSource cardSource)
+                {
+                    if (CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass))
+                    {
+                        if (cardSource.EqualsTraits("NSo"))
+                        {
+                            if (cardSource.IsDigimon)
+                            {
+                                if (cardSource.HasLevel)
+                                {
+                                    if (cardSource.Level <= 4)
+                                    {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardInTrash))
+                    {
+                        int maxCount = Math.Min(1, card.Owner.TrashCards.Count(CanSelectCardInTrash));
+
+                        List<CardSource> selectedCards = new List<CardSource>();
+
+                        SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                        selectCardEffect.SetUp(
+                            canTargetCondition: CanSelectCardInTrash,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            canNoSelect: () => true,
+                            selectCardCoroutine: SelectCardCoroutine,
+                            afterSelectCardCoroutine: null,
+                            message: "Select 1 card to play.",
+                            maxCount: maxCount,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            mode: SelectCardEffect.Mode.Custom,
+                            root: SelectCardEffect.Root.Trash,
+                            customRootCardList: null,
+                            canLookReverseCard: true,
+                            selectPlayer: card.Owner,
+                            cardEffect: activateClass);
+
+                        selectCardEffect.SetUpCustomMessage("Select 1 card to play.", "The opponent is selecting 1 card to play.");
+                        selectCardEffect.SetUpCustomMessage_ShowCard("Played Card");
+
+                        yield return StartCoroutine(selectCardEffect.Activate());
+
+                        IEnumerator SelectCardCoroutine(CardSource cardSource)
+                        {
+                            selectedCards.Add(cardSource);
+
+                            yield return null;
+                        }
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                            cardSources: selectedCards,
+                            activateClass: activateClass,
+                            payCost: false,
+                            isTapped: false,
+                            root: SelectCardEffect.Root.Trash,
+                            activateETB: true));
+                    }
+                }
+            }
+            #endregion
+            
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/Piedmon_EX8_062.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/Piedmon_EX8_062.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13fd258dfc3022d449412a2d03ecdd88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/SeventhJewelrize_EX8_072.cs
+++ b/Assets/CardEffect/EX8/Purple/SeventhJewelrize_EX8_072.cs
@@ -1,0 +1,184 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class SeventhJewelrize_EX8_072 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Trash Your Turn
+            
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Return this to bottom of deck, Activate Main", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDiscription());
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                {
+                    return "[Trash] [Your Turn] When your Digimon digivolves into [Barbamon (X Antibody)], by returning this card to the bottom of the deck, activate this card's [Main] effect.";
+                }
+
+                bool PermanentCondition(Permanent permanent)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(permanent, card))
+                    {
+                        if (permanent.TopCard.CardNames.Contains("Barbamon (X Antibody)"))
+                        {
+                            return true;
+                        }
+
+                        if (permanent.TopCard.CardNames.Contains("Barbamon(XAntibody)"))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }              
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnTrash(card))
+                    {
+                        if (CardEffectCommons.IsOwnerTurn(card))
+                        {
+                            if (CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, PermanentCondition))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnTrash(card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnTrash(card))
+                    {
+                        List<CardSource> cardSources = new List<CardSource>() { card };
+
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Card", true, true));
+
+                        ActivateClass mainActivateClass = CardEffectCommons.OptionMainEffect(card);
+
+                        if (mainActivateClass != null)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(mainActivateClass.Activate(CardEffectCommons.OptionMainCheckHashtable(card)));
+                        }
+                    }
+                }
+            }
+            
+            #endregion
+            
+            #region Main
+            
+            if (timing == EffectTiming.OptionSkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Opponent trashes 1 card, then delete 1 Digimon.", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDiscription());
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                {
+                    return "[Main] If your opponent has 5 or more cards in their hand, they trash 1 card in their hand. Then, delete 1 of your opponent's level 7 or lower Digimon. For every 3 cards in your opponent's hand, remove 1 from this effect's level maximum.";
+                }
+
+                bool SelectOpponentsDigimon(Permanent permanent)
+                {
+                    var levelMax = 7 - (card.Owner.Enemy.HandCards.Count / 3);
+                    if (CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
+                    {
+                        if (permanent.TopCard.HasLevel && permanent.Level <= levelMax)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (card.Owner.Enemy.HandCards.Count >= 5)
+                    {
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner.Enemy,
+                            canTargetCondition: (CardSource) => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+                    }
+
+                    if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, SelectOpponentsDigimon))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: SelectOpponentsDigimon,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to delete.", "The opponent is selecting 1 Digimon tto delete.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+
+                    yield return null;
+                }
+            }
+            
+            #endregion
+
+            #region Security Effect
+
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                CardEffectCommons.AddActivateMainOptionSecurityEffect(card: card, cardEffects: ref cardEffects,
+                    effectName: "Opponent trashes 1 card, then delete 1 Digimon.");
+            }
+
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/SeventhJewelrize_EX8_072.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/SeventhJewelrize_EX8_072.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20e9c1f57f8193f4491683fd0d6d91a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Purple/Syakomon_EX8_056.cs
+++ b/Assets/CardEffect/EX8/Purple/Syakomon_EX8_056.cs
@@ -1,0 +1,188 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects.EX8
+{
+    public class Syakomon_EX8_056 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution
+
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.IsLevel2 && targetPermanent.TopCard.EqualsTraits("DS");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition,
+                    digivolutionCost: 0,
+                    ignoreDigivolutionRequirement: false,
+                    card: card,
+                    condition: null)
+                );
+            }
+
+            #endregion
+            
+            #region On Deletion
+            
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Draw 1 and trash 1 card from hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Deletion] <Draw 1> and trash 1 card in your hand.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnDeletion(hashtable,card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return true;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    if (card.Owner.LibraryCards.Count >= 1)
+                        yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 1, activateClass).Draw());
+
+                    if (card.Owner.HandCards.Count >= 1)
+                    {
+                        int discardCount = 1;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: (cardSource) => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: discardCount,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+                    }
+                }
+            }
+            
+            #endregion
+            
+            #region When Attacking - ESS
+            
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Delete opponents level 3 Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("WhenAttacking_EX8_056");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] [Once Per Turn] Delete 1 of your opponent's level 3 Digimon.";
+                }
+
+                bool SelectOpponentsLevel3Digimon(Permanent permanent)
+                {
+                    if(CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
+                    {
+                        if(permanent.Level == 3)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        return true;
+                    }
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool discarded = false;
+
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: (cardSource) => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                        mode: SelectHandEffect.Mode.Discard,
+                        cardEffect: activateClass);
+
+                    yield return StartCoroutine(selectHandEffect.Activate());
+                    
+                    IEnumerator AfterSelectCardCoroutine(List<CardSource> selectedCards)
+                    {
+                        if(selectedCards.Count > 0)
+                            discarded = true;
+
+                        yield return null;
+                    }
+
+                    if (discarded)
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: SelectOpponentsLevel3Digimon,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+                }
+            }
+            
+            #endregion
+            
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/CardEffect/EX8/Purple/Syakomon_EX8_056.cs.meta
+++ b/Assets/CardEffect/EX8/Purple/Syakomon_EX8_056.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea605bc52cc061e4a8173f1ae3039860
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CardEffect/EX8/Yellow/SkullMammothmon_EX8_036.cs
+++ b/Assets/CardEffect/EX8/Yellow/SkullMammothmon_EX8_036.cs
@@ -55,42 +55,50 @@ namespace DCGO.CardEffects.EX8
                 {
                     return cardSource.IsDigimon &&
                            cardSource.EqualsTraits("NSo") &&
-                           cardSource.HasPlayCost && cardSource.GetCostItself <= 5;
+                           cardSource.HasPlayCost &&
+                           cardSource.GetCostItself <= 5;
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnBattleArea(card) &&
-                           card.Owner.HandCards.Some(CanSelectCardCondition);
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) &&
+                           (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition) ||
+                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition));
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    if (card.Owner.HandCards.Some(CanSelectCardCondition))
+                    bool canSelectHand = CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+                    bool canSelectTrash = CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
+
+                    if (canSelectHand || canSelectTrash)
                     {
+                        if (canSelectHand && canSelectTrash)
+                        {
+                            List<SelectionElement<bool>> selectionElements = new List<SelectionElement<bool>>()
+                            {
+                                new(message: "From hand", value: true, spriteIndex: 0),
+                                new(message: "From trash", value: false, spriteIndex: 1),
+                            };
+
+                            string selectPlayerMessage = "From which area do you play a card?";
+                            string notSelectPlayerMessage = "The opponent is choosing from which area to play a card.";
+
+                            GManager.instance.userSelectionManager.SetBoolSelection(selectionElements: selectionElements,
+                                selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage,
+                                notSelectPlayerMessage: notSelectPlayerMessage);
+                        }
+                        else
+                        {
+                            GManager.instance.userSelectionManager.SetBool(canSelectHand);
+                        }
+
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager
+                            .WaitForEndSelect());
+
+                        bool fromHand = GManager.instance.userSelectionManager.SelectedBoolValue;
+
                         List<CardSource> selectedCards = new List<CardSource>();
-
-                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
-
-                        selectHandEffect.SetUp(
-                            selectPlayer: card.Owner,
-                            canTargetCondition: CanSelectCardCondition,
-                            canTargetCondition_ByPreSelecetedList: null,
-                            canEndSelectCondition: null,
-                            maxCount: 1,
-                            canNoSelect: true,
-                            canEndNotMax: false,
-                            isShowOpponent: true,
-                            selectCardCoroutine: SelectCardCoroutine,
-                            afterSelectCardCoroutine: null,
-                            mode: SelectHandEffect.Mode.Custom,
-                            cardEffect: activateClass);
-
-                        selectHandEffect.SetUpCustomMessage("Select 1 Digimon card to play.",
-                            "The opponent is selecting 1 Digimon card to play.");
-                        selectHandEffect.SetUpCustomMessage_ShowCard("Played Card");
-
-                        yield return StartCoroutine(selectHandEffect.Activate());
 
                         IEnumerator SelectCardCoroutine(CardSource cardSource)
                         {
@@ -98,9 +106,61 @@ namespace DCGO.CardEffects.EX8
                             yield return null;
                         }
 
-                        yield return ContinuousController.instance.StartCoroutine(
-                            CardEffectCommons.PlayPermanentCards(cardSources: selectedCards, activateClass: activateClass,
-                                payCost: false, isTapped: false, root: SelectCardEffect.Root.Hand, activateETB: true));
+                        if (fromHand)
+                        {
+                            SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                            selectHandEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: CanSelectCardCondition,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: true,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                selectCardCoroutine: SelectCardCoroutine,
+                                afterSelectCardCoroutine: null,
+                                mode: SelectHandEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            selectHandEffect.SetUpCustomMessage("Select 1 card to play.", "The opponent is selecting 1 card to play.");
+                            selectHandEffect.SetUpCustomMessage_ShowCard("Played Card");
+
+                            yield return StartCoroutine(selectHandEffect.Activate());
+                        }
+                        else
+                        {
+                            SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                            selectCardEffect.SetUp(
+                                canTargetCondition: CanSelectCardCondition,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                canNoSelect: () => true,
+                                selectCardCoroutine: SelectCardCoroutine,
+                                afterSelectCardCoroutine: null,
+                                message: "Select 1 card to play.",
+                                maxCount: 1,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                mode: SelectCardEffect.Mode.Custom,
+                                root: SelectCardEffect.Root.Trash,
+                                customRootCardList: null,
+                                canLookReverseCard: true,
+                                selectPlayer: card.Owner,
+                                cardEffect: activateClass);
+
+                            selectCardEffect.SetUpCustomMessage("Select 1 card to play.", "The opponent is selecting 1 card to play.");
+                            selectCardEffect.SetUpCustomMessage_ShowCard("Played Card");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+                        }
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                            cardSources: selectedCards, activateClass: activateClass, payCost: false, isTapped: false,
+                            root: fromHand ? SelectCardEffect.Root.Hand : SelectCardEffect.Root.Trash,
+                            activateETB: true));
                     }
                 }
             }


### PR DESCRIPTION
All EX8 Purple cards, except for the face up security effect of the Nightmare Soldiers option card.

Also fixed an issue with EX8 SkullMammothmon so it properly plays from Hand or Trash.