### PR TITLE
Task - 1.8.0.3 Bug Fixes

### DIFF
--- a/Assets/CardEffect/ST20/Black/ST20_01.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_01.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST20
             {
                 bool condition()
                 {
-                    return card.PermanentOfThisCard().TopCard.EqualsTraits("ADVENTURE");
+                    return card.PermanentOfThisCard().TopCard.HasAdventureTraits;
                 }
 
                 cardEffects.Add(CardEffectFactory.ChangeSelfDPStaticEffect(

--- a/Assets/CardEffect/ST20/Black/ST20_10.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_10.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST20
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return (targetPermanent.TopCard.EqualsTraits("ADVENTURE") || targetPermanent.TopCard.EqualsTraits("HERO")) && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 2;
+                    return (targetPermanent.TopCard.HasAdventureTraits || targetPermanent.TopCard.EqualsTraits("HERO")) && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 2;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null));

--- a/Assets/CardEffect/ST20/Black/ST20_11.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_11.cs
@@ -17,7 +17,7 @@ namespace DCGO.CardEffects.ST20
             {
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return (permanent.TopCard.EqualsTraits("ADVENTURE") || permanent.TopCard.EqualsTraits("Hero")) 
+                    return (permanent.TopCard.HasAdventureTraits || permanent.TopCard.EqualsTraits("Hero"))
                         && permanent.Level == 5;
                 }
 

--- a/Assets/CardEffect/ST20/Black/ST20_13.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_13.cs
@@ -135,7 +135,7 @@ namespace DCGO.CardEffects.ST20
                 {
                     if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
                     {
-                        if (permanent.TopCard.EqualsTraits("ADVENTURE"))
+                        if (permanent.TopCard.HasAdventureTraits)
                         {
                             return true;
                         }

--- a/Assets/CardEffect/ST20/Black/ST20_13.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_13.cs
@@ -24,10 +24,7 @@ namespace DCGO.CardEffects.ST20
                 }
 
                 bool PlayCardCondition(CardSource cardSource)
-                {
-                    return CardEffectCommons.IsExistOnHand(cardSource) &&
-                           cardSource.IsDigimon && cardSource.EqualsTraits("ADVENTURE");
-                }
+                    => CardEffectCommons.IsExistOnHand(cardSource) && cardSource.IsDigimon && cardSource.HasAdventureTraits && cardSource.Owner == card.Owner;
 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/ST20/Black/ST20_14.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_14.cs
@@ -25,7 +25,7 @@ namespace DCGO.CardEffects.ST20
                 {
                     return CardEffectCommons.HasMatchConditionPermanent(permanent => 
                         CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(permanent, card)
-                        && permanent.TopCard.EqualsTraits("ADVENTURE")
+                        && permanent.TopCard.HasAdventureTraits
                         && (permanent.IsTamer || permanent.IsDigimon), true);
                 }
 
@@ -118,7 +118,7 @@ namespace DCGO.CardEffects.ST20
                             if (CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass))
                             {
                                 return cardSource.IsDigimon &&
-                                        cardSource.EqualsTraits("ADVENTURE") &&
+                                        cardSource.HasAdventureTraits &&
                                         cardSource.Level <= 5;
                             }
 

--- a/Assets/CardEffect/ST20/Black/ST20_14.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_14.cs
@@ -41,7 +41,7 @@ namespace DCGO.CardEffects.ST20
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Draw 2", CanUseCondition, card);
-                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()

--- a/Assets/CardEffect/ST20/Green/ST20_07.cs
+++ b/Assets/CardEffect/ST20/Green/ST20_07.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST20
             {
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return permanent.Level == 2 && permanent.TopCard.EqualsTraits("ADVENTURE");
+                    return permanent.Level == 2 && permanent.TopCard.HasAdventureTraits;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 0, false, card, null));

--- a/Assets/CardEffect/ST20/Green/ST20_08.cs
+++ b/Assets/CardEffect/ST20/Green/ST20_08.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.ST20
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -45,7 +45,7 @@ namespace DCGO.CardEffects.ST20
                 bool IsAdventureTamerCondition(CardSource cardSource)
                 {
                     return cardSource.IsTamer &&
-                           cardSource.EqualsTraits("ADVENTURE") &&
+                           cardSource.HasAdventureTraits &&
                            CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
                 }
 

