### PR TITLE
Separate Attack Process into steps

### DIFF
--- a/Assets/Scripts/Script/AttackProcess.cs
+++ b/Assets/Scripts/Script/AttackProcess.cs
@@ -19,6 +19,44 @@ public class AttackProcess : MonoBehaviourPunCallbacks
     public bool IsEndAttack { get; set; } = false;
 
     public bool UsedBlitz { get; set; } = false;
+    public Hashtable EffectHashtable { get; set; } = null;
+
+    public Hashtable CounterEffectHashtable { get; set; } = null;
+    public AttackState State { get; set; } = AttackState.None;
+    public enum AttackState
+    {
+        None,
+        Counter,
+        Block,
+        Battle,
+        End
+    }
+
+    public bool ActiveAttack()
+    {
+        return State != null && State != AttackState.None;
+    }
+
+    public IEnumerator ProcessNextState()
+    {
+        switch (State)
+        {
+            case AttackState.Counter:
+                yield return ContinuousController.instance.StartCoroutine(CounterTiming());
+                break;
+            case AttackState.Block:
+                yield return ContinuousController.instance.StartCoroutine(BlockTiming());
+                break;
+            case AttackState.Battle:
+                yield return ContinuousController.instance.StartCoroutine(DetermineAttackOutcome());
+                break;
+            case AttackState.End:
+                yield return ContinuousController.instance.StartCoroutine(EndAttack());
+                break;
+            default:
+                yield break;
+        }
+    }
 
     void SetAttackerDefender(Permanent attackingPermanent, Permanent defendingPermanent)
     {
@@ -50,11 +88,12 @@ public class AttackProcess : MonoBehaviourPunCallbacks
         IsAttacking = false;
         HasDefender = false;
         IsEndAttack = false;
+        CounterEffectHashtable = null;
 
         SetAttackerDefender(attackingPermanent, defendingPermanent);
 
-        Hashtable effectHashtable = CardEffectCommons.OnAttackCheckHashtableOfPermanent(AttackingPermanent, attackEffect);
-        Hashtable counterEffectHashtable = CardEffectCommons.OnAttackCheckHashtableOfPermanent(new Permanent(AttackingPermanent.cardSources), attackEffect);
+        EffectHashtable = CardEffectCommons.OnAttackCheckHashtableOfPermanent(AttackingPermanent, attackEffect);
+        CounterEffectHashtable = CardEffectCommons.OnAttackCheckHashtableOfPermanent(new Permanent(AttackingPermanent.cardSources), attackEffect);
 
         IsAttacking = true;
 
@@ -66,7 +105,9 @@ public class AttackProcess : MonoBehaviourPunCallbacks
         // force to end attack
         if (IsEndAttack)
         {
-            goto EndAttack;
+            State = AttackState.End;
+
+            yield break;
         }
 
         #region Attack Process
@@ -103,17 +144,17 @@ public class AttackProcess : MonoBehaviourPunCallbacks
             if (DefendingPermanent != null)
             {
                 if (CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(DefendingPermanent))
-                    log += $"\nÅ´\n{DefendingPermanent.TopCard.BaseENGCardNameFromEntity}({DefendingPermanent.TopCard.CardID})\n";
+                    log += $"\n¬Å¬´\n{DefendingPermanent.TopCard.BaseENGCardNameFromEntity}({DefendingPermanent.TopCard.CardID})\n";
             }
 
             else
             {
-                log += $"\nÅ´\nSecurity\n";
+                log += $"\n¬Å¬´\nSecurity\n";
             }
 
             PlayLog.OnAddLog?.Invoke(log);
 
-            List<SkillInfo> stackedSkillInfos = new List<SkillInfo>();
+            /*List<SkillInfo> stackedSkillInfos = new List<SkillInfo>();
 
             if (GManager.instance.autoProcessing.executingMultipleSkills != null)
             {
@@ -129,7 +170,7 @@ public class AttackProcess : MonoBehaviourPunCallbacks
                 {
                     GManager.instance.autoProcessing.executingMultipleSkills.StackedSkillInfos.Remove(skillInfo);
                 }
-            }
+            }*/
 
             // suspend
             if (!withoutTap)
@@ -165,8 +206,8 @@ public class AttackProcess : MonoBehaviourPunCallbacks
             }
 
             // activate cutin effects
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.RuleProcess());
-            //yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.TriggeredSkillProcess(true, null));
+            // yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.RuleProcess());
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.TriggeredSkillProcess(true, null));
 
             // callback that is processed before [On Attack]
             if (beforeOnAttackCoroutine != null)
