### PR TITLE
1.7.6.2 Bug Fixes

### DIFF
--- a/Assets/CardEffect/BT18/Black/BT18_072.cs
+++ b/Assets/CardEffect/BT18/Black/BT18_072.cs
@@ -120,6 +120,61 @@ namespace DCGO.CardEffects.BT18
                        CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentConditionShared);
             }
 
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                int degenrationMaxCount = 2;
+                int degenrationCount = 0;
+
+                SelectCountEffect selectCountEffect = GManager.instance.GetComponent<SelectCountEffect>();
+                if (selectCountEffect != null)
+                {
+                    selectCountEffect.SetUp(
+                        SelectPlayer: card.Owner,
+                        targetPermanent: null,
+                        MaxCount: degenrationMaxCount,
+                        CanNoSelect: false,
+                        Message: "How much will you De-Digivolve?",
+                        Message_Enemy: "The opponent is choosing how much to De-Digivolve.",
+                        SelectCountCoroutine: SelectCountCoroutine);
+
+                    yield return ContinuousController.instance.StartCoroutine(selectCountEffect.Activate());
+
+                    IEnumerator SelectCountCoroutine(int count)
+                    {
+                        degenrationCount = count;
+                        yield return null;
+                    }
+                }
+
+                SelectPermanentEffect selectPermanentEffect =
+                    GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentConditionShared));
+
+                selectPermanentEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: CanSelectPermanentConditionShared,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: maxCount,
+                    canNoSelect: false,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: SelectPermanentCoroutine,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Custom,
+                    cardEffect: activateClass);
+
+                selectPermanentEffect.SetUpCustomMessage("Select Digimons to De-Digivolve",
+                    "The opponent is selecting Digimons to De-Digivolve");
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(
+                        new IDegeneration(permanent, degenrationCount, activateClass, true).Degeneration());
+                }
+            }
+
             #endregion
 
             #region On Play
@@ -128,7 +183,7 @@ namespace DCGO.CardEffects.BT18
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("De-Digivolve 2 2 of your opponent's Digimon ", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateConditionShared, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateConditionShared, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
@@ -141,37 +196,6 @@ namespace DCGO.CardEffects.BT18
                 {
                     return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
                 }
-
-                IEnumerator ActivateCoroutine(Hashtable hashtable)
-                {
-                    SelectPermanentEffect selectPermanentEffect =
-                        GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentConditionShared));
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanSelectPermanentConditionShared,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: maxCount,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-                    selectPermanentEffect.SetUpCustomMessage("Select 2 Digimon to De-Digivolve 2.",
-                        "The opponent is selecting 2 Digimon to De-Digivolve 2.");
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(
-                            new IDegeneration(permanent, 2, activateClass).Degeneration());
-                    }
-                }
             }
 
             #endregion
@@ -182,7 +206,7 @@ namespace DCGO.CardEffects.BT18
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("De-Digivolve 2 2 of your opponent's Digimon ", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateConditionShared, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateConditionShared, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
@@ -194,61 +218,6 @@ namespace DCGO.CardEffects.BT18
                 bool CanUseCondition(Hashtable hashtable)
                 {
                     return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-                }
-
-                IEnumerator ActivateCoroutine(Hashtable hashtable)
-                {
-                    int degenrationMaxCount = 2;
-                    int degenrationCount = 0;
-
-                    SelectCountEffect selectCountEffect = GManager.instance.GetComponent<SelectCountEffect>();
-                    if (selectCountEffect != null)
-                    {
-                        selectCountEffect.SetUp(
-                            SelectPlayer: card.Owner,
-                            targetPermanent: null,
-                            MaxCount: degenrationMaxCount,
-                            CanNoSelect: false,
-                            Message: "How much will you De-Digivolve?",
-                            Message_Enemy: "The opponent is choosing how much to De-Digivolve.",
-                            SelectCountCoroutine: SelectCountCoroutine);
-
-                        yield return ContinuousController.instance.StartCoroutine(selectCountEffect.Activate());
-
-                        IEnumerator SelectCountCoroutine(int count)
-                        {
-                            degenrationCount = count;
-                            yield return null;
-                        }
-                    }
-
-                    SelectPermanentEffect selectPermanentEffect =
-                        GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentConditionShared));
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanSelectPermanentConditionShared,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: maxCount,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-                    selectPermanentEffect.SetUpCustomMessage("Select Digimons to De-Digivolve",
-                        "The opponent is selecting Digimons to De-Digivolve");
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(
-                            new IDegeneration(permanent, degenrationCount, activateClass, true).Degeneration());
-                    }
                 }
             }
 