--- a/Assets/CardEffect/ST20/Green/ST20_09.cs
+++ b/Assets/CardEffect/ST20/Green/ST20_09.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST20
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -36,7 +36,7 @@ namespace DCGO.CardEffects.ST20
 
                 foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
                 {
-                    if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE"))
+                    if (permanent.IsTamer && permanent.TopCard.HasAdventureTraits)
                     {
                         tamerCards.Add(permanent.TopCard);
                     }
@@ -169,7 +169,7 @@ namespace DCGO.CardEffects.ST20
                 {
                     if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card) && permanent != card.PermanentOfThisCard())
                     {
-                        return permanent.TopCard.EqualsTraits("ADVENTURE");
+                        return permanent.TopCard.HasAdventureTraits;
                     }
                     return false;
                 }

--- a/Assets/CardEffect/ST20/Red/ST20_02.cs
+++ b/Assets/CardEffect/ST20/Red/ST20_02.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST20
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 2;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 2;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -50,12 +50,12 @@ namespace DCGO.CardEffects.ST20
 
                 bool selectAdventureDigimon(CardSource source)
                 {
-                    return source.EqualsTraits("ADVENTURE") && source.IsDigimon;
+                    return source.HasAdventureTraits && source.IsDigimon;
                 }
 
                 bool selectAdventureTorO(CardSource source)
                 {
-                    return source.EqualsTraits("ADVENTURE") && (source.IsOption || source.IsTamer);
+                    return source.HasAdventureTraits && (source.IsOption || source.IsTamer);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/CardEffect/ST20/Red/ST20_03.cs
+++ b/Assets/CardEffect/ST20/Red/ST20_03.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.ST20
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -32,7 +32,7 @@ namespace DCGO.CardEffects.ST20
 
                     foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
                     {
-                        if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE"))
+                        if (permanent.IsTamer && permanent.TopCard.HasAdventureTraits)
                         {
                             tamerCards.Add(permanent.TopCard);
                         }
@@ -66,7 +66,7 @@ namespace DCGO.CardEffects.ST20
 
                 bool CanDigivolveIntoCardCondition(CardSource cardSource)
                 {
-                    return cardSource.IsDigimon && cardSource.EqualsTraits("ADVENTURE");
+                    return cardSource.IsDigimon && cardSource.HasAdventureTraits;
                 }
 
 
@@ -107,7 +107,7 @@ namespace DCGO.CardEffects.ST20
 
                 bool CanDigivolveIntoCardCondition(CardSource cardSource)
                 {
-                    return cardSource.IsDigimon && cardSource.EqualsTraits("ADVENTURE");
+                    return cardSource.IsDigimon && cardSource.HasAdventureTraits;
                 }
 
 

--- a/Assets/CardEffect/ST20/Red/ST20_04.cs
+++ b/Assets/CardEffect/ST20/Red/ST20_04.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST20
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -189,7 +189,7 @@ namespace DCGO.CardEffects.ST20
                 {
                     if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card) && permanent != card.PermanentOfThisCard())
                     {
-                        return permanent.TopCard.EqualsTraits("ADVENTURE");
+                        return permanent.TopCard..HasAdventureTraits;
                     }
                     return false;
                 }

--- a/Assets/CardEffect/ST20/Red/ST20_12.cs
+++ b/Assets/CardEffect/ST20/Red/ST20_12.cs
@@ -42,7 +42,7 @@ namespace DCGO.CardEffects.ST20
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {
-                            if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, permanent => permanent.IsDigimon && permanent.TopCard.EqualsTraits("ADVENTURE"))){
+                            if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, permanent => permanent.IsDigimon && permanent.TopCard.HasAdventureTraits))
                                 return true;
                             }
                         }

