### PR TITLE
Adding once-per-turn check to CanTrigger (BT22-052 & EX9-056)

### DIFF
--- a/Assets/Scripts/ICardEffect.cs
+++ b/Assets/Scripts/ICardEffect.cs
@@ -288,6 +288,15 @@ public abstract class ICardEffect
 
         #endregion
 
+        #region Effect availability determined by the maximum number of times it can be used in a turn
+
+        if (EffectSourceCard.cEntity_EffectController.isOverMaxCountPerTurn(this, MaxCountPerTurn))
+        {
+            return false;
+        }
+
+        #endregion
+
         #region Determination of availability for each effect
 
         if (CanUseCondition == null || !CanUseCondition(hashtable))


### PR DESCRIPTION
Adding the same OPT check that CanActivate has to CanTrigger.

Context: The autoProcessor_CutIn processor doesn't update as much as the regular autoProcessor, which regularly cleans its queue of stacked skills. In any scenario where autoProcessor_CutIn .StackSkillInfos adds triggered effects to its list of stacked effects, but those effects can't activate right away (like if the effect is OPT and has already been used), the triggered effect stays in the list and gets stale, until it is cleaned out at the next action.  If that next action happens on the opponent's turn, the OPT check is cleared and the effect can activate.  Adding the check in CanTrigger stops that effect from ever getting added if it's already been used the max number of times that turn.