### PR TITLE
Task - 1.8.0.1 Bug Fixes

### DIFF
--- a/Assets/CardEffect/ST20/Black/ST20_14.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_14.cs
@@ -56,6 +56,7 @@ namespace DCGO.CardEffects.ST20
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
+                    if (card.Owner.LibraryCards.Count <= 1) yield break;
                     yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 2, activateClass).Draw());
 
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlaceDelayOptionCards(card: card, cardEffect: activateClass));
@@ -64,11 +65,12 @@ namespace DCGO.CardEffects.ST20
             #endregion
 
             #region delay
-            if (timing == EffectTiming.OnDeclaration)
+
+            if (timing == EffectTiming.WhenRemoveField)
             {
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Draw 2", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetUpICardEffect("Play level 5 ADVENTURE digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, true, EffectDescription());
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
@@ -78,41 +80,15 @@ namespace DCGO.CardEffects.ST20
 
                 bool PermanentCondition(Permanent permanent)
                 {
-                    if (CardEffectCommons.IsOwnerPermanent(permanent, card))
-                    {
-                        return permanent.TopCard.Level >= 5;
-                    }
-
-                    return false;
+                    return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                           && permanent.TopCard.Level >= 5
+                           && permanent.willBeRemoveField;
                 }
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.IsExistOnBattleArea(card))
-                    {
-                        if (CardEffectCommons.CanTriggerWhenPermanentRemoveField(hashtable, PermanentCondition))
-                        {
-                            if (CardEffectCommons.CanDeclareOptionDelayEffect(card))
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    return false;
-                }
-
-                bool CanActivateCondition(Hashtable hashtable)
-                {
-                    if (CardEffectCommons.IsExistOnBattleArea(card))
-                    {
-                        if (card.PermanentOfThisCard().CanBeDestroyedBySkill(activateClass))
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
+                    return CardEffectCommons.CanTriggerWhenPermanentRemoveField(hashtable, PermanentCondition) &&
+                           CardEffectCommons.CanDeclareOptionDelayEffect(card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/CardEffect/ST21/Blue/ST21_03.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_03.cs
@@ -11,7 +11,8 @@ namespace DCGO.CardEffects.ST21
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
             #region Alt Digivolution
-            if(timing == EffectTiming.None)
+
+            if (timing == EffectTiming.None)
             {
                 bool PermanentCondition(Permanent permanent)
                 {
@@ -19,19 +20,23 @@ namespace DCGO.CardEffects.ST21
                 }
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 2, false, card, null));
             }
+
             #endregion
 
             #region Security
+
             if (timing == EffectTiming.SecuritySkill)
             {
                 cardEffects.Add(CardEffectFactory.PlaySelfDigimonAfterBattleSecurityEffect(card: card));
             }
+
             #endregion
 
             #region On Play/When Digivolving shared
+
             bool CanActivateConditonShared(Hashtable hashtable)
             {
-                return CardEffectCommons.IsExistOnBattleAreaDigimon(card) && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanTargetStrip);
+                return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
             }
 
             bool CanTargetStrip(Permanent permanent)
@@ -44,15 +49,92 @@ namespace DCGO.CardEffects.ST21
                 return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) &&
                        permanent.DigivolutionCards.Count == 0;
             }
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                Permanent selectedPermanent = null;
+                if (CardEffectCommons.HasMatchConditionPermanent(CanTargetStrip))
+                {
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanTargetStrip,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        selectedPermanent = permanent;
+
+                        yield return null;
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    if (selectedPermanent != null)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(selectedPermanent, 2, true, activateClass));
+                    }
+                }
+
+                selectedPermanent = null;
+                SelectPermanentEffect selectPermanentEffect2 = GManager.instance.GetComponent<SelectPermanentEffect>();
+                selectPermanentEffect2.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: OpponentsDigimonWithoutSources,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: 1,
+                    canNoSelect: false,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: SelectPermanentCoroutine2,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Custom,
+                    cardEffect: activateClass);
+
+                IEnumerator SelectPermanentCoroutine2(Permanent permanent)
+                {
+                    selectedPermanent = permanent;
+
+                    yield return null;
+                }
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect2.Activate());
+
+                if (selectedPermanent != null)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotAttack(
+                            targetPermanent: selectedPermanent,
+                            defenderCondition: null,
+                            effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                            activateClass: activateClass,
+                            effectName: "Can't Attack"));
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotBlock(
+                        targetPermanent: selectedPermanent,
+                        attackerCondition: null,
+                        effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                        activateClass: activateClass,
+                        effectName: "Can't Block"));
+                }
+            }
+
             #endregion
 