--- a/Assets/CardEffect/ST20/Red/ST20_12.cs
+++ b/Assets/CardEffect/ST20/Red/ST20_12.cs
@@ -72,10 +72,7 @@ namespace DCGO.CardEffects.ST20
                 }
 
                 bool PlayCardCondition(CardSource cardSource)
-                {
-                    return CardEffectCommons.IsExistOnHand(cardSource) &&
-                           cardSource.IsDigimon && cardSource.EqualsTraits("ADVENTURE");
-                }
+                    => CardEffectCommons.IsExistOnHand(cardSource) && cardSource.IsDigimon && cardSource.HasAdventureTraits && cardSource.Owner == card.Owner;
 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/ST20/Yellow/ST20_05.cs
+++ b/Assets/CardEffect/ST20/Yellow/ST20_05.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST20
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null));

--- a/Assets/CardEffect/ST20/Yellow/ST20_06.cs
+++ b/Assets/CardEffect/ST20/Yellow/ST20_06.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.ST20
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -53,7 +53,7 @@ namespace DCGO.CardEffects.ST20
                         {
                             foreach (CardSource cardSource in card.Owner.HandCards)
                             {
-                                if (cardSource.EqualsTraits("ADVENTURE"))
+                                if (cardSource.HasAdventureTraits)
                                 {
                                     if (cardSource.CanPlayCardTargetFrame(permanent.PermanentFrame, false, activateClass))
                                     {
@@ -69,7 +69,7 @@ namespace DCGO.CardEffects.ST20
 
                 bool ValidDigivolveIntoHand(CardSource source)
                 {
-                    return source.EqualsTraits("ADVENTURE");
+                    return source.HasAdventureTraits;
                 }
 
                 bool CanUseCondition(Hashtable hashtable)
@@ -158,7 +158,7 @@ namespace DCGO.CardEffects.ST20
                         {
                             foreach (CardSource cardSource in card.Owner.HandCards)
                             {
-                                if (cardSource.EqualsTraits("ADVENTURE"))
+                                if (cardSource.HasAdventureTraits)
                                 {
                                     if (cardSource.CanPlayCardTargetFrame(permanent.PermanentFrame, false, activateClass))
                                     {
@@ -174,7 +174,7 @@ namespace DCGO.CardEffects.ST20
 
                 bool ValidDigivolveIntoHand(CardSource source)
                 {
-                    return source.EqualsTraits("ADVENTURE");
+                    return source.HasAdventureTraits;
                 }
 
                 
@@ -258,7 +258,7 @@ namespace DCGO.CardEffects.ST20
                 {
                     if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card) && permanent != card.PermanentOfThisCard())
                     {
-                        return permanent.TopCard.EqualsTraits("ADVENTURE");
+                        return permanent.TopCard.HasAdventureTraits;
                     }
                     return false;
                 }

--- a/Assets/CardEffect/ST21/Blue/ST21_02.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_02.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST21
             {
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return permanent.Level == 2 && permanent.TopCard.EqualsTraits("ADVENTURE");
+                    return permanent.Level == 2 && permanent.TopCard.HasAdventureTraits;
                 }
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 0, false, card, null));
             }

--- a/Assets/CardEffect/ST21/Blue/ST21_03.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_03.cs
@@ -36,7 +36,7 @@ namespace DCGO.CardEffects.ST21
 
             bool CanActivateConditonShared(Hashtable hashtable)
             {
-                return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                return CardEffectCommons.HasMatchConditionPermanent(CanTargetStrip);
             }
 
             bool CanTargetStrip(Permanent permanent)
@@ -143,7 +143,7 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
                 }
             }
 
@@ -164,7 +164,7 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card) && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
                 }
             }
 

--- a/Assets/CardEffect/ST21/Blue/ST21_03.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_03.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.ST21
             {
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return permanent.Level == 3 && permanent.TopCard.EqualsTraits("ADVENTURE");
+                    return permanent.Level == 3 && permanent.TopCard.HasAdventureTraits;
                 }
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 2, false, card, null));
             }

