### PR TITLE
1.8.0.4 Bug Fixes

### DIFF
--- a/Assets/CardBaseEntity/BT1/Green/Digimon/BT1_083.asset
+++ b/Assets/CardBaseEntity/BT1/Green/Digimon/BT1_083.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1de2bfa74c314f5f2dc67293fee545acbd25f543ef6a6da602f4b177a601e455
-size 1861
+oid sha256:3c1f5dd3bba9e504f16e7f10008b0872ba02d1e8be6e2c5662e5000395d64040
+size 1853

--- a/Assets/CardBaseEntity/BT1/Green/Digimon/BT1_083_P1.asset
+++ b/Assets/CardBaseEntity/BT1/Green/Digimon/BT1_083_P1.asset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8c6cf1ff62f37687ffa3a935f508cc3c29cbf5f01bfa4042f9e2f63301928c6
-size 1867
+oid sha256:e0ccd30f618bb46d17612c668e1406aac52f9c6b7725287dc7cc2a188f81c188
+size 1859

--- a/Assets/CardEffect/ST20/Black/ST20_14.cs
+++ b/Assets/CardEffect/ST20/Black/ST20_14.cs
@@ -13,6 +13,7 @@ namespace DCGO.CardEffects.ST20
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
             #region ignoring colours
+
             if (timing == EffectTiming.None)
             {
                 IgnoreColorConditionClass ignoreColorConditionClass = new IgnoreColorConditionClass();
@@ -22,21 +23,16 @@ namespace DCGO.CardEffects.ST20
                 cardEffects.Add(ignoreColorConditionClass);
 
                 bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.HasMatchConditionPermanent(permanent => 
-                        CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(permanent, card)
-                        && permanent.TopCard.HasAdventureTraits
-                        && (permanent.IsTamer || permanent.IsDigimon), true);
-                }
+                    => CardEffectCommons.HasMatchConditionPermanent((permanent) => (permanent.IsTamer || permanent.IsDigimon) && permanent.TopCard.HasAdventureTraits, true);
 
                 bool CardCondition(CardSource cardSource)
-                {
-                    return (cardSource == card);
-                }
+                    => cardSource == card;
             }
+
             #endregion
 
             #region Main effect
+
             if (timing == EffectTiming.OptionSkill)
             {
                 ActivateClass activateClass = new ActivateClass();
@@ -56,12 +52,11 @@ namespace DCGO.CardEffects.ST20
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    if (card.Owner.LibraryCards.Count <= 1) yield break;
-                    yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 2, activateClass).Draw());
-
+                    if (card.Owner.LibraryCards.Count >= 2) yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 2, activateClass).Draw());
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlaceDelayOptionCards(card: card, cardEffect: activateClass));
                 }
             }
+
             #endregion
 
             #region delay
@@ -114,7 +109,6 @@ namespace DCGO.CardEffects.ST20
 
                         bool CanPlayAdventureCondition(CardSource cardSource)
                         {
-                            
                             if (CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass))
                             {
                                 return cardSource.IsDigimon &&
@@ -172,13 +166,16 @@ namespace DCGO.CardEffects.ST20
                     }
                 }
             }
+
             #endregion
 
             #region Security
+
             if (timing == EffectTiming.SecuritySkill)
             {
                 cardEffects.Add(CardEffectFactory.PlaceSelfDelayOptionSecurityEffect(card));
             }
+
             #endregion
 
             return cardEffects;

--- a/Assets/CardEffect/ST21/Blue/ST21_03.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_03.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 //ST21 Ikkakumon
 namespace DCGO.CardEffects.ST21
@@ -35,94 +36,74 @@ namespace DCGO.CardEffects.ST21
             #region On Play/When Digivolving shared
 
             bool CanActivateConditonShared(Hashtable hashtable)
-            {
-                return CardEffectCommons.HasMatchConditionPermanent(CanTargetStrip);
-            }
+                => CardEffectCommons.IsExistOnBattleAreaDigimon(card);
 
-            bool CanTargetStrip(Permanent permanent)
-            {
-                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
-            }
+            bool CanSelectPermanentCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
 
             bool OpponentsDigimonWithoutSources(Permanent permanent)
