### PR TITLE
On Play Shared Timings Fix

### DIFF
--- a/Assets/CardEffect/BT15/Blue/BT15_030.cs
+++ b/Assets/CardEffect/BT15/Blue/BT15_030.cs
@@ -18,11 +18,6 @@ namespace DCGO.CardEffects.BT15
 
             #region On Deletion/On Play Shared
 
-            string EffectDiscription()
-            {
-                return "[On Play] [On Deletion] Trash the top 2 digivolution cards of all of your opponent's Digimon. Then, return 2 of your opponent's Digimon with no digivolution cards to the deck bottom";
-            }
-
             bool CanSelectPermanentCondition1(Permanent permanent)
             {
                 if (CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
@@ -44,8 +39,13 @@ namespace DCGO.CardEffects.BT15
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Trash digivolution cards and return 1 Digimon without digivolution cards to the deck bottom", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Play] Trash the top 2 digivolution cards of all of your opponent's Digimon. Then, return 2 of your opponent's Digimon with no digivolution cards to the deck bottom";
+                }
 
                 bool CanSelectPermanentCondition(Permanent permanent)
                 {
@@ -120,8 +120,13 @@ namespace DCGO.CardEffects.BT15
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Trash digivolution cards and return 1 Digimon without digivolution cards to the deck bottom", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Deletion] Trash the top 2 digivolution cards of all of your opponent's Digimon. Then, return 2 of your opponent's Digimon with no digivolution cards to the deck bottom";
+                }
 
                 bool CanSelectPermanentCondition(Permanent permanent)
                 {

--- a/Assets/CardEffect/BT15/Blue/BT15_031.cs
+++ b/Assets/CardEffect/BT15/Blue/BT15_031.cs
@@ -46,11 +46,6 @@ namespace DCGO.CardEffects.BT15
 
             #region On Play/When Attacking Shared
 
-            string EffectSharedDiscription()
-            {
-                return "[On Play] [When Attacking] Return 1 of your opponent's level 5 or lower Digimon to the bottom of their deck.";
-            }
-
             bool CanSelectPermanentCondition(Permanent permanent)
             {
                 if (CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
@@ -87,8 +82,13 @@ namespace DCGO.CardEffects.BT15
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Return 1 level 5 or lower Digimon to hand", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectSharedDiscription());
+                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Play] Return 1 of your opponent's level 5 or lower Digimon to the bottom of their deck.";
+                }
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
@@ -129,8 +129,13 @@ namespace DCGO.CardEffects.BT15
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Return 1 level 5 or lower Digimon to hand", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectSharedDiscription());
+                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] Return 1 of your opponent's level 5 or lower Digimon to the bottom of their deck.";
+                }
 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/BT15/Green/BT15_052.cs
+++ b/Assets/CardEffect/BT15/Green/BT15_052.cs
@@ -43,11 +43,6 @@ namespace DCGO.CardEffects.BT15
 
             #region On Play/When Attacking Shared
 
-            string EffectSharedDescription()
-            {
-                return "[On Play] [When Attacking] Return 1 of your opponent's suspended Digimon to the bottom of the deck.";
-            }
-
             bool CanSelectPermanentCondition(Permanent permanent)
             {
                 if (CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
@@ -79,8 +74,13 @@ namespace DCGO.CardEffects.BT15
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Return 1 suspended Digimon to the bottom of deck", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectSharedDescription());
+                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Play] Return 1 of your opponent's suspended Digimon to the bottom of the deck.";
+                }
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
@@ -121,8 +121,13 @@ namespace DCGO.CardEffects.BT15
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Return 1 suspended Digimon to the bottom of deck", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectSharedDescription());
+                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] Return 1 of your opponent's suspended Digimon to the bottom of the deck.";
+                }
 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/BT15/Purple/BT15_079.cs
+++ b/Assets/CardEffect/BT15/Purple/BT15_079.cs
@@ -13,11 +13,6 @@ namespace DCGO.CardEffects.BT15
 
             #region On Play/When Attacking Shared
 
-            string EffectSharedDiscription()
-            {
-                return "[On Play] [When Attacking] Delete 1 of your opponent's unsuspended Digimon.";
-            }
-
             bool CanSelectPermanentCondition(Permanent permanent)
             {
                 if (CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
@@ -51,8 +46,13 @@ namespace DCGO.CardEffects.BT15
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Delete 1 unsuspened Digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectSharedDiscription());
+                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Play] Delete 1 of your opponent's unsuspended Digimon.";
+                }
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
@@ -93,8 +93,13 @@ namespace DCGO.CardEffects.BT15
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Delete 1 unsuspened Digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectSharedDiscription());
+                activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[When Attacking] Delete 1 of your opponent's unsuspended Digimon.";
+                }
 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/BT20/Red/BT20_021.cs