-
             #region On Play
+
             if (timing == EffectTiming.OnEnterFieldAnyone)
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Strip top 2, then freeze", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateConditonShared, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateConditonShared, (hashtable) => SharedActivateCoroutine(hashtable, activateClass), -1, false, EffectDescription());
 
                 string EffectDescription()
                 {
@@ -61,86 +143,19 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
-
-                IEnumerator ActivateCoroutine(Hashtable hashtable)
-                {
-                    Permanent selectedPermanent = null;
-                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanTargetStrip,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        selectedPermanent = permanent;
-
-                        yield return null;
-                    }
-
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    if(selectedPermanent != null)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(selectedPermanent, 2, true, activateClass));
-                    }
-
-                    selectedPermanent = null;
-                    selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: OpponentsDigimonWithoutSources,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    if (selectedPermanent != null)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotAttack(
-                                targetPermanent: selectedPermanent,
-                                defenderCondition: null,
-                                effectDuration: EffectDuration.UntilOpponentTurnEnd,
-                                activateClass: activateClass,
-                                effectName: "Can't Attack"));
-
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotBlock(
-                            targetPermanent: selectedPermanent,
-                            attackerCondition: null,
-                            effectDuration: EffectDuration.UntilOpponentTurnEnd,
-                            activateClass: activateClass,
-                            effectName: "Can't Block"));
-                    }
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
                 }
             }
+
             #endregion
 
             #region When Digivolving
+
             if (timing == EffectTiming.OnEnterFieldAnyone)
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Strip top 2, then freeze", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateConditonShared, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateConditonShared, (hashtable) => SharedActivateCoroutine(hashtable, activateClass), -1, false, EffectDescription());
 
                 string EffectDescription()
                 {
@@ -149,80 +164,11 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-                }
-
-                IEnumerator ActivateCoroutine(Hashtable hashtable)
-                {
-                    Permanent selectedPermanent = null;
-                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanTargetStrip,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        selectedPermanent = permanent;
-
-                        yield return null;
-                    }
-
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    if (selectedPermanent != null)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(selectedPermanent, 2, true, activateClass));
-                    }
-
-                    selectedPermanent = null;
-                    selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: OpponentsDigimonWithoutSources,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    if (selectedPermanent != null)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotAttack(
-                                targetPermanent: selectedPermanent,
-                                defenderCondition: null,
-                                effectDuration: EffectDuration.UntilOpponentTurnEnd,
-                                activateClass: activateClass,
-                                effectName: "Can't Attack"));
-
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotBlock(
-                            targetPermanent: selectedPermanent,
-                            attackerCondition: null,
-                            effectDuration: EffectDuration.UntilOpponentTurnEnd,
-                            activateClass: activateClass,
-                            effectName: "Can't Block"));
-                    }
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
                 }
             }
-            #endregion
 
+            #endregion
 
             #region When Attacking - ESS
 
@@ -270,7 +216,6 @@ namespace DCGO.CardEffects.ST21
             }
 
             #endregion
-
 
             return cardEffects;
         }

