### PR TITLE
Implement ST24-07 and proposal for how dual cards can handle

### DIFF
--- a/Assets/Scripts/CardEffect/ST24/Yellow/ST24_07.cs
+++ b/Assets/Scripts/CardEffect/ST24/Yellow/ST24_07.cs
@@ -1,0 +1,384 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Shinegreymon // GeoGrey Sword
+namespace DCGO.CardEffects.ST24
+{
+    public class ST24_07 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Digimon Effects
+
+            #region Can't play this card
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.DualCardCantPlay(card));
+            }
+            #endregion
+
+            #region Alt Digivolution
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return permanent.TopCard.IsLevel5 
+                        && (permanent.TopCard.EqualsTraits("DATA SQUAD")
+                            || permanent.TopCard.ContainsCardName("RizeGreymon"));
+
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 3, true, card, null));
+            }
+            #endregion
+
+            #region Raid
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                cardEffects.Add(CardEffectFactory.RaidSelfEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Piercing
+            if (timing == EffectTiming.OnDetermineDoSecurityCheck)
+            {
+                cardEffects.Add(CardEffectFactory.PierceSelfEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Security Attack +1
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.ChangeSelfSAttackStaticEffect(changeValue: 1, isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared WD / WA
+
+            string SharedHashString = "ST24_07_WD_WA";
+
+            string SharedEffectName = "You may play a tamer up to 5 cost from hand or trash. -9k to an enemy Digimon.";
+
+            string SharedEffectDescription(string tag) => $"[{tag}] [Once Per Turn] You may play 1 Tamer card with a play cost of 5 or less from your hand or trash without paying the cost. Then, 1 of your opponent's Digimon gets -9000 DP for the turn.";
+
+            bool SharedCanActivateCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+
+            bool PlayableTamerCard(CardSource cardSource, ActivateClass activateClass)
+            {
+                return cardSource.IsTamer
+                    && cardSource.HasPlayCost
+                    && cardSource.GetCostItself <= 5
+                    && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
+            }
+
+            bool EnemyDigimonCondition(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                #region Play Tamer
+                bool PlayTamer = false;
+                bool playFromHand = false;
+                bool playFromTrash = false;
+
+                bool canSelectHand = CardEffectCommons.HasMatchConditionOwnersHand(card, cardSource => PlayableTamerCard(cardSource, activateClass));
+                bool canSelectTrash = CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, cardSource => PlayableTamerCard(cardSource, activateClass));
+
+                if (canSelectHand || canSelectTrash)
+                {
+                    #region User Selection - Play Token or Select Card Location
+
+                    var playOptions = new List<SelectionElement<bool>>()
+                    {
+                        new SelectionElement<bool>(message: $"Play a Tamer", value: true, spriteIndex: 0),
+                        new SelectionElement<bool>(message: $"Don't Play", value: false, spriteIndex: 1)
+                    };
+
+                    string selectPlayerMessage = "Will you play a tamer?";
+                    string notSelectPlayerMessage = "The opponent is choosing if they will play a tamer.";
+
+                    GManager.instance.userSelectionManager.SetBoolSelection(selectionElements: playOptions, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage, notSelectPlayerMessage: notSelectPlayerMessage);
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+                    PlayTamer = GManager.instance.userSelectionManager.SelectedBoolValue;
+                }
+
+                if (PlayTamer)
+                {
+                    if (canSelectHand && canSelectTrash)
+                    {
+                        List<SelectionElement<bool>> selectionElements1 = new List<SelectionElement<bool>>()
+                        {
+                            new SelectionElement<bool>(message: $"From hand", value : true, spriteIndex: 0),
+                            new SelectionElement<bool>(message: $"From trash", value : false, spriteIndex: 1),
+                        };
+
+                        string selectPlayerMessage1 = "From which area do you select a card?";
+                        string notSelectPlayerMessage1 = "The opponent is choosing from which area to select a card.";
+
+                        GManager.instance.userSelectionManager.SetBoolSelection(selectionElements: selectionElements1, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage1, notSelectPlayerMessage: notSelectPlayerMessage1);
+                    }
+                    else
+                    {
+                        GManager.instance.userSelectionManager.SetBool(canSelectHand);
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+
+                    var handOrTrashSelection = GManager.instance.userSelectionManager.SelectedBoolValue;
+                    if (handOrTrashSelection) playFromHand = true;
+                    else playFromTrash = true;
+                }
+
+                #endregion
+
+                CardSource selectedCard = null;
+                IEnumerator SelectCardCoroutine(CardSource cardSource)
+                {
+                    selectedCard = cardSource;
+                    yield return null;
+                }
+
+                if (playFromHand)
+                {
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: cardSource => PlayableTamerCard(cardSource, activateClass),
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectHandEffect.SetUpCustomMessage("Select 1 tamer to play", "The opponent is selecting 1 tamer to play");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                    if (selectedCard != null) yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                        new List<CardSource>() { selectedCard },
+                        activateClass: activateClass,
+                        payCost: false,
+                        isTapped: false,
+                        root: SelectCardEffect.Root.Hand,
+                        activateETB: true));
+                }
+
+                if (playFromTrash)
+                {
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: cardSource => PlayableTamerCard(cardSource, activateClass),
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        message: "Select 1 tamer to play",
+                        maxCount: 1,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Custom,
+                        root: SelectCardEffect.Root.Trash,
+                        customRootCardList: null,
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    selectCardEffect.SetUpCustomMessage("Select 1 tamer to play", "The opponent is selecting 1 tamer to play");
+                    selectCardEffect.SetUpCustomMessage_ShowCard("Selected Tamer");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+                    if (selectedCard != null) yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                        new List<CardSource>() { selectedCard },
+                        activateClass: activateClass,
+                        payCost: false,
+                        isTapped: false,
+                        root: SelectCardEffect.Root.Trash,
+                        activateETB: true));
+                }
+                #endregion
+
+                if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, EnemyDigimonCondition))
+                {
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: EnemyDigimonCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -9000.", "The opponent is selecting 1 Digimon that will get DP -9000.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -9000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                    }
+                }
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
+                activateClass.SetUpActivateClass(SharedCanActivateCondition, hash => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
+                activateClass.SetHashString(SharedHashString);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card) &&
+                           CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                }
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
+                activateClass.SetUpActivateClass(SharedCanActivateCondition, hash => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
+                activateClass.SetHashString(SharedHashString);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card) &&
+                           CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                }
+            }
+            #endregion
+
+            #endregion 
+
+            #region Option Effects
+
+            #region Ignore Colour Requirement
+            if (timing == EffectTiming.None)
+            {
+                IgnoreColorConditionClass ignoreColorConditionClass = new IgnoreColorConditionClass();
+                ignoreColorConditionClass.SetUpICardEffect("Ignore color requirements", CanUseCondition, card);
+                ignoreColorConditionClass.SetUpIgnoreColorConditionClass(cardCondition: CardCondition);
+                cardEffects.Add(ignoreColorConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.HasMatchConditionOwnersPermanent(card, PermanentCondition);
+                }
+
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return (permanent.IsDigimon || permanent.IsTamer)
+                        && permanent.TopCard.EqualsTraits("DATA SQUAD");
+                }
+
+                bool CardCondition(CardSource cardSource)
+                {
+                    return cardSource == card;
+                }
+
+            }
+            #endregion
+
+            #region Main
+            if (timing == EffectTiming.OptionSkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("1 Enemy Digimon gets -6k  DP, Delete 1 Enemy Digimon with 7k or less DP.", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDiscription());
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                    => "[Main] 1 of your opponent's Digimon gets -6000 DP for the turn. Then, delete 1 of your opponent's Digimon with 7000 DP or less.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+
+                bool CanSelectDPMinusPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+                bool CanSelectDeletePermamentCondition(Permanent permanent)
+                {
+                    return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                        && permanent.DP <= 7000;
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectDPMinusPermanentCondition))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectDPMinusPermanentCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -6000.", "The opponent is selecting 1 Digimon that will get DP -6000.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -6000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                        }
+                    }
+
+                    if(CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectDeletePermamentCondition))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectDeletePermamentCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+                }
+            }
+            #endregion
+
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/ST24/Yellow/ST24_07.cs
+++ b/Assets/Scripts/CardEffect/ST24/Yellow/ST24_07.cs
@@ -277,27 +277,12 @@ namespace DCGO.CardEffects.ST24
             #region Ignore Colour Requirement
             if (timing == EffectTiming.None)
             {
-                IgnoreColorConditionClass ignoreColorConditionClass = new IgnoreColorConditionClass();
-                ignoreColorConditionClass.SetUpICardEffect("Ignore color requirements", CanUseCondition, card);
-                ignoreColorConditionClass.SetUpIgnoreColorConditionClass(cardCondition: CardCondition);
-                cardEffects.Add(ignoreColorConditionClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.HasMatchConditionOwnersPermanent(card, PermanentCondition);
-                }
+                cardEffects.Add(CardEffectFactory.UseRequirements(card, PermanentCondition));
 
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return (permanent.IsDigimon || permanent.IsTamer)
-                        && permanent.TopCard.EqualsTraits("DATA SQUAD");
+                    return permanent.TopCard.EqualsTraits("DATA SQUAD");
                 }