+++ b/Assets/CardEffect/BT20/Red/BT20_021.cs
@@ -79,7 +79,7 @@ namespace DCGO.CardEffects.BT20
 
                 string EffectDescription()
                 {
-                    return "[OnPlay] [Once Per Turn] Place 1 [Royal Knight] trait card from your hand or trash as this Digimon's bottom digivolution card, delete 1 of your opponent's Digimon with as much or less DP as this digimon.";
+                    return "[On Play] [Once Per Turn] Place 1 [Royal Knight] trait card from your hand or trash as this Digimon's bottom digivolution card, delete 1 of your opponent's Digimon with as much or less DP as this digimon.";
                 }
 
                 bool CanUseCondition(Hashtable hashtable)

--- a/Assets/CardEffect/EX6/Yellow/EX6_018.cs
+++ b/Assets/CardEffect/EX6/Yellow/EX6_018.cs
@@ -113,12 +113,6 @@ namespace DCGO.CardEffects.EX6
             
             #region On Play/ Start of Your Main Phase Shared
             
-            string EffectSharedDescription()
-            {
-                return
-                    "[On Play] [Start of Your Main Phase] Reveal the top 3 cards of your deck. Add 1 card with the [Angel]/[Archangel]/[Three Great Angels]/[Seven Great Demon Lords] trait among them to your hand. Trash the rest.";
-            }
-            
             bool CanSelectCardSharedCondition(CardSource cardSource)
             {
                 if (cardSource.CardTraits.Contains("Angel") ||
@@ -156,8 +150,14 @@ namespace DCGO.CardEffects.EX6
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Reveal the top 3 cards of deck", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[On Play] Reveal the top 3 cards of your deck. Add 1 card with the [Angel]/[Archangel]/[Three Great Angels]/[Seven Great Demon Lords] trait among them to your hand. Trash the rest.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {
@@ -195,8 +195,14 @@ namespace DCGO.CardEffects.EX6
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Reveal the top 3 cards of deck", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[Start of Your Main Phase] Reveal the top 3 cards of your deck. Add 1 card with the [Angel]/[Archangel]/[Three Great Angels]/[Seven Great Demon Lords] trait among them to your hand. Trash the rest.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/EX6/Yellow/EX6_023.cs
+++ b/Assets/CardEffect/EX6/Yellow/EX6_023.cs
@@ -69,12 +69,6 @@ namespace DCGO.CardEffects.EX6
             
             #region On Play/ When Attacking/ ESS Shared
             
-            string EffectSharedDescription()
-            {
-                return
-                    "[On Play] [When Attacking] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, delete 1 of your opponent's Digimon with 6000 DP or less.";
-            }
-            
             bool CanSelectSecMinusPermanentSharedCondition(Permanent permanent)
             {
                 if (CardEffectCommons.IsPermanentExistsOnBattleArea(permanent))
@@ -99,9 +93,15 @@ namespace DCGO.CardEffects.EX6
                     "1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, delete 1 of your opponent's Digimon with 6000 DP or less.",
                     CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 activateClass.SetHashString("SecurityAttack-1Delete_EX6-023");
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[On Play] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, delete 1 of your opponent's Digimon with 6000 DP or less.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {
@@ -218,9 +218,15 @@ namespace DCGO.CardEffects.EX6
                     "1 Digimon may gain [Security Attack -1] until the end of your opponent's turn",
                     CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 activateClass.SetHashString("SecurityAttack-1_EX6-023");
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[When Attacking] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, delete 1 of your opponent's Digimon with 6000 DP or less.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/EX6/Yellow/EX6_024.cs
+++ b/Assets/CardEffect/EX6/Yellow/EX6_024.cs
@@ -69,12 +69,6 @@ namespace DCGO.CardEffects.EX6
             
             #region On Play/ When Attacking/ ESS Shared
             
-            string EffectSharedDescription()
-            {
-                return
-                    "[On Play] [When Attacking] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, 1 of your opponent's Digimon or Tamers can't suspend until the end of their turn.";
-            }
-            
             bool CanSelectSecMinusPermanentSharedCondition(Permanent permanent)
             {
                 if (CardEffectCommons.IsPermanentExistsOnBattleArea(permanent))
@@ -99,9 +93,15 @@ namespace DCGO.CardEffects.EX6
                     "1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, 1 of your opponent's Digimon or Tamers can't suspend until the end of their turn.",
                     CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 activateClass.SetHashString("SecurityAttack-1CantSuspend_EX6-024");
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[On Play] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, 1 of your opponent's Digimon or Tamers can't suspend until the end of their turn.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {
@@ -259,9 +259,15 @@ namespace DCGO.CardEffects.EX6
                     "1 Digimon may gain [Security Attack -1] until the end of your opponent's turn",
                     CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 activateClass.SetHashString("SecurityAttack-1_EX6-024");
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[When Attacking] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, 1 of your opponent's Digimon or Tamers can't suspend until the end of their turn.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/EX6/Yellow/EX6_026.cs
+++ b/Assets/CardEffect/EX6/Yellow/EX6_026.cs
@@ -69,12 +69,6 @@ namespace DCGO.CardEffects.EX6
             
             #region On Play/ When Attacking/ ESS Shared
             
-            string EffectSharedDescription()
-            {
-                return
-                    "[On Play] [When Attacking] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, this Digimon gets +3000 DP and [Blocker] until the end of your opponent's turn.";
-            }
-            
             bool CanSelectSecMinusPermanentSharedCondition(Permanent permanent)
             {
                 if (CardEffectCommons.IsPermanentExistsOnBattleArea(permanent))
@@ -99,9 +93,15 @@ namespace DCGO.CardEffects.EX6
                     "1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, this Digimon gets +3000 DP and [Blocker] until the end of your opponent's turn.",
                     CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 activateClass.SetHashString("SecurityAttack-1Buff_EX6-026");
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[On Play] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, this Digimon gets +3000 DP and [Blocker] until the end of your opponent's turn.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {
@@ -182,9 +182,15 @@ namespace DCGO.CardEffects.EX6
                     "1 Digimon may gain [Security Attack -1] until the end of your opponent's turn",
                     CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 activateClass.SetHashString("SecurityAttack-1_EX6-026");
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[When Attacking] [Once Per Turn] 1 Digimon may gain [Security Attack -1] until the end of your opponent's turn. Then, if DigiXrosing, this Digimon gets +3000 DP and [Blocker] until the end of your opponent's turn.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/EX6/Yellow/EX6_063.cs
+++ b/Assets/CardEffect/EX6/Yellow/EX6_063.cs
@@ -12,12 +12,6 @@ namespace DCGO.CardEffects.EX6
             
             #region Start of Your Main Phase/ On Play Shared
             
-            string EffectSharedDescription()
-            {
-                return
-                    "[Start Of Your Main Phase] [On Play] 1 of your yellow Digimon gains [Barrier] until the end of your opponent's turn.";
-            }
-            
             bool IsOwnerYellowDigimonSharedCondition(Permanent permanent)
             {
                 if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
@@ -52,8 +46,14 @@ namespace DCGO.CardEffects.EX6
                     "1 of your yellow Digimon gains [Barrier] until the end of your opponent's turn.", CanUseCondition,
                     card);
                 activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[On Play] 1 of your yellow Digimon gains [Barrier] until the end of your opponent's turn.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {
@@ -111,8 +111,14 @@ namespace DCGO.CardEffects.EX6
                     "1 of your yellow Digimon gains [Barrier] until the end of your opponent's turn.", CanUseCondition,
                     card);
                 activateClass.SetUpActivateClass(CanActivateSharedCondition, ActivateCoroutine, -1, false,
-                    EffectSharedDescription());
+                    EffectDescription());
                 cardEffects.Add(activateClass);
+            
+                string EffectDescription()
+                {
+                    return
+                        "[Start Of Your Main Phase] 1 of your yellow Digimon gains [Barrier] until the end of your opponent's turn.";
+                }
                 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/EX8/Black/EX8_049.cs
+++ b/Assets/CardEffect/EX8/Black/EX8_049.cs
@@ -26,7 +26,7 @@ namespace DCGO.CardEffects.EX8
 
                 string EffectDiscription()
                 {
-                    return "[On Play] [On Deletion] <De-Digivolve 1> 1 of your opponent's Digimon.";
+                    return "[On Play] <De-Digivolve 1> 1 of your opponent's Digimon.";
                 }
 
                 bool CanUseCondition(Hashtable hashtable)


### PR DESCRIPTION
Fix the issue that a handful of cards have where their on play effects are shared with another timing, but they're not being properly split up in the code, causing Valdur Arm to break the other timings.