--- a/Assets/CardEffect/ST21/Blue/ST21_04.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_04.cs
@@ -17,7 +17,7 @@ namespace DCGO.CardEffects.ST21
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -37,7 +37,7 @@ namespace DCGO.CardEffects.ST21
 
                 foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
                 {
-                    if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE"))
+                    if (permanent.IsTamer && permanent.TopCard.HasAdventureTraits)
                     {
                         tamerCards.Add(permanent.TopCard);
                     }
@@ -197,7 +197,7 @@ namespace DCGO.CardEffects.ST21
                 {
                     if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card) && permanent != card.PermanentOfThisCard())
                     {
-                        return permanent.TopCard.EqualsTraits("ADVENTURE");
+                        return permanent.TopCard.HasAdventureTraits;
                     }
                     return false;
                 }

--- a/Assets/CardEffect/ST21/Blue/ST21_12.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_12.cs
@@ -72,16 +72,10 @@ namespace DCGO.CardEffects.ST21
                 {
                     return "[Your Turn] When any Digimon cards with the [ADVENTURE] trait would be played from your hand, by suspending this Tamer, reduce the play cost by 1.";
                 }
+
                 bool PlayCardCondition(CardSource cardSource)
-                {
-                    if (CardEffectCommons.IsExistOnHand(cardSource))
-                    {
-                        return cardSource.IsDigimon && cardSource.HasAdventureTraits;
-                    }
-
-                    return false;
-                }
-
+                    => CardEffectCommons.IsExistOnHand(cardSource) && cardSource.IsDigimon && cardSource.HasAdventureTraits && cardSource.Owner == card.Owner;
+                    
                 bool CanUseCondition(Hashtable hashtable)
                 {
                     if (CardEffectCommons.IsExistOnBattleArea(card))

--- a/Assets/CardEffect/ST21/Blue/ST21_12.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_12.cs
@@ -43,7 +43,7 @@ namespace DCGO.CardEffects.ST21
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {
-                            if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, permanent => permanent.IsDigimon && permanent.TopCard.EqualsTraits("ADVENTURE")))
+                            if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, permanent => permanent.IsDigimon && permanent.TopCard.HasAdventureTraits))
                             {
                                 return true;
                             }

--- a/Assets/CardEffect/ST21/Green/ST21_07.cs
+++ b/Assets/CardEffect/ST21/Green/ST21_07.cs
@@ -40,9 +40,7 @@ namespace DCGO.CardEffects.ST21
                 }
 
                 bool HasAdventureTrait(CardSource cardSource)
-                {
-                    return cardSource.ContainsTraits("ADVENTURE");
-                }
+                   => cardSource.HasAdventureTraits;
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/ST21/Green/ST21_07.cs
+++ b/Assets/CardEffect/ST21/Green/ST21_07.cs
@@ -14,7 +14,7 @@ namespace DCGO.CardEffects.ST21
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 2;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 2;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null));

--- a/Assets/CardEffect/ST21/Green/ST21_08.cs
+++ b/Assets/CardEffect/ST21/Green/ST21_08.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.ST21
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -32,7 +32,7 @@ namespace DCGO.CardEffects.ST21
 
                     foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
                     {
-                        if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE"))
+                        if (permanent.IsTamer && permanent.TopCard.HasAdventureTraits)
                         {
                             tamerCards.Add(permanent.TopCard);
                         }
@@ -66,7 +66,7 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanDigivolveIntoCardCondition(CardSource cardSource)
                 {
-                    return cardSource.IsDigimon && cardSource.EqualsTraits("ADVENTURE");
+                    return cardSource.IsDigimon && cardSource.HasAdventureTraits;
                 }
 
 
@@ -107,7 +107,7 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanDigivolveIntoCardCondition(CardSource cardSource)
                 {
-                    return cardSource.IsDigimon && cardSource.EqualsTraits("ADVENTURE");
+                    return cardSource.IsDigimon && cardSource.HasAdventureTraits;
                 }
 
 

--- a/Assets/CardEffect/ST21/Green/ST21_09.cs
+++ b/Assets/CardEffect/ST21/Green/ST21_09.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.ST21
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -36,7 +36,7 @@ namespace DCGO.CardEffects.ST21
 
                 foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
                 {
-                    if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE"))
+                    if (permanent.IsTamer && permanent.TopCard.HasAdventureTraits)
                     {
                         tamerCards.Add(permanent.TopCard);
                     }
@@ -173,7 +173,7 @@ namespace DCGO.CardEffects.ST21
                 {
                     if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card) && permanent != card.PermanentOfThisCard())
                     {
-                        return permanent.TopCard.EqualsTraits("ADVENTURE");
+                        return permanent.TopCard.HasAdventureTraits;
                     }
                     return false;
                 }