-
-                bool CardCondition(CardSource cardSource)
-                {
-                    return cardSource == card;
-                }
-
             }
             #endregion
 

--- a/Assets/Scripts/Script/CEntity_Base.cs
+++ b/Assets/Scripts/Script/CEntity_Base.cs
@@ -42,6 +42,7 @@ public class CEntity_Base : ScriptableObject
     public int MaxCountInDeck = 4;
     public bool HasLoadStarted { get; set; } = false;
     public Sprite CardSprite { get; set; } = null;
+    public List<CardColor> DualCardColors = new List<CardColor>();
     public async Task LoadCardImage()
     {
         if (String.IsNullOrEmpty(CardSpriteName))
@@ -232,7 +233,7 @@ public class CEntity_Base : ScriptableObject
     #endregion
 
     #region whether it is permanent card
-    public bool IsPermanent => cardKind == CardKind.Digimon || cardKind == CardKind.Tamer || cardKind == CardKind.DigiEgg;
+    public bool IsPermanent => cardKind == CardKind.Digimon || cardKind == CardKind.Tamer || cardKind == CardKind.DigiEgg || cardKind == CardKind.DualCard;
     #endregion
 
     #region �J�[�hIndex���f�b�L�R�[�h�ɗp���镶����ɕϊ�(256�i��)
@@ -315,12 +316,12 @@ public class CEntity_Base : ScriptableObject
     {
         get
         {
-            if (Level == 0)
+            if (Level <= 0)
             {
                 return false;
             }
 
-            if (cardKind != CardKind.Digimon && cardKind != CardKind.DigiEgg)
+            if (cardKind != CardKind.Digimon && cardKind != CardKind.DigiEgg && cardKind != CardKind.DualCard)
             {
                 return false;
             }
@@ -335,11 +336,11 @@ public class CEntity_Base : ScriptableObject
     #endregion
 
     #region Wheter the card has play cost
-    public bool HasPlayCost => cardKind != CardKind.Option && PlayCost >= 0;
+    public bool HasPlayCost => cardKind != CardKind.Option && cardKind != CardKind.DualCard && PlayCost >= 0;
     #endregion
 
     #region Wheter the card has use cost
-    public bool HasUseCost => cardKind == CardKind.Option && PlayCost >= 0;
+    public bool HasUseCost => (cardKind == CardKind.Option || cardKind == CardKind.DualCard) && PlayCost >= 0;
     #endregion
 }
 public enum CardKind
@@ -348,6 +349,8 @@ public enum CardKind
     Tamer,
     Option,
     DigiEgg,
+
+    DualCard
 }
 
 [Serializable]

--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -301,6 +301,7 @@ public class PlayCardClass
     {
         bool burstDigivolved = false;
         bool appFusion = false;
+        bool isEvolution = false;
 
         List<CardSource> playedCards_fixed = new List<CardSource>();
 
@@ -388,8 +389,6 @@ public class PlayCardClass
             #endregion
 
             #region Determine if Evolution
-
-            bool isEvolution = false;
 
             if (targetPermanents.Count >= 1)
             {
@@ -997,8 +996,9 @@ public class PlayCardClass
 
         #region filter cards
 
-        List<CardSource> permanentCards = playedCards_fixed.Filter(cardSource => cardSource.IsPermanent);
-        List<CardSource> optionCards = playedCards_fixed.Filter(cardSource => !cardSource.IsPermanent);
+        bool isDualCardAsOption(CardSource cardSource) => cardSource.IsDualCard && !isEvolution;
+        List<CardSource> permanentCards = playedCards_fixed.Filter(cardSource => cardSource.IsPermanent && !isDualCardAsOption(cardSource));
+        List<CardSource> optionCards = playedCards_fixed.Filter(cardSource => !cardSource.IsPermanent || isDualCardAsOption(cardSource));
 
         #region play permanent
 
@@ -1751,6 +1751,11 @@ public class UseOptionClass
             }
 
             #endregion
+
+            if (card.Owner.ExecutingCards.Contains(card) && card.IsDualCard)
+            {
+                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ArtsDigivolve(card));
+            }
 
             if (card.Owner.ExecutingCards.Contains(card))
             {

--- a/Assets/Scripts/Script/CardEffectCommons.cs
+++ b/Assets/Scripts/Script/CardEffectCommons.cs
@@ -1010,6 +1010,55 @@ public partial class CardEffectCommons
 
     #endregion
 
+    #region Arts Digivolve
+    public static IEnumerator ArtsDigivolve(CardSource card, ActivateClass activateClass = null)
+    {
+        Permanent targetPermanent = null;
+
+        bool PermanentCondition(Permanent permanent) 
+            => card.CanPlayCardTargetFrame(permanent.PermanentFrame, false, activateClass, isBreedingArea: true)
+            || card.CanPlayCardTargetFrame(permanent.PermanentFrame, false, activateClass, isBreedingArea: false);
+
+        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+        {
+            targetPermanent = permanent;
+
+            yield return null;
+        }
+
+        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+        selectPermanentEffect.SetUp(
+            selectPlayer: card.Owner,
+            canTargetCondition: PermanentCondition,
+            canTargetCondition_ByPreSelecetedList: null,
+            canEndSelectCondition: null,
+            maxCount: 1,
+            canNoSelect: true,
+            canEndNotMax: false,
+            selectPermanentCoroutine: null,
+            afterSelectPermanentCoroutine: null,
+            mode: SelectPermanentEffect.Mode.Custom,
+            cardEffect: activateClass);
+
+        selectPermanentEffect.SetUpCustomMessage("Select a digimon to Arts Digivolve.", "Opponent is selecting a digimon to Arts Digivolve.");
+
+        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+        if (targetPermanent != null)
+        {
+            yield return ContinuousController.instance.StartCoroutine(new PlayCardClass(
+                cardSources: new List<CardSource>() { card },
+                hashtable: CardEffectHashtable(activateClass),
+                payCost: false,
+                targetPermanent: targetPermanent,
+                isTapped: false,
+                root: SelectCardEffect.Root.Execution,
+                activateETB: true).PlayCard());
+        }
+    }
+    #endregion
+
     #region Target permanent Digivolves into Digimon card execution area
 
     public static IEnumerator DigivolveIntoExcecutingAreaCard(

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -715,4 +715,29 @@ public partial class CardEffectFactory
     }
 
     #endregion
+
+    #region Can't play this dual card
+    public static ICardEffect DualCardCantPlay(CardSource card)
+    {
+        CanNotPutFieldClass canNotPutFieldClass = new CanNotPutFieldClass();
+        canNotPutFieldClass.SetUpICardEffect("Can't play to the field.", CanUseCondition, card);
+        canNotPutFieldClass.SetUpCanNotPutFieldClass(cardCondition: CardCondition, cardEffectCondition: CardEffectCondition);
+        return canNotPutFieldClass;
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            return true;
+        }
+
+        bool CardCondition(CardSource cardSource)
+        {
+            return cardSource == card;
+        }
+
+        bool CardEffectCondition(ICardEffect cardEffect)
+        {
+            return true;
+        }
+    }
+    #endregion
 }

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -740,4 +740,30 @@ public partial class CardEffectFactory
         }
     }
     #endregion
