### PR TITLE
fixed evo costs and lack of virus

### DIFF
--- a/Assets/CardBaseEntity/BT19/Blue/Digimon/BT19_016.asset
+++ b/Assets/CardBaseEntity/BT19/Blue/Digimon/BT19_016.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dfa7c9cd7dfefeb050e4b1047a16b2d68afc0289b327693cce0ca36747bd9439
-size 1144
+oid sha256:4a38614d56cbd18c918ab857f4f1f1093cacd9b4058a8eeee3aa1e691e7fe21a
+size 1191

--- a/Assets/CardBaseEntity/BT19/Red/Digimon/BT19_007.asset
+++ b/Assets/CardBaseEntity/BT19/Red/Digimon/BT19_007.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:43c987bfb470ba79849fa0ca636a9221963da65ae8c6b57610aff8ea459e230d
+oid sha256:c7710146f0173fff9b7aa6f8fd798a933faf312ae87b0ca6ee6a4b5b8972789f
 size 1233

--- a/Assets/CardBaseEntity/BT19/Yellow/Digimon/BT19_030.asset
+++ b/Assets/CardBaseEntity/BT19/Yellow/Digimon/BT19_030.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:526f3717411bb0bc2957b05b6195dcf1b71a44d25ed32a3da2edd3e304354e32
-size 1223
+oid sha256:696934a90d7b0d26a99e0af974d1ff15e80a83b5e7640bd862b4ed3a3be99dca
+size 1268

--- a/Assets/CardBaseEntity/BT19/Yellow/Digimon/BT19_034.asset
+++ b/Assets/CardBaseEntity/BT19/Yellow/Digimon/BT19_034.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b813a9bc74287b8d5ed081b2b92a30486cae9a3462ec68651b9200aeeae602fe
-size 1273
+oid sha256:c8749f35dd26e61aae25f86bd59e9c4f61740b2fcf3cd8a2ea08035db3bb9da6
+size 1318


### PR DESCRIPTION
Fixed evolution costs for bt19 guilmon, gaossmon, renamon, and kyubimon, as well as making gaossmon virus