@@ -176,20 +217,20 @@ public class AttackProcess : MonoBehaviourPunCallbacks
 
             // trigger [On Attack] effect
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.StackSkillInfos(
-                effectHashtable,
+                EffectHashtable,
                 EffectTiming.OnAllyAttack));
 
             // activate cutin effects
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.RuleProcess());
+            // yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.RuleProcess());
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.TriggeredSkillProcess(true, null));
 
-            if (stackedSkillInfos.Count >= 1)
+            /*if (stackedSkillInfos.Count >= 1)
             {
                 foreach (SkillInfo skillInfo in stackedSkillInfos)
                 {
                     GManager.instance.autoProcessing.PutStackedSkill(skillInfo);
                 }
-            }
+            }*/
 
             GManager.instance.turnStateMachine.IsSelecting = true;
 
@@ -209,14 +250,16 @@ public class AttackProcess : MonoBehaviourPunCallbacks
             }
 
             // check timing
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+            // yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
 
             GManager.instance.turnStateMachine.IsSelecting = true;
 
             // force to end attack
             if (IsEndAttack)
             {
-                goto EndAttack;
+                State = AttackState.End;
+
+                yield break;
             }
 
             if (AttackingPermanent.TopCard != null)
@@ -233,235 +276,267 @@ public class AttackProcess : MonoBehaviourPunCallbacks
                     DefendingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
                 }
             }