-            {
-                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) &&
-                       permanent.DigivolutionCards.Count == 0;
-            }
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                && permanent.HasNoDigivolutionCards;
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
-                Permanent selectedPermanent = null;
-                if (CardEffectCommons.HasMatchConditionPermanent(CanTargetStrip))
-                {
-                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanTargetStrip,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        selectedPermanent = permanent;
-
-                        yield return null;
-                    }
-
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    if (selectedPermanent != null)
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(selectedPermanent, 2, true, activateClass));
-                    }
-                }
-
-                selectedPermanent = null;
-                SelectPermanentEffect selectPermanentEffect2 = GManager.instance.GetComponent<SelectPermanentEffect>();
-                selectPermanentEffect2.SetUp(
+                selectPermanentEffect.SetUp(
                     selectPlayer: card.Owner,
-                    canTargetCondition: OpponentsDigimonWithoutSources,
+                    canTargetCondition: CanSelectPermanentCondition,
                     canTargetCondition_ByPreSelecetedList: null,
                     canEndSelectCondition: null,
                     maxCount: 1,
                     canNoSelect: false,
                     canEndNotMax: false,
-                    selectPermanentCoroutine: SelectPermanentCoroutine2,
+                    selectPermanentCoroutine: SelectPermanentCoroutine,
                     afterSelectPermanentCoroutine: null,
                     mode: SelectPermanentEffect.Mode.Custom,
                     cardEffect: activateClass);
 
-                IEnumerator SelectPermanentCoroutine2(Permanent permanent)
-                {
-                    selectedPermanent = permanent;
+                selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will trash digivolution cards.", "The opponent is selecting 1 Digimon that will trash digivolution cards.");
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
 
-                    yield return null;
+                IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: permanent, trashCount: 2, isFromTop: true, activateClass: activateClass));
                 }
-                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect2.Activate());
 
-                if (selectedPermanent != null)
+                if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, OpponentsDigimonWithoutSources))
                 {
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotAttack(
-                            targetPermanent: selectedPermanent,
-                            defenderCondition: null,
+                    SelectPermanentEffect selectPermanentEffect2 = GManager.instance.GetComponent<SelectPermanentEffect>();
+                    selectPermanentEffect2.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: OpponentsDigimonWithoutSources,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine2,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect2.SetUpCustomMessage("Select 1 Digimon that cant attack or block.", "The opponent is selecting 1 Digimon that cant attack or block");
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect2.Activate());
+                    IEnumerator SelectPermanentCoroutine2(Permanent permanent)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotAttack(
+                                targetPermanent: permanent,
+                                defenderCondition: null,
+                                effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                                activateClass: activateClass,
+                                effectName: "Can't Attack"));
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotBlock(
+                            targetPermanent: permanent,
+                            attackerCondition: null,
                             effectDuration: EffectDuration.UntilOpponentTurnEnd,
                             activateClass: activateClass,
-                            effectName: "Can't Attack"));
-
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotBlock(
-                        targetPermanent: selectedPermanent,
-                        attackerCondition: null,
-                        effectDuration: EffectDuration.UntilOpponentTurnEnd,
-                        activateClass: activateClass,
-                        effectName: "Can't Block"));
+                            effectName: "Can't Block"));
+                    }
                 }
             }
 

--- a/Assets/CardEffect/ST21/Blue/ST21_03.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_03.cs
@@ -116,16 +116,14 @@ namespace DCGO.CardEffects.ST21
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Strip top 2, then freeze", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateConditonShared, (hashtable) => SharedActivateCoroutine(hashtable, activateClass), -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
 
                 string EffectDescription()
-                {
-                    return "[On Play] Trash the top 2 digivolution cards of 1 of your opponent's Digimon. Then, 1 of their Digimon with no digivolution cards can't attack or block until their turn ends.";
-                }
+                    => "[On Play] Trash the top 2 digivolution cards of 1 of your opponent's Digimon. Then, 1 of their Digimon with no digivolution cards can't attack or block until their turn ends.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
+                => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
             }
 
             #endregion
@@ -137,16 +135,14 @@ namespace DCGO.CardEffects.ST21
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Strip top 2, then freeze", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateConditonShared, (hashtable) => SharedActivateCoroutine(hashtable, activateClass), -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
 
                 string EffectDescription()