--- a/Assets/CardEffect/ST21/Blue/ST21_12.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_12.cs
@@ -76,7 +76,7 @@ namespace DCGO.CardEffects.ST21
                 {
                     if (CardEffectCommons.IsExistOnHand(cardSource))
                     {
-                        return cardSource.EqualsTraits("ADVENTURE");
+                        return cardSource.IsDigimon && cardSource.HasAdventureTraits;
                     }
 
                     return false;

--- a/Assets/CardEffect/ST21/Purple/ST21_11.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_11.cs
@@ -49,9 +49,9 @@ namespace DCGO.CardEffects.ST21
                     }
                 }
                 var distinctColorCombos = tamerCards
-    .Select(tc => string.Join(",", tc.CardColors.OrderBy(c => c)))
-    .Distinct()
-    .ToList();
+                    .Select(tc => string.Join(",", tc.CardColors.OrderBy(c => c)))
+                    .Distinct()
+                    .ToList();
                 return distinctColorCombos.Count / 2;
             }
 

--- a/Assets/CardEffect/ST21/Purple/ST21_11.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_11.cs
@@ -43,12 +43,16 @@ namespace DCGO.CardEffects.ST21
 
                 foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
                 {
-                    if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE"))
+                    if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE") && permanent.TopCard.CardColors.Count == 2)
                     {
                         tamerCards.Add(permanent.TopCard);
                     }
                 }
-                return Combinations.GetDifferenetColorCardCount(tamerCards) / 2;
+                var distinctColorCombos = tamerCards
+    .Select(tc => string.Join(",", tc.CardColors.OrderBy(c => c)))
+    .Distinct()
+    .ToList();
+                return distinctColorCombos.Count / 2;
             }
 
             bool CanSelectPermanentCondition(Permanent permanent)

--- a/Assets/CardEffect/ST21/Purple/ST21_11.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_11.cs
@@ -37,27 +37,11 @@ namespace DCGO.CardEffects.ST21
                         && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectPermanentCondition);
             }
 
-            int TamerTwoColourCount()
-            {
-                List<CardSource> tamerCards = new List<CardSource>();
-
-                foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
-                {
-                    if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE") && permanent.TopCard.CardColors.Count == 2)
-                    {
-                        tamerCards.Add(permanent.TopCard);
-                    }
-                }
-                var distinctColorCombos = tamerCards
-                    .Select(tc => string.Join(",", tc.CardColors.OrderBy(c => c)))
-                    .Distinct()
-                    .ToList();
-                return distinctColorCombos.Count / 2;
-            }
+            bool CanGetCardColour(Permanent permanent) => permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE");
 
             bool CanSelectPermanentCondition(Permanent permanent)
             {
-                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) && permanent.Level <= 4 + TamerTwoColourCount();
+                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) && permanent.Level <= 4 + (CardEffectCommons.GetUniqueColourCountOnOwnerBattleArea(card, CanGetCardColour) / 2);
             }
             #endregion
 

--- a/Assets/CardEffect/ST21/Purple/ST21_13.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_13.cs
@@ -26,7 +26,7 @@ namespace DCGO.CardEffects.ST21
                 {
                     if (CardEffectCommons.IsExistOnHand(cardSource))
                     {
-                        return cardSource.EqualsTraits("ADVENTURE");
+                        return cardSource.IsDigimon && cardSource.HasAdventureTraits;
                     }
 
                     return false;

--- a/Assets/CardEffect/ST21/Purple/ST21_14.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_14.cs
@@ -20,7 +20,7 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.HasMatchConditionPermanent((permanent) => (permanent.IsTamer || permanent.IsDigimon) && permanent.TopCard.EqualsTraits("ADVENTURE"));
+                    return CardEffectCommons.HasMatchConditionPermanent((permanent) => (permanent.IsTamer || permanent.IsDigimon) && permanent.TopCard.EqualsTraits("ADVENTURE"), true);
                 }
 
                 bool CardCondition(CardSource cardSource)