--- a/Assets/CardEffect/BT18/Green/BT18_052.cs
+++ b/Assets/CardEffect/BT18/Green/BT18_052.cs
@@ -28,20 +28,56 @@ namespace DCGO.CardEffects.BT18
             #endregion
 
             #region On Play/When Digivolving Shared
+
             bool IsOpponenetsDigimon(Permanent permanent)
             {
                 return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
             }
 
-            
+            bool SharedCanActivateCondition(Hashtable hashtable)
+            {
+                if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    return card.Owner.SecurityCards.Count(cardSource => !cardSource.IsFlipped) > 0;
+
+                return false;
+            }
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                int maxCount = card.Owner.SecurityCards.Count(cardSource => !cardSource.IsFlipped);
+
+                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                selectPermanentEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: IsOpponenetsDigimon,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: 1,
+                    canNoSelect: false,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: DeDigivolvePermanent,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Custom,
+                    cardEffect: activateClass);
+
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                IEnumerator DeDigivolvePermanent(Permanent permanent)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new IDegeneration(permanent, maxCount, activateClass, true).Degeneration());
+                }
+            }
+
             #endregion
 
             #region On Play
+
             if (timing == EffectTiming.OnEnterFieldAnyone)
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("For each of your face up security cards, <De-Digivolve 1> 1 of your opponent's Digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
+                activateClass.SetUpActivateClass(SharedCanActivateCondition, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, false, EffectDiscription());
                 cardEffects.Add(activateClass);
 
                 string EffectDiscription()
@@ -53,50 +89,17 @@ namespace DCGO.CardEffects.BT18
                 {
                     return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
                 }
-
-                bool CanActivateCondition(Hashtable hashtable)
-                {
-                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
-                        return card.Owner.SecurityCards.Count(cardSource => !cardSource.IsFlipped) > 0;
-
-                    return false;
-                }
-
-                IEnumerator ActivateCoroutine(Hashtable hashtable)
-                {
-                    int maxCount = card.Owner.SecurityCards.Count(cardSource => !cardSource.IsFlipped);
-
-                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: IsOpponenetsDigimon,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: DeDigivolvePermanent,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    IEnumerator DeDigivolvePermanent(Permanent permanent)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(new IDegeneration(permanent, maxCount, activateClass).Degeneration());
-                    }                    
-                }
             }
+
             #endregion
 
             #region When Digivolving
+
             if (timing == EffectTiming.OnEnterFieldAnyone)
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("For each of your face up security cards, <De-Digivolve 1> 1 of your opponent's Digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
+                activateClass.SetUpActivateClass(SharedCanActivateCondition, (hashTable) => SharedActivateCoroutine(hashTable, activateClass), -1, false, EffectDiscription());
                 cardEffects.Add(activateClass);
 
                 string EffectDiscription()
@@ -108,45 +111,12 @@ namespace DCGO.CardEffects.BT18
                 {
                     return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
                 }
-
-                bool CanActivateCondition(Hashtable hashtable)
-                {
-                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
-                        return card.Owner.SecurityCards.Count(cardSource => !cardSource.IsFlipped) > 0;
-
-                    return false;
-                }
-
-                IEnumerator ActivateCoroutine(Hashtable hashtable)
-                {
-                    int maxCount = card.Owner.SecurityCards.Count(cardSource => !cardSource.IsFlipped);
-
-                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: IsOpponenetsDigimon,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: DeDigivolvePermanent,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    IEnumerator DeDigivolvePermanent(Permanent permanent)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(new IDegeneration(permanent, maxCount, activateClass, true).Degeneration());
-                    }
-                }
             }
+
             #endregion
 
             #region All Turns - ESS