+
+    #region Use Requirements
+    public static ActivateClass UseRequirements(CardSource card, Func<Permanent, bool> permanentCondition)
+    {
+        IgnoreColorConditionClass ignoreColorConditionClass = new IgnoreColorConditionClass();
+        ignoreColorConditionClass.SetUpICardEffect("Ignore color requirements", CanUseCondition, card);
+        ignoreColorConditionClass.SetUpIgnoreColorConditionClass(cardCondition: CardCondition);
+        return ignoreColorConditionClass;
+
+        bool PermanentCondition(Permanent permanent)
+        {
+            return (permanent.IsDigimon || permanent.IsTamer)
+                && permanentCondition(permanent);
+        }
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            return CardEffectCommons.HasMatchConditionOwnersPermanent(card, PermanentCondition);
+        }
+
+        bool CardCondition(CardSource cardSource)
+        {
+            return cardSource == card;
+        }
+    }
+    #endregion
 }

--- a/Assets/Scripts/Script/CardSource.cs
+++ b/Assets/Scripts/Script/CardSource.cs
@@ -108,12 +108,17 @@ public class CardSource : MonoBehaviour
     {
         get
         {
+            if (IsDualCard && Owner.GetBattleAreaDigimons().Some(permanent => CanPlayCardTargetFrame(permanent.PermanentFrame, true, null)))
+            {
+                return true;
+            }
+
             if (CanNotPlayThisOption)
             {
                 return false;
             }
 
-            if (_cEntity_Base.IsPermanent)
+            if (_cEntity_Base.IsPermanent && !IsDualCard)
             {
                 if (!CanPlayJogress(true))
                 {
@@ -267,9 +272,11 @@ public class CardSource : MonoBehaviour
 
                 #endregion
 
-                bool matchColorRequirement = CardColors.Every(cardColor =>
+                List<CardColor> colorsToCheck = IsDualCard ? DualCardColors : CardColors;
+
+                bool matchColorRequirement = colorsToCheck.Every(cardColor =>
                     Owner.GetFieldPermanents().Some(permanent =>
-                        !permanent.TopCard.IsOption && permanent.TopCard.CardColors.Contains(cardColor)));
+                        permanent.TopCard.IsPermanent && permanent.TopCard.CardColors.Contains(cardColor)));
 
                 if (!matchColorRequirement)
                 {
@@ -315,6 +322,8 @@ public class CardSource : MonoBehaviour
 
     public List<CardColor> BaseCardColorsFromEntity => _cEntity_Base.cardColors.Distinct().ToList();
 
+    public List<CardColor> BaseDualCardColorsFromEntity => _cEntity_Base.DualCardColors.Distinct().ToList();
+
     #endregion
 
     #region base card colors
@@ -358,6 +367,45 @@ public class CardSource : MonoBehaviour
         }
     }
 
+    public List<CardColor> BaseDualCardColors
+    {
+        get
+        {
+            List<CardColor> baseCardColors = BaseDualCardColorsFromEntity;
+
+            #region the effects that changes base card colors
+
+            #region the effects of itself
+
+            if (PermanentOfThisCard() == null)
+            {
+                EffectList(EffectTiming.None)
+                    .Filter(cardEffect => cardEffect is IChangeBaseCardColorEffect && cardEffect.CanUse(null))
+                    .ForEach(cardEffect => baseCardColors = ((IChangeBaseCardColorEffect)cardEffect).GetBaseCardColors(baseCardColors, this));
+            }
+
+            #endregion
+
+            #region the effects of permanents
+
+            GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer
+                .Map(player => player.GetFieldPermanents())
+                .Flat()
+                .Map(permanent => permanent.EffectList(EffectTiming.None))
+                .Flat()
+                .Filter(cardEffect => cardEffect is IChangeBaseCardColorEffect && cardEffect.CanUse(null))
+                .ForEach(cardEffect => baseCardColors = ((IChangeBaseCardColorEffect)cardEffect).GetBaseCardColors(baseCardColors, this));
+
+            #endregion
+
+            #endregion
+
+            baseCardColors = baseCardColors.Distinct().ToList();
+
+            return baseCardColors;
+        }
+    }
+
     #endregion
 
     #region card colors
@@ -367,6 +415,45 @@ public class CardSource : MonoBehaviour
         get
         {
             List<CardColor> cardColors = BaseCardColors;
+
+            #region the effects that changes card colors
+
+            #region the effects of itself
+
+            if (PermanentOfThisCard() == null)
+            {
+                EffectList(EffectTiming.None)
+                    .Filter(cardEffect => cardEffect is IChangeCardColorEffect && cardEffect.CanUse(null))
+                    .ForEach(cardEffect => cardColors = ((IChangeCardColorEffect)cardEffect).GetCardColors(cardColors, this));
+            }
+
+            #endregion
+
+            #region the effects of permanents
+
+            GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer
+                .Map(player => player.GetFieldPermanents())
+                .Flat()
+                .Map(permanent => permanent.EffectList(EffectTiming.None))
+                .Flat()
+                .Filter(cardEffect => cardEffect is IChangeCardColorEffect && cardEffect.CanUse(null))
+                .ForEach(cardEffect => cardColors = ((IChangeCardColorEffect)cardEffect).GetCardColors(cardColors, this));
+
+            #endregion
+
+            #endregion
+
+            cardColors = cardColors.Distinct().ToList();
+
+            return cardColors;
+        }
+    }
+
+    public List<CardColor> DualCardColors
+    {
+        get
+        {
+            List<CardColor> cardColors = BaseDualCardColors;
 
             #region the effects that changes card colors
 
@@ -1386,6 +1473,24 @@ public class CardSource : MonoBehaviour
         || cardName.Contains(replaced)
         || cardName.Contains(lower)
         || cardName.ToLower().Contains(lower));
+    }
+
+    #endregion
+
+    #region whether this card has the mentioned color
+
+    public bool HasCardColor(CardColor cardColor, bool isOptionOnly = false)
+    {
+        if (isOptionOnly)
+        {
+            if (!IsOption)
+                return false;
+            if (IsDualCard)
+            {
+                return DualCardColors.Contains(cardColor);
+            }
+        }
+        return CardColors.Contains(cardColor);
     }
 
     #endregion
@@ -3166,7 +3271,7 @@ public class CardSource : MonoBehaviour
 
     #region whether this card is Digimon
 
-    public bool IsDigimon => CardKind == CardKind.Digimon;
+    public bool IsDigimon => CardKind == CardKind.Digimon || IsDualCard;
 
     #endregion
 
@@ -3184,7 +3289,13 @@ public class CardSource : MonoBehaviour
 
     #region whether this card is Option
 
-    public bool IsOption => CardKind == CardKind.Option;
+    public bool IsOption => CardKind == CardKind.Option || IsDualCard;
+
+    #endregion
+
+    #region whether this card is a Dual Card
+
+    public bool IsDualCard => CardKind == CardKind.DualCard;
 
     #endregion
 

--- a/Assets/Scripts/Script/TurnStateMachine.cs
+++ b/Assets/Scripts/Script/TurnStateMachine.cs
@@ -2057,22 +2057,25 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
                             {
                                 bool CanPlayEmptyFrame = false;
 
-                                foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
+                                if (!handCard1.cardSource.IsDualCard)
                                 {
-                                    if (fieldCardFrame.IsEmptyFrame())
+                                    foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
                                     {
-                                        if (handCard1.cardSource.CanPlayCardTargetFrame(fieldCardFrame, true, null))
+                                        if (fieldCardFrame.IsEmptyFrame())
                                         {
-                                            CanPlayEmptyFrame = true;
-                                            break;
+                                            if (handCard1.cardSource.CanPlayCardTargetFrame(fieldCardFrame, true, null))
+                                            {
+                                                CanPlayEmptyFrame = true;
+                                                break;
+                                            }
                                         }
                                     }
-                                }
 
-                                if (CanPlayEmptyFrame)
-                                {
-                                    GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(true);
-                                    GManager.instance.You.playMatCardFrame.OnFrame_Select(DataBase.SelectColor_Blue);
+                                    if (CanPlayEmptyFrame)
+                                    {
+                                        GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(true);
+                                        GManager.instance.You.playMatCardFrame.OnFrame_Select(DataBase.SelectColor_Blue);
+                                    }
                                 }
 
                                 foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
@@ -2522,51 +2525,53 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
 
                                     bool CanPlayEmptyFrame = false;
 
-                                    foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
+                                    if(!handCard.cardSource.IsDualCard)
                                     {
-                                        if (fieldCardFrame.IsEmptyFrame())
+                                        foreach (FieldCardFrame fieldCardFrame in GManager.instance.You.fieldCardFrames)
                                         {
-                                            if (handCard.cardSource.CanPlayCardTargetFrame(fieldCardFrame, true, null))
+                                            if (fieldCardFrame.IsEmptyFrame())
                                             {
-                                                CanPlayEmptyFrame = true;
-                                                break;
-                                            }
-                                        }
-                                    }
-
-                                    if (CanPlayEmptyFrame)
-                                    {
-                                        #region Check for drops on the playmat
-                                        if (dropAreas.Count((dropArea) => dropArea.IsChildThisDropArea(GManager.instance.You.playMatCardFrame.Frame)) > 0)
-                                        {
-                                            if (handCard.cardSource.Owner.HandTransform.GetComponent<HandContoller>() != null)
-                                            {
-                                                handCard.cardSource.Owner.HandTransform.GetComponent<HandContoller>().isDragging = true;
-                                            }
-
-                                            OffHandCardTarget(gameContext.TurnPlayer);
-
-                                            handCard.Outline_Select.gameObject.SetActive(false);
-
-                                            foreach (Player player in gameContext.Players_ForTurnPlayer)
-                                            {
-                                                foreach (FieldCardFrame fieldCardFrame in player.fieldCardFrames)
+                                                if (handCard.cardSource.CanPlayCardTargetFrame(fieldCardFrame, true, null))
                                                 {
-                                                    fieldCardFrame.RemoveClickTarget();
+                                                    CanPlayEmptyFrame = true;
+                                                    break;
                                                 }
                                             }
-
-                                            GManager.instance.You.playMatCardFrame.RemoveClickTarget();
-                                            GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(false);
-
-                                            photonView.RPC("SetPlayCard", RpcTarget.All, handCard.cardSource.CardIndex, handCard.cardSource.PreferredFrame().FrameID, new int[0], -1, new int[0]);
-                                            selected = true;
-
-                                            return;
                                         }
-                                        #endregion
-                                    }
 
+                                        if (CanPlayEmptyFrame)
+                                        {
+                                            #region Check for drops on the playmat
+                                            if (dropAreas.Count((dropArea) => dropArea.IsChildThisDropArea(GManager.instance.You.playMatCardFrame.Frame)) > 0)
+                                            {
+                                                if (handCard.cardSource.Owner.HandTransform.GetComponent<HandContoller>() != null)
+                                                {
+                                                    handCard.cardSource.Owner.HandTransform.GetComponent<HandContoller>().isDragging = true;
+                                                }
+
+                                                OffHandCardTarget(gameContext.TurnPlayer);
+
+                                                handCard.Outline_Select.gameObject.SetActive(false);
+
+                                                foreach (Player player in gameContext.Players_ForTurnPlayer)
+                                                {
+                                                    foreach (FieldCardFrame fieldCardFrame in player.fieldCardFrames)
+                                                    {
+                                                        fieldCardFrame.RemoveClickTarget();
+                                                    }
+                                                }
+
+                                                GManager.instance.You.playMatCardFrame.RemoveClickTarget();
+                                                GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(false);
+
+                                                photonView.RPC("SetPlayCard", RpcTarget.All, handCard.cardSource.CardIndex, handCard.cardSource.PreferredFrame().FrameID, new int[0], -1, new int[0]);
+                                                selected = true;
+
+                                                return;
+                                            }
+                                            #endregion
+                                        }
+                                    }
                                 }
                                 #endregion
 


### PR DESCRIPTION
TODO:

- [x] Arts Digivolution is not by effect. Need to separate it from activateClass.
- [ ] Change all instances of CardSource.CardColors.Contains to CardSource.HasCardColor everywhere. Not going to this effort until we confirm the approach (I will do this change, just need confirmation first so I am not wasting time)
- [x] Make it so when player drags a DualCard that is seen as using the option
- [x] Update json parsing to populate DualCardColors when present. and to recognise when cardkind is dualcard
- [x] Tweaking to the right click window and deck building screen to display all information.
- [ ] Further changes to cEntity_Base to store the separate effect text for the option half.
- [ ] Update cards which trash Delay options such as BT19-064 Justimon, BT18-100 Gospel of the Fallen Angel to NOT delete DualCards, depending on rulings
- [x] Rework for CardKind being a list

I am not suggesting all of the above will be done by me, just trying to track all things likely to be needed