-
-            // trigger effects when counter timing (except [Counter] effects)
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.StackSkillInfos(
-                counterEffectHashtable,
-                EffectTiming.OnCounterTiming,
-                cardEffect => !cardEffect.IsCounterEffect));
-
-            // activate cutin effects
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.RuleProcess());
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.TriggeredSkillProcess(true, null));
-
-            GManager.instance.turnStateMachine.IsSelecting = true;
-
-            // force to end attack
-            if (IsEndAttack)
-            {
-                goto EndAttack;
-            }
-
-            // trigger effects when counter timing ([Counter] effects)
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.StackSkillInfos(
-                counterEffectHashtable,
-                EffectTiming.OnCounterTiming,
-                cardEffect => cardEffect.IsCounterEffect));
-
-            bool HasCounterEffect(List<SkillInfo> skillInfos, SkillInfo skillInfo)
-            {
-                return skillInfos.Count((skillInfo1) => skillInfo1.CardEffect.IsCounterEffect) >= 1;
-            }
-
-            // activate cutin effects
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.RuleProcess());
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.TriggeredSkillProcess(true, HasCounterEffect));
-
-            GManager.instance.turnStateMachine.IsSelecting = true;
-
-            // force to end attack
-            if (IsEndAttack)
-            {
-                goto EndAttack;
-            }
-
-            if (AttackingPermanent.TopCard == null || !AttackingPermanent.IsDigimon)
-            {
-                goto EndAttack;
-            }
-
-            AttackingPermanent.ShowingPermanentCard.SetOrangeOutline();
-            AttackingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
-
-            if (DefendingPermanent != null)
-            {
-                if (CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(DefendingPermanent))
-                {
-                    DefendingPermanent.ShowingPermanentCard.SetOrangeOutline();
-                    DefendingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
-                }
-            }
-
-            #region select blocker
-            bool CanSelectBlockerCondition(Permanent permanent)
-            {
-                if (CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, AttackingPermanent.TopCard))
-                {
-                    if (permanent != DefendingPermanent)
-                    {
-                        if (permanent.HasBlocker && permanent.CanBlock(AttackingPermanent))
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
-            }
-
-            if (AttackingPermanent.TopCard.Owner.Enemy.GetBattleAreaDigimons().Count(CanSelectBlockerCondition) >= 1)
-            {
-                int maxCount = 1;
-
-                Permanent selectedPermanent = null;
-
-                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                selectPermanentEffect.SetUp(
-                    selectPlayer: AttackingPermanent.TopCard.Owner.Enemy,
-                    canTargetCondition: CanSelectBlockerCondition,
-                    canTargetCondition_ByPreSelecetedList: null,
-                    canEndSelectCondition: null,
-                    maxCount: maxCount,
-                    canNoSelect: (!IsBlocking),
-                    canEndNotMax: false,
-                    selectPermanentCoroutine: SelectPermanentCoroutine,
-                    afterSelectPermanentCoroutine: null,
-                    mode: SelectPermanentEffect.Mode.Custom,
-                    cardEffect: null);
-
-                selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will block.", "The opponent is selecting 1 Digimon that will block.");
-                
-                if(!IsBlocking)
-                    selectPermanentEffect.SetUpCustomBackButtonMessage("Not Block");
-
-                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                {
-                    selectedPermanent = permanent;
-
-                    yield return null;
-                }
-
-                if (selectedPermanent != null)
-                {
-                    yield return ContinuousController.instance.StartCoroutine(SwitchDefender(null, true, selectedPermanent));
-                }
-            }
-            #endregion
-
-            GManager.instance.turnStateMachine.IsSelecting = true;
-
-            //end attack
-            if (IsEndAttack)
-            {
-                goto EndAttack;
-            }
-
-            if (AttackingPermanent.TopCard == null)
-            {
-                goto EndAttack;
-            }
-
-            AttackingPermanent.ShowingPermanentCard.SetOrangeOutline();
-            AttackingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
-
-            if (DefendingPermanent != null)
-            {
-                if (CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(DefendingPermanent))
-                {
-                    DefendingPermanent.ShowingPermanentCard.SetOrangeOutline();
-                    DefendingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
-                }
-            }
-
-            #region there is no Defending Permanent
-            if (DefendingPermanent == null)
-            {
-                if (AttackingPermanent.Strike >= 1)
-                {
-                    //if there is no security, end the game
-                    if (AttackingPermanent.TopCard.Owner.Enemy.SecurityCards.Count == 0)
-                    {
-                        GManager.instance.turnStateMachine.EndGame(AttackingPermanent.TopCard.Owner, false);
-                        yield break;
-                    }
-                }
-
-                DoSecurityCheck = true;
-            }
-            #endregion
-
-            #region there is Defending Permanent
-            else
-            {
-                if (!CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(DefendingPermanent) || !CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(AttackingPermanent))
-                {
-                    goto EndAttack;
-                }
-
-                DefendingPermanent.TopCard.Owner.securityObject.securityBreakGlass.gameObject.SetActive(false);
-
-                DefendingPermanent.ShowingPermanentCard.SetOrangeOutline();
-                DefendingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
-
-                // battle
-                IBattle battle = new IBattle(AttackingPermanent: AttackingPermanent, DefendingPermanent: DefendingPermanent, null);
-                yield return ContinuousController.instance.StartCoroutine(battle.Battle());
-
-                /*#region effect when determine whether to do security check
-                Hashtable hashtable = new Hashtable()
-                {
-                    {"battle", battle}
-                };
-
-                List<SkillInfo> skillInfos_Pierce = AutoProcessing.GetSkillInfos(hashtable, EffectTiming.OnDetermineDoSecurityCheck)
-                    .Filter(skillInfo => skillInfo.CardEffect != null && skillInfo.CardEffect.CanActivate(skillInfo.Hashtable));
-
-                if (skillInfos_Pierce.Count >= 1)
-                {
-                    GManager.instance.autoProcessing.PutStackedSkill(skillInfos_Pierce[0]);
-                }
-                #endregion*/
-                
-                yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.TriggeredSkillProcess(true, null));
-                GManager.instance.turnStateMachine.IsSelecting = true;
-            }
-            #endregion
-
-            if (AttackingPermanent.TopCard == null)
-            {
-                goto EndAttack;
-            }
-
-            #region do security check
-            if (DoSecurityCheck && AttackingPermanent.TopCard.Owner.Enemy.SecurityCards.Count >= 1)
-            {
-                //security check process
-                yield return ContinuousController.instance.StartCoroutine(new ISecurityCheck(
-                    AttackingPermanent: AttackingPermanent,
-                    player: GManager.instance.turnStateMachine.gameContext.NonTurnPlayer).SecurityCheck());
-            }
-            #endregion
-        }
-
+            State = AttackState.Counter;
+        }    
         else
         {
             if (beforeOnAttackCoroutine != null)
             {
                 yield return ContinuousController.instance.StartCoroutine(beforeOnAttackCoroutine());
             }
+            State = AttackState.End;
         }