+
             if (timing == EffectTiming.OnEndBattle)
             {
                 ActivateClass activateClass = new ActivateClass();
@@ -196,9 +166,11 @@ namespace DCGO.CardEffects.BT18
                         fromTop: true).DestroySecurity());
                 }
             }
+
             #endregion
 
             #region All Turns - Security
+
             if (timing == EffectTiming.None)
             {
                 bool CanUseCondition()
@@ -233,6 +205,7 @@ namespace DCGO.CardEffects.BT18
                     card: card,
                     condition: CanUseCondition));
             }
+
             #endregion
 
             return cardEffects;

--- a/Assets/CardEffect/BT19/Red/BT19_090.cs
+++ b/Assets/CardEffect/BT19/Red/BT19_090.cs
@@ -47,16 +47,16 @@ namespace DCGO.CardEffects.BT19
                 {
                     return CardEffectCommons.IsOwnerPermanent(permanent, card) &&
                            permanent.TopCard.EqualsCardName("Shoutmon EX6") &&
-                           CardEffectCommons.CanUnsuspend(permanent) &&
-                           permanent.IsSuspended;
+                           permanent.IsSuspended &&
+                    CardEffectCommons.CanUnsuspend(permanent);
                 }
 
                 bool IsUnsuspendedStarmonCondition(Permanent permanent)
                 {
                     return CardEffectCommons.IsOwnerPermanent(permanent, card) &&
                            permanent.TopCard.EqualsCardName("ShootingStarmon") &&
-                           CardEffectCommons.CanUnsuspend(permanent) &&
-                           permanent.IsSuspended;
+                           permanent.IsSuspended &&
+                           CardEffectCommons.CanUnsuspend(permanent);
                 }
 
                 bool IsYourDigimon(Permanent permanent)
@@ -163,7 +163,7 @@ namespace DCGO.CardEffects.BT19
                     {
                         // if only 0-1 of targets is on the field, effect ends here & we dont unsuspend anything
                         var digimonPresent = card.Owner.GetBattleAreaDigimons().Filter(x => (IsUnsuspendedStarmonCondition(x) || IsUnsuspendedShoutmonCondition(x))).ToList();
-                        if (digimonPresent.Count <= 1) yield return null;
+                        if (digimonPresent.Count <= 1) yield break;
 
                         List<Permanent> selectedPermanents = new();
 
@@ -182,7 +182,7 @@ namespace DCGO.CardEffects.BT19
                             canTargetCondition_ByPreSelecetedList: null,
                             canEndSelectCondition: null,
                             maxCount: 1,
-                            canNoSelect: true,
+                            canNoSelect: false,
                             canEndNotMax: false,
                             selectPermanentCoroutine: SelectPermanentCoroutine1,
                             afterSelectPermanentCoroutine: null,
@@ -197,7 +197,7 @@ namespace DCGO.CardEffects.BT19
                             canTargetCondition_ByPreSelecetedList: null,
                             canEndSelectCondition: null,
                             maxCount: 1,
-                            canNoSelect: true,
+                            canNoSelect: false,
                             canEndNotMax: false,
                             selectPermanentCoroutine: SelectPermanentCoroutine1,
                             afterSelectPermanentCoroutine: null,

--- a/Assets/CardEffect/EX7/Red/EX7_008.cs
+++ b/Assets/CardEffect/EX7/Red/EX7_008.cs
@@ -82,7 +82,7 @@ namespace DCGO.CardEffects.EX7
                         {
                         new SimplifiedSelectCardConditionClass(
                             canTargetCondition:CanSelectCardCondition,
-                            message: "Select 1 Digimon card with [Three Musketeers] in its Texr.",
+                            message: "Select 1 Digimon card with [Three Musketeers] in its Text.",
                             mode: SelectCardEffect.Mode.AddHand,
                             maxCount: 1,
                             selectCardCoroutine: null),


### PR DESCRIPTION
### Cards

BT18-052 CannonBeemon - OP fixed to work as WD
BT18-072 AncientBeetlemon - OP fixed to work as WD
BT19-090 Meteor Rock Soul - Corrected Yeild break to stop effect, and updatrd Digimon Select to not allow No Select.
EX7-008 ToyAgumon - Fixed Typo