-                {
-                    return "[When Digivolving] Trash the top 2 digivolution cards of 1 of your opponent's Digimon. Then, 1 of their Digimon with no digivolution cards can't attack or block until their turn ends.";
-                }
+                    => "[When Digivolving] Trash the top 2 digivolution cards of 1 of your opponent's Digimon. Then, 1 of their Digimon with no digivolution cards can't attack or block until their turn ends.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-                }
+                => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
             }
 
             #endregion

--- a/Assets/CardEffect/ST21/Blue/ST21_03.cs
+++ b/Assets/CardEffect/ST21/Blue/ST21_03.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 //ST21 Ikkakumon
 namespace DCGO.CardEffects.ST21
@@ -38,44 +37,48 @@ namespace DCGO.CardEffects.ST21
             bool CanActivateConditonShared(Hashtable hashtable)
                 => CardEffectCommons.IsExistOnBattleAreaDigimon(card);
 
-            bool CanSelectPermanentCondition(Permanent permanent)
-                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
-
-            bool OpponentsDigimonWithoutSources(Permanent permanent)
-                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
-                && permanent.HasNoDigivolutionCards;
-
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
-                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                bool CanSelectPermanentCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                && permanent.DigivolutionCards.Count >= 2;
 
-                selectPermanentEffect.SetUp(
-                    selectPlayer: card.Owner,
-                    canTargetCondition: CanSelectPermanentCondition,
-                    canTargetCondition_ByPreSelecetedList: null,
-                    canEndSelectCondition: null,
-                    maxCount: 1,
-                    canNoSelect: false,
-                    canEndNotMax: false,
-                    selectPermanentCoroutine: SelectPermanentCoroutine,
-                    afterSelectPermanentCoroutine: null,
-                    mode: SelectPermanentEffect.Mode.Custom,
-                    cardEffect: activateClass);
+                bool CanSelectPermanentCondition2(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                    && permanent.HasNoDigivolutionCards;
 
-                selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will trash digivolution cards.", "The opponent is selecting 1 Digimon that will trash digivolution cards.");
-                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CanSelectPermanentCondition(permanent)))
                 {
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: permanent, trashCount: 2, isFromTop: true, activateClass: activateClass));
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: (permanent) => CanSelectPermanentCondition(permanent),
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will trash digivolution cards.", "The opponent is selecting 1 Digimon that will trash digivolution cards.");
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: permanent, trashCount: 2, isFromTop: true, activateClass: activateClass));
+                    }
                 }
 
-                if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, OpponentsDigimonWithoutSources))
+                if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CanSelectPermanentCondition2(permanent)))
                 {
-                    SelectPermanentEffect selectPermanentEffect2 = GManager.instance.GetComponent<SelectPermanentEffect>();
-                    selectPermanentEffect2.SetUp(
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                    selectPermanentEffect.SetUp(
                         selectPlayer: card.Owner,
-                        canTargetCondition: OpponentsDigimonWithoutSources,
+                        canTargetCondition: (permanent) => CanSelectPermanentCondition2(permanent),
                         canTargetCondition_ByPreSelecetedList: null,
                         canEndSelectCondition: null,
                         maxCount: 1,
@@ -86,8 +89,8 @@ namespace DCGO.CardEffects.ST21
                         mode: SelectPermanentEffect.Mode.Custom,
                         cardEffect: activateClass);
 
-                    selectPermanentEffect2.SetUpCustomMessage("Select 1 Digimon that cant attack or block.", "The opponent is selecting 1 Digimon that cant attack or block");
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect2.Activate());
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that cant attack or block.", "The opponent is selecting 1 Digimon that cant attack or block");
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
                     IEnumerator SelectPermanentCoroutine2(Permanent permanent)
                     {
                         yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotAttack(


### PR DESCRIPTION
### Cards

BT1-083 GranKuwagamon - Corrected Effect Class name for both arts.
ST20-14 Our Courage United - Fixed Delay issue, Now allows breeding targets for ignore colour requirement
ST21-03 Ikkakumon - Fixed OP/WD not activating & selectable target logic