-    #endregion
+        #endregion
+    }
+
+    IEnumerator CounterTiming()
+    {
+        // force to end attack
+        if (IsEndAttack)
+        {
+            State = AttackState.End;
+
+            yield break;
+        }
+        
+        // trigger effects when counter timing (except [Counter] effects)
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.StackSkillInfos(
+            CounterEffectHashtable,
+            EffectTiming.OnCounterTiming,
+            cardEffect => !cardEffect.IsCounterEffect));
+
+        // activate cutin effects
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.TriggeredSkillProcess(true, null));
+
+        GManager.instance.turnStateMachine.IsSelecting = true;
+
+        // force to end attack
+        if (IsEndAttack)
+        {
+            State = AttackState.End;
+
+            yield break;
+        }
+
+        // trigger effects when counter timing ([Counter] effects)
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.StackSkillInfos(
+            CounterEffectHashtable,
+            EffectTiming.OnCounterTiming,
+            cardEffect => cardEffect.IsCounterEffect));
+
+        bool HasCounterEffect(List<SkillInfo> skillInfos, SkillInfo skillInfo)
+        {
+            return skillInfos.Count((skillInfo1) => skillInfo1.CardEffect.IsCounterEffect) >= 1;
+        }
+
+        // activate cutin effects
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing_CutIn.TriggeredSkillProcess(true, HasCounterEffect));
+
+        GManager.instance.turnStateMachine.IsSelecting = true;
+
+        // force to end attack
+        if (IsEndAttack || AttackingPermanent.TopCard == null || !AttackingPermanent.IsDigimon)
+        {
+            State = AttackState.End;
+
+            yield break;
+        }
+
+        AttackingPermanent.ShowingPermanentCard.SetOrangeOutline();
+        AttackingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
+
+        if (DefendingPermanent != null)
+        {
+            if (CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(DefendingPermanent))
+            {
+                DefendingPermanent.ShowingPermanentCard.SetOrangeOutline();
+                DefendingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
+            }
+        }
+        State = AttackState.Block;
+    }
+
+    IEnumerator BlockTiming()
+    {
+        // force to end attack
+        if (IsEndAttack || AttackingPermanent.TopCard == null || !AttackingPermanent.IsDigimon)
+        {
+            State = AttackState.End;
+
+            yield break;
+        }
+        
+        #region select blocker
+        bool CanSelectBlockerCondition(Permanent permanent)
+        {
+            return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, AttackingPermanent.TopCard)
+                && permanent != DefendingPermanent
+                && permanent.HasBlocker 
+                && permanent.CanBlock(AttackingPermanent);
+        }
+
+        if (AttackingPermanent.TopCard.Owner.Enemy.GetBattleAreaDigimons().Count(CanSelectBlockerCondition) >= 1)
+        {
+            int maxCount = 1;
+
+            Permanent selectedPermanent = null;
+
+            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+            selectPermanentEffect.SetUp(
+                selectPlayer: AttackingPermanent.TopCard.Owner.Enemy,
+                canTargetCondition: CanSelectBlockerCondition,
+                canTargetCondition_ByPreSelecetedList: null,
+                canEndSelectCondition: null,
+                maxCount: maxCount,
+                canNoSelect: (!IsBlocking),
+                canEndNotMax: false,
+                selectPermanentCoroutine: SelectPermanentCoroutine,
+                afterSelectPermanentCoroutine: null,
+                mode: SelectPermanentEffect.Mode.Custom,
+                cardEffect: null);
+
+            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will block.", "The opponent is selecting 1 Digimon that will block.");
+            
+            if(!IsBlocking)
+                selectPermanentEffect.SetUpCustomBackButtonMessage("Not Block");
+
+            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+            IEnumerator SelectPermanentCoroutine(Permanent permanent)
+            {
+                selectedPermanent = permanent;
+
+                yield return null;
+            }
+
+            if (selectedPermanent != null)
+            {
+                yield return ContinuousController.instance.StartCoroutine(SwitchDefender(null, true, selectedPermanent));
+            }
+        }
+        #endregion
+
+        GManager.instance.turnStateMachine.IsSelecting = true;
+
+        //end attack
+        if (IsEndAttack || AttackingPermanent.TopCard == null || !AttackingPermanent.IsDigimon)
+        {
+            State = AttackState.End;
+
+            yield break;
+        }
+
+        AttackingPermanent.ShowingPermanentCard.SetOrangeOutline();
+        AttackingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
+
+        if (DefendingPermanent != null)
+        {
+            if (CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(DefendingPermanent))
+            {
+                DefendingPermanent.ShowingPermanentCard.SetOrangeOutline();
+                DefendingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
+            }
+        }
+        State = AttackState.Battle;
+    }
+
+    IEnumerator DetermineAttackOutcome()
+    {
+        //end attack
+        if (IsEndAttack || AttackingPermanent.TopCard == null || !AttackingPermanent.IsDigimon)
+        {
+            State = AttackState.End;
+
+            yield break;
+        }
+
+        #region there is no Defending Permanent
+        if (DefendingPermanent == null)
+        {
+            if (AttackingPermanent.Strike >= 1)
+            {
+                //if there is no security, end the game
+                if (AttackingPermanent.TopCard.Owner.Enemy.SecurityCards.Count == 0)
+                {
+                    GManager.instance.turnStateMachine.EndGame(AttackingPermanent.TopCard.Owner, false);
+                    yield break;
+                }
+            }
+
+            DoSecurityCheck = true;
+        }
+        #endregion
+
+        #region there is Defending Permanent
+        else
+        {
+            if (!CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(DefendingPermanent) || !CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(AttackingPermanent))
+            {
+                State = AttackState.End;
+
+                yield break;
+            }
+
+            DefendingPermanent.TopCard.Owner.securityObject.securityBreakGlass.gameObject.SetActive(false);
+
+            DefendingPermanent.ShowingPermanentCard.SetOrangeOutline();
+            DefendingPermanent.ShowingPermanentCard.Outline_Select.gameObject.SetActive(true);
+
+            // battle
+            IBattle battle = new IBattle(AttackingPermanent: AttackingPermanent, DefendingPermanent: DefendingPermanent, null);
+            yield return ContinuousController.instance.StartCoroutine(battle.Battle());
+
+            //TODO: Reimplement the below to ensure full correctness of battle by effect. 
+            //Will need bool AttackProcess.WasDigimonDestroyedInBattle and change to piercing to check it
+            /*#region effect when determine whether to do security check
+            Hashtable hashtable = new Hashtable()
+            {
+                {"battle", battle}
+            };
+
+            List<SkillInfo> skillInfos_Pierce = AutoProcessing.GetSkillInfos(hashtable, EffectTiming.OnDetermineDoSecurityCheck)
+                .Filter(skillInfo => skillInfo.CardEffect != null && skillInfo.CardEffect.CanActivate(skillInfo.Hashtable));
+
+            if (skillInfos_Pierce.Count >= 1)
+            {
+                GManager.instance.autoProcessing.PutStackedSkill(skillInfos_Pierce[0]);
+            }
+            #endregion*/
+            
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.TriggeredSkillProcess(true, null));
+            GManager.instance.turnStateMachine.IsSelecting = true;
+        }
+        #endregion
+
+        if (AttackingPermanent.TopCard == null)
+        {
+            State = AttackState.End;
+
+            yield break;
+        }
+
+        #region do security check
+        if (DoSecurityCheck && AttackingPermanent.TopCard.Owner.Enemy.SecurityCards.Count >= 1)
+        {
+            //security check process
+            yield return ContinuousController.instance.StartCoroutine(new ISecurityCheck(
+                AttackingPermanent: AttackingPermanent,
+                player: GManager.instance.turnStateMachine.gameContext.NonTurnPlayer).SecurityCheck());
+        }
+        #endregion
+        State = AttackState.End;
+    }
+
+
 
     #region End Attack