--- a/Assets/CardEffect/ST21/Purple/ST21_01.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_01.cs
@@ -47,7 +47,7 @@ namespace DCGO.CardEffects.ST21
                 {
                     if (cardSource.IsDigimon)
                     {
-                        if (cardSource.EqualsTraits("ADVENTURE"))
+                        if (cardSource.HasAdventureTraits)
                         {
                             return true;
                         }

--- a/Assets/CardEffect/ST21/Purple/ST21_10.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_10.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.ST21
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return (targetPermanent.TopCard.EqualsTraits("ADVENTURE") || targetPermanent.TopCard.EqualsTraits("HERO")) && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 2;
+                    return (targetPermanent.TopCard.HasAdventureTraits || targetPermanent.TopCard.EqualsTraits("HERO")) && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 2;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null));

--- a/Assets/CardEffect/ST21/Purple/ST21_11.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_11.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST21
             {
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return permanent.Level == 5 && permanent.TopCard.EqualsTraits("ADVENTURE");
+                    return permanent.Level == 5 && permanent.TopCard.HasAdventureTraits;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 3, false, card, null));
@@ -37,7 +37,7 @@ namespace DCGO.CardEffects.ST21
                         && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectPermanentCondition);
             }
 
-            bool CanGetCardColour(Permanent permanent) => permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE") && permanent.TopCard.Owner == card.Owner;
+            bool CanGetCardColour(Permanent permanent) => permanent.IsTamer && permanent.TopCard.HasAdventureTraits && permanent.TopCard.Owner == card.Owner;
 
             bool CanSelectPermanentCondition(Permanent permanent)
             {

--- a/Assets/CardEffect/ST21/Purple/ST21_11.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_11.cs
@@ -37,7 +37,7 @@ namespace DCGO.CardEffects.ST21
                         && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectPermanentCondition);
             }
 
-            bool CanGetCardColour(Permanent permanent) => permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE");
+            bool CanGetCardColour(Permanent permanent) => permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE") && permanent.TopCard.Owner == card.Owner;
 
             bool CanSelectPermanentCondition(Permanent permanent)
             {

--- a/Assets/CardEffect/ST21/Purple/ST21_13.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_13.cs
@@ -134,7 +134,7 @@ namespace DCGO.CardEffects.ST21
                 {
                     if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
                     {
-                        if (permanent.TopCard.EqualsTraits("ADVENTURE") && permanent.Level >= 5)
+                        if (permanent.TopCard.HasAdventureTraits && permanent.Level >= 5)
                         {
                             return true;
                         }

--- a/Assets/CardEffect/ST21/Purple/ST21_13.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_13.cs
@@ -23,14 +23,7 @@ namespace DCGO.CardEffects.ST21
                     return "[Your Turn] When any Digimon cards with the [ADVENTURE] trait would be played from your hand, by suspending this Tamer, reduce the play cost by 1.";
                 }
                 bool PlayCardCondition(CardSource cardSource)
-                {
-                    if (CardEffectCommons.IsExistOnHand(cardSource))
-                    {
-                        return cardSource.IsDigimon && cardSource.HasAdventureTraits;
-                    }
-
-                    return false;
-                }
+                    => CardEffectCommons.IsExistOnHand(cardSource) && cardSource.IsDigimon && cardSource.HasAdventureTraits && cardSource.Owner == card.Owner;
 
                 bool CanUseCondition(Hashtable hashtable)
                 {

--- a/Assets/CardEffect/ST21/Purple/ST21_14.cs
+++ b/Assets/CardEffect/ST21/Purple/ST21_14.cs
@@ -20,7 +20,7 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.HasMatchConditionPermanent((permanent) => (permanent.IsTamer || permanent.IsDigimon) && permanent.TopCard.EqualsTraits("ADVENTURE"), true);
+                    return CardEffectCommons.HasMatchConditionPermanent((permanent) => (permanent.IsTamer || permanent.IsDigimon) && permanent.TopCard.HasAdventureTraits, true);
                 }
 
                 bool CardCondition(CardSource cardSource)
@@ -50,7 +50,7 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanSelectCardCondition(CardSource cardSource)
                 {
-                    return cardSource.EqualsTraits("ADVENTURE");
+                    return cardSource.HasAdventureTraits;
                 }
 
                 bool CanUseCondition(Hashtable hashtable)

--- a/Assets/CardEffect/ST21/Yellow/ST21_05.cs
+++ b/Assets/CardEffect/ST21/Yellow/ST21_05.cs
@@ -17,7 +17,7 @@ namespace DCGO.CardEffects.ST21
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 3;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null));