--- a/Assets/CardEffect/ST21/Yellow/ST21_05.cs
+++ b/Assets/CardEffect/ST21/Yellow/ST21_05.cs
@@ -39,14 +39,12 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
                 }
 
                 bool IsAdventureTamerCondition(CardSource cardSource)
                 {
-                    return cardSource.IsTamer &&
-                           cardSource.EqualsTraits("ADVENTURE") &&
-                           CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
+                    return cardSource.IsTamer && cardSource.HasAdventureTraits && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)
@@ -86,11 +84,10 @@ namespace DCGO.CardEffects.ST21
                         IEnumerator SelectCardCoroutine(CardSource cardSource)
                         {
                             selectedCards.Add(cardSource);
-
-                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
-                                cardSources: selectedCards, activateClass: activateClass, payCost: false, isTapped: false,
-                                root: SelectCardEffect.Root.Hand, activateETB: true));
+                            yield return null;
                         }
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(cardSources: selectedCards, activateClass: activateClass, payCost: false, isTapped: false, root: SelectCardEffect.Root.Hand, activateETB: true));
                     }
                 }
             }

--- a/Assets/Scripts/CardEffectCommons/GameContextDeterminarion.cs
+++ b/Assets/Scripts/CardEffectCommons/GameContextDeterminarion.cs
@@ -499,5 +499,27 @@ public partial class CardEffectCommons
 
         return false;
     }
+
+    #endregion
+
+    #region Get unique colour count from permanents in owners battle area
+
+    public static int GetUniqueColourCountOnOwnerBattleArea(CardSource card, Func<Permanent, bool> canGetCardColour)
+    {
+        var permanents = card.Owner.GetBattleAreaPermanents().Filter(x => canGetCardColour(x)).Select(x => x.TopCard).ToList();
+        var distinctColorCombos = permanents
+            .Select(tc => string.Join(",", tc.CardColors.OrderBy(c => c)))
+            .Distinct()
+            .ToList();
+        return distinctColorCombos.Count;
+    }
+
+    #endregion
+
+    #region Get multi colour count from permanents in owners battle area
+
+    public static int GetColourCountOnOwnerBattleArea(CardSource card, Func<Permanent, bool> canGetCardColour) =>
+        card.Owner.GetBattleAreaPermanents().Filter(x => canGetCardColour(x)).ToList().Count;
+
     #endregion
 }

--- a/Assets/Scripts/CardSource.cs
+++ b/Assets/Scripts/CardSource.cs
@@ -2591,6 +2591,23 @@ public class CardSource : MonoBehaviour
     }
 
     #endregion
+
+    #region whether this card has "ADVENTURE" trait
+
+    public bool HasAdventureTraits
+    {
+        get
+        {
+            if (CardTraits.Contains("ADVENTURE"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    #endregion
 }
 
 public class JogressCondition


### PR DESCRIPTION
### Cards
ST20-14 Our Courage United - Now Draw 2 is not optional, if player deck is to low to do this, will auto trash itself & Delay Effect timing and triggers corrected.
ST21-03 Ikkakumon - Fixed ON & WD
ST21-05 Angemon - Fixed WD
ST21-11 MetalGarurumon ACE - Now using new method to calcuate each unique colour on tamers for effect (See Below)
ST21-12 Joe Kido & Mimi Tachikawa - Now correctly only lowering cost of digimon played
ST21-13 Matt Ishida & T.K. Takaishi - Now correctly only lowering cost of digimon played
ST21-14 Believe in Our Friendship - Now using breeding area for Ignore Colour requirement

### Properties
Added HasAdventureTraits boolean to Card Source.

### Methods
Added GetUniqueColourCountOnOwnerBattleArea
This will take take in the passed in canTarget function, organise their colours, and select distinct colours and return to count of those.

Added GetColourCountOnOwnerBattleArea
This will return the count of all colours of passed in canTarget Permanents, regardless if they are unique or not.