-    EndAttack:;
-
+    IEnumerator EndAttack()
+    {
         // [On End Attack] effect
         if (AttackingPermanent != null && AttackingPermanent.TopCard != null)
         {
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(effectHashtable, EffectTiming.OnEndAttack));
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(EffectHashtable, EffectTiming.OnEndAttack));
         }
         
         // activate cutin effects
@@ -485,6 +560,8 @@ public class AttackProcess : MonoBehaviourPunCallbacks
         SecurityDigimon = null;
         IsAttacking = false;
         IsEndAttack = false;
+        CounterEffectHashtable = null;
+        State = AttackState.None;
     }
 
     public IEnumerator SwitchDefender(ICardEffect cardEffect, bool isBlock, Permanent newDefendingPermanent)

--- a/Assets/Scripts/Script/TurnStateMachine.cs
+++ b/Assets/Scripts/Script/TurnStateMachine.cs
@@ -572,6 +572,15 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
 
         // 自動処理チェックタイミング
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+        
+        //Handle attacks by effect caused in this phase
+        while (GManager.instance.attackProcess.ActiveAttack())
+        {
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.ProcessNextState());
+
+            //自動処理チェックタイミング
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+        }
 
         //ターン終了チェック
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.EndTurnCheck());
@@ -628,6 +637,18 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
         //自動処理チェックタイミング
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
 