--- a/Assets/CardEffect/ST21/Yellow/ST21_06.cs
+++ b/Assets/CardEffect/ST21/Yellow/ST21_06.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.ST21
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsTraits("ADVENTURE") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
+                    return targetPermanent.TopCard.HasAdventureTraits && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 4;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
@@ -29,7 +29,7 @@ namespace DCGO.CardEffects.ST21
 
                 foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
                 {
-                    if (permanent.IsTamer && permanent.TopCard.EqualsTraits("ADVENTURE"))
+                    if (permanent.IsTamer && permanent.TopCard.HasAdventureTraits)
                     {
                         tamerCards.Add(permanent.TopCard);
                     }
@@ -190,7 +190,7 @@ namespace DCGO.CardEffects.ST21
                 {
                     if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card) && permanent != card.PermanentOfThisCard())
                     {
-                        return permanent.TopCard.EqualsTraits("ADVENTURE");
+                        return permanent.TopCard.HasAdventureTraits;
                     }
                     return false;
                 }

--- a/Assets/Scripts/CardEffectCommons/GameContextDeterminarion.cs
+++ b/Assets/Scripts/CardEffectCommons/GameContextDeterminarion.cs
@@ -506,12 +506,13 @@ public partial class CardEffectCommons
 
     public static int GetUniqueColourCountOnOwnerBattleArea(CardSource card, Func<Permanent, bool> canGetCardColour)
     {
-        var permanents = card.Owner.GetBattleAreaPermanents().Filter(x => canGetCardColour(x)).Select(x => x.TopCard).ToList();
-        var distinctColorCombos = permanents
-            .Select(tc => string.Join(",", tc.CardColors.OrderBy(c => c)))
-            .Distinct()
-            .ToList();
-        return distinctColorCombos.Count;
+        var uniqueColors = card.Owner.GetBattleAreaPermanents()
+        .Filter(x => canGetCardColour(x))
+        .Select(x => x.TopCard)
+        .SelectMany(x => x.CardColors)
+        .Distinct()
+        .ToHashSet();
+        return uniqueColors.Count;
     }
 
     #endregion


### PR DESCRIPTION
### Cards
Digimon
ST21-11 MetalGarurumon ACE - Now working as intended using fixed method (see below)
ST21-03 Ikkakumon - Updated Use & Activate triggers.

Tamers
ST20-12 Sora Takenouchi & Kari Kamiya - Now only triggers on own digimon being played
ST20-13 Tai Kamiya & Izzy Izumi -  Now only triggers on own digimon being played
ST21-12 Joe Kido & Mimi Tachikawa -  Now only triggers on own digimon being played
ST21-13 Matt Ishida & T.K. Takaishi -  Now only triggers on own digimon being played

Options
ST20-14 Our Courage United - No longer optional

### Methods
GetUniqueColourCountOnOwnerBattleArea - Fixed & simplified this method

### Misc
Code Cleanup on multiple old cards, now using IsAdventureTraits boolean instead of GetTraits method