### PR TITLE
fixed traits for beelz and gargo, fixed effect for beelz

### DIFF
--- a/Assets/CardBaseEntity/BT19/Green/Digimon/BT19_049.asset
+++ b/Assets/CardBaseEntity/BT19/Green/Digimon/BT19_049.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a63252714fb2e7863cb175ebc0bed799952cfaf6c2f87857922f68bf524b4ff9
-size 1241
+oid sha256:ca0ff811498320724b445fac94c2c5b667d49b8d6628608c6216ee604f4c1b29
+size 1242

--- a/Assets/CardBaseEntity/BT19/Purple/Digimon/BT19_071.asset
+++ b/Assets/CardBaseEntity/BT19/Purple/Digimon/BT19_071.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:892f9026c1852bdb4554d082faae663d799e91eff7dbf15262be48856ce82a7d
-size 1331
+oid sha256:2b714ff9724ba98d4302a3db15c29be772c5899ccd4f120851e18005b93279af
+size 1359

--- a/Assets/CardEffect/BT19/Purple/BT19_071.cs
+++ b/Assets/CardEffect/BT19/Purple/BT19_071.cs
@@ -92,7 +92,7 @@ namespace DCGO.CardEffects.BT19
                     }
 
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainBlocker(
-                        targetPermanent: card.PermanentOfThisCard(), effectDuration: EffectDuration.UntilEachTurnEnd,
+                        targetPermanent: card.PermanentOfThisCard(), effectDuration: EffectDuration.UntilOpponentTurnEnd,
                         activateClass: activateClass));
                 }
             }


### PR DESCRIPTION
Fixed traits for gargomon (missing beastkin, had digimon instead), beelzemon (misssing 7gdl), and fixed beelz's effect duration (was set to UntilEachTurnEnd instead of UntilOpponentTurnEnd)