+        //Handle attacks by effect caused in this phase
+        while (GManager.instance.attackProcess.ActiveAttack())
+        {
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.ProcessNextState());
+
+            //自動処理チェックタイミング
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+        }
+
+        //ターン終了チェック
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.EndTurnCheck());
+
         #region アクティブフェイズ終了時までの効果をリセット
         gameContext.TurnPlayer.UntilOwnerActivePhaseEffects = new List<Func<EffectTiming, ICardEffect>>();
         #endregion
@@ -674,6 +695,15 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
 
         //自動処理チェックタイミング
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+        
+        //Handle attacks by effect caused in this phase
+        while (GManager.instance.attackProcess.ActiveAttack())
+        {
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.ProcessNextState());
+
+            //自動処理チェックタイミング
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+        }
         //ターン終了チェック
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.EndTurnCheck());
     }
@@ -800,6 +830,15 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
         //自動処理チェックタイミング
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
 
+        //Handle attacks by effect caused in this phase
+        while (GManager.instance.attackProcess.ActiveAttack())
+        {
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.ProcessNextState());
+
+            //自動処理チェックタイミング
+            yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+        }
+
         //ターン終了チェック
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.EndTurnCheck());
 
@@ -911,6 +950,15 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
 
             //自動処理チェックタイミング
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+            //Handle attack steps
+            while (GManager.instance.attackProcess.ActiveAttack())
+            {
+                Debug.Log($"Active Attack, {Enum.GetName(typeof(AttackProcess.AttackState),GManager.instance.attackProcess.State)} Step");
+                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.ProcessNextState());
+
+                //自動処理チェックタイミング
+                yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+            }
             //ターン終了チェック
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.EndTurnCheck());
 


### PR DESCRIPTION
Separated attacks in to steps, TurnStateMachine handles progressing through them and calling autoprocessing.AutoProcessCheck (includes rules process) in between.

Removed calls to RulesProcessing and AutoProcessCheck from the attack declaration process, by handling all effects triggered as part of the attack declaration in the autoprocessing outside of it, this should ensure correct sequencing of effects considered to be simultaneous, such as when an effect does something else that can cause triggers as well as declaring an attack (BT23-047 Examon as example, triggers on the 5 opponent's Digimon suspending should be simultaneous to when attackings and ordered as turn player chooses)

Left in autoProcessing_CutIn.TriggeredSkillProcess for immediate effects.