### PR TITLE
General fix: Multiple DigiXros or Assemblies at once

### DIFF
--- a/Assets/Scripts/CardEffect/BT10/Purple/BT10_093.cs
+++ b/Assets/Scripts/CardEffect/BT10/Purple/BT10_093.cs
@@ -114,7 +114,7 @@ namespace DCGO.CardEffects.BT10
             {
                 if (CardEffectCommons.IsExistOnBattleArea(card))
                 {
-                    if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, (permanent) => permanent.IsTamer && permanent.DigivolutionCards.Count((cardSource) => cardSource.IsDigimon && cardSource.CardColors.Contains(CardColor.Purple) && GManager.instance.GetComponent<SelectDigiXrosClass>().addDigivolutionCardInfos.Count((addDigivolutionCardInfo) => addDigivolutionCardInfo.cardSources.Contains(cardSource)) == 0) >= 1))
+                    if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, (permanent) => permanent.IsTamer && permanent.DigivolutionCards.Count((cardSource) => cardSource.IsDigimon && cardSource.CardColors.Contains(CardColor.Purple) && GManager.instance.GetComponent<SelectDigiXrosClass>().GetAddDigivolutionCardInfos(CardEffectCommons.GetCardFromHashtable(hashtable)).Count((addDigivolutionCardInfo) => addDigivolutionCardInfo.cardSources.Contains(cardSource)) == 0) >= 1))
                     {
                         return true;
                     }
@@ -133,7 +133,7 @@ namespace DCGO.CardEffects.BT10
                     {
                         if (!digivolutionCards.Contains(cardSource))
                         {
-                            if (GManager.instance.GetComponent<SelectDigiXrosClass>().addDigivolutionCardInfos.Count((addDigivolutionCardInfo) => addDigivolutionCardInfo.cardSources.Contains(cardSource)) == 0)
+                            if (GManager.instance.GetComponent<SelectDigiXrosClass>().GetAddDigivolutionCardInfos(CardEffectCommons.GetCardFromHashtable(_hashtable)).Count((addDigivolutionCardInfo) => addDigivolutionCardInfo.cardSources.Contains(cardSource)) == 0)
                             {
                                 if (cardSource.CardColors.Contains(CardColor.Purple))
                                 {
@@ -280,7 +280,7 @@ namespace DCGO.CardEffects.BT10
 
                     if (digivolutionCards.Count >= 1)
                     {
-                        GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(new AddDigivolutionCardsInfo(activateClass2, digivolutionCards));
+                        GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(CardEffectCommons.GetCardFromHashtable(_hashtable), new AddDigivolutionCardsInfo(activateClass2, digivolutionCards));
 
                         int reduceCount = 2 * digivolutionCards.Count;
 

--- a/Assets/Scripts/CardEffect/BT12/White/BT12_112.cs
+++ b/Assets/Scripts/CardEffect/BT12/White/BT12_112.cs
@@ -111,7 +111,7 @@ namespace DCGO.CardEffects.BT12
                                     {
                                         if (!selectedPermanent.TopCard.CanNotBeAffected(activateClass))
                                         {
-                                            GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(new AddDigivolutionCardsInfo(activateClass, new List<CardSource>() { selectedPermanent.TopCard }));
+                                            GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(card, new AddDigivolutionCardsInfo(activateClass, new List<CardSource>() { selectedPermanent.TopCard }));
 
                                             if (card.Owner.CanReduceCost(null, card))
                                             {

--- a/Assets/Scripts/CardEffect/BT15/White/BT15_102.cs
+++ b/Assets/Scripts/CardEffect/BT15/White/BT15_102.cs
@@ -218,7 +218,7 @@ namespace DCGO.CardEffects.BT15
 
                             if (selectedCards.Count >= 1)
                             {
-                                GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(new AddDigivolutionCardsInfo(activateClass, selectedCards));
+                                GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(card, new AddDigivolutionCardsInfo(activateClass, selectedCards));
 
                                 yield return StartCoroutine(AfterSelectCardCoroutine(selectedCards));
                             }

--- a/Assets/Scripts/CardEffect/BT21/Red/BT21_030.cs
+++ b/Assets/Scripts/CardEffect/BT21/Red/BT21_030.cs
@@ -221,7 +221,7 @@ namespace DCGO.CardEffects.BT21
                                     {
                                         if (!selectedPermanent.TopCard.CanNotBeAffected(activateClass))
                                         {
-                                            GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(new AddDigivolutionCardsInfo(activateClass, new List<CardSource>() { selectedPermanent.TopCard }));
+                                            GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(card, new AddDigivolutionCardsInfo(activateClass, new List<CardSource>() { selectedPermanent.TopCard }));
 
                                             if (card.Owner.CanReduceCost(null, card))
                                             {

--- a/Assets/Scripts/CardEffect/EX10/White/EX10_061.cs
+++ b/Assets/Scripts/CardEffect/EX10/White/EX10_061.cs
@@ -218,7 +218,7 @@ namespace DCGO.CardEffects.EX10
 
                             if (selectedCards.Count >= 1)
                             {
-                                GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(new AddDigivolutionCardsInfo(activateClass, selectedCards));
+                                GManager.instance.GetComponent<SelectDigiXrosClass>().AddDigivolutionCardInfos(card, new AddDigivolutionCardsInfo(activateClass, selectedCards));
                                 yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                     player: card.Owner,
                                     refSkillInfos: ref ContinuousController.instance.nullSkillInfos,

--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -1224,15 +1224,9 @@ public class PlayPermanentClass
         {
             yield return ContinuousController.instance.StartCoroutine(card.Owner.brainStormObject.CloseBrainstrorm(card));
 
-            if (GManager.instance.GetComponent<SelectDigiXrosClass>().playCard == card)
-            {
-                _digiXrosCount = GManager.instance.GetComponent<SelectDigiXrosClass>().selectedDigicrossCards.Count;
-            }
+            _digiXrosCount = GManager.instance.GetComponent<SelectDigiXrosClass>().GetSelectedCardCount(card);
 
-            if (GManager.instance.GetComponent<SelectAssemblyClass>().playCard == card)
-            {
-                _assemblyCount = GManager.instance.GetComponent<SelectAssemblyClass>().selectedAssemblyCards.Count;
-            }
+            _assemblyCount = GManager.instance.GetComponent<SelectAssemblyClass>().GetSelectedCardCount(card);
 
             bool isFromDigimonDigivolutionCards = card.Owner.GetFieldPermanents().Some((permanent) => permanent.DigivolutionCards.Contains(card));
 
@@ -1613,12 +1607,13 @@ public class PlayPermanentClass
                 }
             }
 
-            GManager.instance.GetComponent<SelectDigiXrosClass>().ResetSelectDigiXrosClass();
-            GManager.instance.GetComponent<SelectAssemblyClass>().ResetSelectAssemblyClass();
             GManager.instance.GetComponent<SelectDNACondition>().ResetSelectDNAConditionClass();
 
             yield return GManager.instance.photonWaitController.StartWait("EndPlayPermanent");
         }
+
+        GManager.instance.GetComponent<SelectDigiXrosClass>().ResetSelectDigiXrosClass();
+        GManager.instance.GetComponent<SelectAssemblyClass>().ResetSelectAssemblyClass();
 
         // except [On Play] effect
         bool CardEffectCondition(ICardEffect cardEffect)

--- a/Assets/Scripts/Script/CardEffectCommons/GameContextDeterminarion.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GameContextDeterminarion.cs
@@ -190,8 +190,8 @@ public partial class CardEffectCommons
         int fixedCost = -1) =>
     cardSource != null &&
     (isPlayOption || !cardSource.IsOption) &&
-    !GManager.instance.GetComponent<SelectDigiXrosClass>().selectedDigicrossCards.Contains(cardSource) &&
-    !GManager.instance.GetComponent<SelectAssemblyClass>().selectedAssemblyCards.Contains(cardSource)
+    !GManager.instance.GetComponent<SelectDigiXrosClass>().PreviouslySelectedDigicrossCards.Contains(cardSource) &&
+    !GManager.instance.GetComponent<SelectAssemblyClass>().PreviouslySelectedAssemblyCards.Contains(cardSource)
     && cardSource.Owner.fieldCardFrames.Some((frame) =>
     frame.IsEmptyFrame()
     && cardSource.CanPlayCardTargetFrame(frame, payCost, cardEffect, root, isBreedingArea: isBreedingArea, fixedCost: fixedCost));

--- a/Assets/Scripts/Script/CardSource.cs
+++ b/Assets/Scripts/Script/CardSource.cs
@@ -570,9 +570,9 @@ public class CardSource : MonoBehaviour
 
                         if (selectDigiXrosClass != null)
                         {
-                            if (selectDigiXrosClass.playCard == this)
+                            if (selectDigiXrosClass.WasDigiXrosed(this))
                             {
-                                Cost -= selectDigiXrosClass.selectedDigicrossCards.Count * digiXrosCondition.reduceCostPerCard;
+                                Cost -= selectDigiXrosClass.GetSelectedCardCount(this) * digiXrosCondition.reduceCostPerCard;
                             }
                         }
                     }
@@ -605,9 +605,9 @@ public class CardSource : MonoBehaviour
 
                         if (selectAssemblyClass != null)
                         {
-                            if (selectAssemblyClass.playCard == this)
+                            if (selectAssemblyClass.WasAssembled(this))
                             {
-                                if (selectAssemblyClass.selectedAssemblyCards.Count == assemblyCondition.elementCount)
+                                if (selectAssemblyClass.GetSelectedCardCount(this) == assemblyCondition.elementCount)
                                     Cost -= assemblyCondition.reduceCost;
                             }
                         }

--- a/Assets/Scripts/Script/SelectAssemblyClass.cs
+++ b/Assets/Scripts/Script/SelectAssemblyClass.cs
@@ -9,20 +9,61 @@ using UnityEngine.Events;
 
 public class SelectAssemblyClass : MonoBehaviourPunCallbacks
 {
-    public List<CardSource> selectedAssemblyCards { get; private set; } = new List<CardSource>();
-    public List<AddDigivolutionCardsInfo> addDigivolutionCardInfos { get; private set; } = new List<AddDigivolutionCardsInfo>();
-    public CardSource playCard { get; private set; } = null;
+    private List<CardSource> selectedAssemblyCards = new List<CardSource>();
+    public List<CardSource> PreviouslySelectedAssemblyCards { get; private set; } = new List<CardSource>();
+    private List<PlayCardTuple> AllAssemblyCards = new List<PlayCardTuple>();
+
+    void AddSelectedCard(CardSource cardSource)
+    {
+        selectedAssemblyCards.Add(cardSource);
+        PreviouslySelectedAssemblyCards.Add(cardSource);
+    }
+
+    public List<CardSource> GetPreviouslySelected()
+    {
+        SelectDigiXrosClass selectDigiXrosClass = GManager.instance.GetComponent<SelectDigiXrosClass>();
+        return AllAssemblyCards.Map(tuple => tuple.SelectedAssemblyCards).Flat().Concat(selectDigiXrosClass.PreviouslySelectedDigicrossCards).ToList();
+    }
+
+    private class PlayCardTuple
+    {
+        public CardSource PlayCard;
+        public List<CardSource> SelectedAssemblyCards;
+        public List<AddDigivolutionCardsInfo> AddDigivolutionCardInfos;
+    }
+
+    private PlayCardTuple GetTupleForCard(CardSource card)
+    {
+        return AllAssemblyCards.FirstOrDefault(tuple => tuple.PlayCard == card);
+    }
+
+    private PlayCardTuple GetOrMakeTupleForCard(CardSource card)
+    {
+        PlayCardTuple cardTuple = GetTupleForCard(card);
+        if (cardTuple == null)
+        {
+            cardTuple = new()
+            {
+                PlayCard = card,
+                SelectedAssemblyCards = new List<CardSource>(),
+                AddDigivolutionCardInfos = new List<AddDigivolutionCardsInfo>()
+            };
+            AllAssemblyCards.Add(cardTuple);
+        }
+        return cardTuple;
+    }
 
     public void ResetSelectAssemblyClass()
     {
+        AllAssemblyCards = new List<PlayCardTuple>();
         selectedAssemblyCards = new List<CardSource>();
-        addDigivolutionCardInfos = new List<AddDigivolutionCardsInfo>();
-        playCard = null;
+        PreviouslySelectedAssemblyCards = new List<CardSource>();
     }
 
-    public void AddDigivolutionCardInfos(AddDigivolutionCardsInfo digivolutionCardsInfo)
+    public void AddDigivolutionCardInfos(CardSource card, AddDigivolutionCardsInfo digivolutionCardsInfo)
     {
-        addDigivolutionCardInfos.Add(digivolutionCardsInfo);
+        PlayCardTuple cardTuple = GetOrMakeTupleForCard(card);
+        cardTuple.AddDigivolutionCardInfos.Add(digivolutionCardsInfo);
     }
 
     #region Is Trash Card
@@ -57,13 +98,14 @@ public class SelectAssemblyClass : MonoBehaviourPunCallbacks
                             {
                                 if (!targetCard.IsToken)
                                 {
-                                    if (!selectedAssemblyCards.Contains(targetCard))
+                                    if (!PreviouslySelectedAssemblyCards.Contains(targetCard))
                                     {
+                                        List<AddDigivolutionCardsInfo> addDigivolutionCardInfos = GetAddDigivolutionCardInfos(card);
                                         if (addDigivolutionCardInfos.Count((addDigivolutionCardInfo) => addDigivolutionCardInfo.cardSources.Contains(targetCard)) == 0)
                                         {
                                             if (element.CanTargetCondition_ByPreSelecetedList != null)
                                             {
-                                                if (!element.CanTargetCondition_ByPreSelecetedList(selectedAssemblyCards, targetCard))
+                                                if (!element.CanTargetCondition_ByPreSelecetedList(PreviouslySelectedAssemblyCards, targetCard))
                                                 {
                                                     return false;
                                                 }
@@ -126,7 +168,7 @@ public class SelectAssemblyClass : MonoBehaviourPunCallbacks
         if (index >= AssemblyCondition.elements.Count)
             return true;
             
-        usedCards ??= new List<CardSource>();
+        usedCards ??= PreviouslySelectedAssemblyCards;
 
         AssemblyConditionElement currentElement = AssemblyCondition.elements[index];
 
@@ -156,9 +198,11 @@ public class SelectAssemblyClass : MonoBehaviourPunCallbacks
     {
         GManager.instance.turnStateMachine.isSync = true;
 
-        selectedAssemblyCards = new List<CardSource>();
+        PlayCardTuple cardTuple = GetOrMakeTupleForCard(card);
 
-        playCard = card;
+        selectedAssemblyCards = cardTuple.SelectedAssemblyCards;
+
+        PreviouslySelectedAssemblyCards = GetPreviouslySelected();
 
         if (CanFulfillConditions(card))
         {
@@ -274,16 +318,45 @@ public class SelectAssemblyClass : MonoBehaviourPunCallbacks
     }
     #endregion
 
+    #region Check if card was Assembled
+    public bool WasAssembled(CardSource card)
+    {
+        return GetTupleForCard(card) != null;
+    }
+    #endregion
+
+    #region Get Count of Digivolution Cards for Card
+    public int GetSelectedCardCount(CardSource card)
+    {
+        PlayCardTuple cardTuple = GetTupleForCard(card);
+        if (cardTuple != null)
+        {
+            return cardTuple.SelectedAssemblyCards.Count;
+        }
+        return 0;
+    }
+    #endregion
+
+    #region Get AddDigivolutionCardInfos
+    public List<AddDigivolutionCardsInfo> GetAddDigivolutionCardInfos(CardSource card)
+    {
+        PlayCardTuple cardTuple = GetOrMakeTupleForCard(card);
+        return cardTuple.AddDigivolutionCardInfos;
+    }
+    #endregion
+
     #region Add Digivolution Cards
     public IEnumerator AddDigivolutiuonCards(CardSource card)
     {
         if (card != null)
         {
-            if (card == playCard)
+            PlayCardTuple cardTuple = GetTupleForCard(card);
+            if (cardTuple != null)
             {
                 if (card.PermanentOfThisCard() != null)
                 {
-                    if (selectedAssemblyCards.Count == playCard.assemblyCondition.elementCount)
+                    selectedAssemblyCards = cardTuple.SelectedAssemblyCards;
+                    if (selectedAssemblyCards.Count == cardTuple.PlayCard.assemblyCondition.elementCount)
                     {
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(selectedAssemblyCards, "Assembly Cards", true, true));
 
@@ -310,42 +383,44 @@ public class SelectAssemblyClass : MonoBehaviourPunCallbacks
     #region Add Digivolution Card
     public IEnumerator AddDigivolutiuonCardsByEffect(CardSource card)
     {
-        if (addDigivolutionCardInfos.Count >= 1)
+        PlayCardTuple cardTuple = GetTupleForCard(card);
+        if (cardTuple != null)
         {
-            if (card != null)
+            List<AddDigivolutionCardsInfo> addDigivolutionCardInfos = cardTuple.AddDigivolutionCardInfos;
+            if (addDigivolutionCardInfos.Count >= 1)
             {
-                if (card.PermanentOfThisCard() != null)
+                if (card != null)
                 {
-                    List<CardSource> addedCards = new List<CardSource>();
-
-                    foreach (AddDigivolutionCardsInfo info in addDigivolutionCardInfos)
+                    if (card.PermanentOfThisCard() != null)
                     {
-                        List<CardSource> underTamerCards = new List<CardSource>();
-                        List<Permanent> digimonPermanents = new List<Permanent>();
-                        List<CardSource> trashCards = new List<CardSource>();
+                        List<CardSource> addedCards = new List<CardSource>();
 
-                        foreach (CardSource cardSource in info.cardSources)
+                        foreach (AddDigivolutionCardsInfo info in addDigivolutionCardInfos)
                         {
-                            if (isTrashCard(cardSource))
+                            List<CardSource> underTamerCards = new List<CardSource>();
+                            List<Permanent> digimonPermanents = new List<Permanent>();
+                            List<CardSource> trashCards = new List<CardSource>();
+
+                            foreach (CardSource cardSource in info.cardSources)
                             {
-                                trashCards.Add(cardSource);
-                                addedCards.Add(cardSource);
+                                if (isTrashCard(cardSource))
+                                {
+                                    trashCards.Add(cardSource);
+                                    addedCards.Add(cardSource);
+                                }
+                            }
+
+                            if (trashCards.Count >= 1)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(trashCards, info.cardEffect));
                             }
                         }
 
-                        if (trashCards.Count >= 1)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(trashCards, info.cardEffect));
-                        }
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(addedCards, "Digivolution Cards", true, true));
                     }
-
-                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(addedCards, "Digivolution Cards", true, true));
                 }
             }
         }
-
-        addDigivolutionCardInfos = new List<AddDigivolutionCardsInfo>();
-
         yield return null;
     }
     #endregion

--- a/Assets/Scripts/Script/SelectDigiXrosClass.cs
+++ b/Assets/Scripts/Script/SelectDigiXrosClass.cs
@@ -9,20 +9,63 @@ using UnityEngine.Events;
 
 public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 {
-    public List<CardSource> selectedDigicrossCards { get; private set; } = new List<CardSource>();
-    public List<AddDigivolutionCardsInfo> addDigivolutionCardInfos { get; private set; } = new List<AddDigivolutionCardsInfo>();
-    public CardSource playCard { get; private set; } = null;
+    private List<CardSource> selectedDigicrossCards = new List<CardSource>();
+
+    public List<CardSource> PreviouslySelectedDigicrossCards { get; private set; } = new List<CardSource>();
+
+    private List<PlayCardTuple> AllDigiXrosCards = new List<PlayCardTuple>();
+
+    private void AddSelectedCard(CardSource cardSource)
+    {
+        selectedDigicrossCards.Add(cardSource);
+        PreviouslySelectedDigicrossCards.Add(cardSource);
+    }
+
+    private List<CardSource> GetPreviouslySelected()
+    {
+        SelectAssemblyClass selectAssemblyClass = GManager.instance.GetComponent<SelectAssemblyClass>();
+        return AllDigiXrosCards.Map(tuple => tuple.SelectedDigicrossCards).Flat().Concat(selectAssemblyClass.PreviouslySelectedAssemblyCards).ToList();
+    }
+    
+    private class PlayCardTuple
+    {
+        public CardSource PlayCard;
+        public List<CardSource> SelectedDigicrossCards;
+        public List<AddDigivolutionCardsInfo> AddDigivolutionCardInfos;
+    }
+
+    private PlayCardTuple GetTupleForCard(CardSource card)
+    {
+        return AllDigiXrosCards.FirstOrDefault(tuple => tuple.PlayCard == card);
+    }
+
+    private PlayCardTuple GetOrMakeTupleForCard(CardSource card)
+    {
+        PlayCardTuple cardTuple = GetTupleForCard(card);
+        if (cardTuple == null)
+        {
+            cardTuple = new()
+            {
+                PlayCard = card,
+                SelectedDigicrossCards = new List<CardSource>(),
+                AddDigivolutionCardInfos = new List<AddDigivolutionCardsInfo>()
+            };
+            AllDigiXrosCards.Add(cardTuple);
+        }
+        return cardTuple;
+    }
 
     public void ResetSelectDigiXrosClass()
     {
+        AllDigiXrosCards = new List<PlayCardTuple>();
         selectedDigicrossCards = new List<CardSource>();
-        addDigivolutionCardInfos = new List<AddDigivolutionCardsInfo>();
-        playCard = null;
+        PreviouslySelectedDigicrossCards = new List<CardSource>();
     }
 
-    public void AddDigivolutionCardInfos(AddDigivolutionCardsInfo digivolutionCardsInfo)
+    public void AddDigivolutionCardInfos(CardSource card, AddDigivolutionCardsInfo digivolutionCardsInfo)
     {
-        addDigivolutionCardInfos.Add(digivolutionCardsInfo);
+        PlayCardTuple cardTuple = GetOrMakeTupleForCard(card);
+        cardTuple.AddDigivolutionCardInfos.Add(digivolutionCardsInfo);
     }
 
     #region Max Trash Count
@@ -34,10 +77,10 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
         {
             List<int> maxTrashCountList = new List<int>();
 
-            #region ‘I‘ğ‰Â”\ƒgƒ‰ƒbƒVƒ…–‡”‚ğ•ÏX‚·‚éŒø‰Ê
+            #region é¸æŠå¯èƒ½ãƒˆãƒ©ãƒƒã‚·ãƒ¥æšæ•°ã‚’å¤‰æ›´ã™ã‚‹åŠ¹æœ
             foreach (Player player in GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer)
             {
-                #region ê‚Ìƒp[ƒ}ƒlƒ“ƒg‚ÌŒø‰Ê
+                #region å ´ã®ãƒ‘ãƒ¼ãƒãƒãƒ³ãƒˆã®åŠ¹æœ
                 foreach (Permanent permanent in player.GetBattleAreaPermanents())
                 {
                     foreach (ICardEffect cardEffect in permanent.EffectList(EffectTiming.None))
@@ -58,7 +101,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                 }
                 #endregion
 
-                #region ƒvƒŒƒCƒ„[‚ÌŒø‰Ê
+                #region ãƒ—ãƒ¬ã‚¤ãƒ¤ãƒ¼ã®åŠ¹æœ
                 foreach (ICardEffect cardEffect in player.EffectList(EffectTiming.None))
                 {
                     if (cardEffect is IAddMaxTrashCountDigiXrosEffect)
@@ -77,7 +120,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                 #endregion
             }
 
-            #region ƒJ[ƒh©g‚ÌŒø‰Ê
+            #region ã‚«ãƒ¼ãƒ‰è‡ªèº«ã®åŠ¹æœ
             if (card.PermanentOfThisCard() == null)
             {
                 foreach (ICardEffect cardEffect in card.EffectList(EffectTiming.None))
@@ -129,10 +172,10 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
         {
             List<int> maxTamerDigivolutionCardsCountList = new List<int>();
 
-            #region ‘I‘ğ‰Â”\ƒeƒCƒ}[i‰»Œ³–‡”‚ğ•ÏX‚·‚éŒø‰Ê
+            #region é¸æŠå¯èƒ½ãƒ†ã‚¤ãƒãƒ¼é€²åŒ–å…ƒæšæ•°ã‚’å¤‰æ›´ã™ã‚‹åŠ¹æœ
             foreach (Player player in GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer)
             {
-                #region ê‚Ìƒp[ƒ}ƒlƒ“ƒg‚ÌŒø‰Ê
+                #region å ´ã®ãƒ‘ãƒ¼ãƒãƒãƒ³ãƒˆã®åŠ¹æœ
                 foreach (Permanent permanent in player.GetBattleAreaPermanents())
                 {
                     foreach (ICardEffect cardEffect in permanent.EffectList(EffectTiming.None))
@@ -153,7 +196,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                 }
                 #endregion
 
-                #region ƒvƒŒƒCƒ„[‚ÌŒø‰Ê
+                #region ãƒ—ãƒ¬ã‚¤ãƒ¤ãƒ¼ã®åŠ¹æœ
                 foreach (ICardEffect cardEffect in player.EffectList(EffectTiming.None))
                 {
                     if (cardEffect is IAddMaxUnderTamerCountDigiXrosEffect)
@@ -172,7 +215,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                 #endregion
             }
 
-            #region ƒJ[ƒh©g‚ÌŒø‰Ê
+            #region ã‚«ãƒ¼ãƒ‰è‡ªèº«ã®åŠ¹æœ
             if (card.PermanentOfThisCard() == null)
             {
                 foreach (ICardEffect cardEffect in card.EffectList(EffectTiming.None))
@@ -314,13 +357,14 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                             {
                                 if (!targetCard.IsToken)
                                 {
-                                    if (!selectedDigicrossCards.Contains(targetCard))
+                                    if (!PreviouslySelectedDigicrossCards.Contains(targetCard))
                                     {
+                                        List<AddDigivolutionCardsInfo> addDigivolutionCardInfos = GetAddDigivolutionCardInfos(card);
                                         if (addDigivolutionCardInfos.Count((addDigivolutionCardInfo) => addDigivolutionCardInfo.cardSources.Contains(targetCard)) == 0)
                                         {
                                             if (card.digiXrosCondition.CanTargetCondition_ByPreSelecetedList != null)
                                             {
-                                                if (!card.digiXrosCondition.CanTargetCondition_ByPreSelecetedList(selectedDigicrossCards, targetCard))
+                                                if (!card.digiXrosCondition.CanTargetCondition_ByPreSelecetedList(PreviouslySelectedDigicrossCards, targetCard))
                                                 {
                                                     return false;
                                                 }
@@ -360,9 +404,11 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
     {
         GManager.instance.turnStateMachine.isSync = true;
 
-        selectedDigicrossCards = new List<CardSource>();
+        PlayCardTuple cardTuple = GetOrMakeTupleForCard(card);
 
-        playCard = card;
+        selectedDigicrossCards = cardTuple.SelectedDigicrossCards;
+
+        PreviouslySelectedDigicrossCards = GetPreviouslySelected();
 
         if (card != null)
         {
@@ -518,7 +564,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                         {
                             GManager.instance.commandText.OpenCommandText($"The opponent is choosing from which area to select {element.selectMessage}.", digiXros: true);
 
-                            #region AIƒ‚[ƒh
+                            #region AIãƒ¢ãƒ¼ãƒ‰
                             if (GManager.instance.IsAI)
                             {
                                 List<int> indexes = new List<int>();
@@ -600,7 +646,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 
             IEnumerator SelectCardCoroutine(CardSource cardSource)
             {
-                selectedDigicrossCards.Add(cardSource);
+                AddSelectedCard(cardSource);
 
                 yield return null;
             }
@@ -624,7 +670,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
     }
     #endregion
 
-    #region Select Battle Area Permanent
+    #region Select Battle Area Permanent
     IEnumerator SelectBattleAreaPermanent(DigiXrosCondition digiXrosCondition, DigiXrosConditionElement element, CardSource card)
     {
         bool CanSelectPermanentCondition(Permanent permanent) => permanent.TopCard.Owner.GetBattleAreaPermanents().Contains(permanent) && CanSelectDigiXros(element, permanent.TopCard, card);
@@ -658,7 +704,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 
             IEnumerator SelectPermanentCoroutine(Permanent permanent)
             {
-                selectedDigicrossCards.Add(permanent.TopCard);
+                AddSelectedCard(permanent.TopCard);
 
                 yield return null;
             }
@@ -775,7 +821,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 
                     IEnumerator SelectCardCoroutine(CardSource cardSource)
                     {
-                        selectedDigicrossCards.Add(cardSource);
+                        AddSelectedCard(cardSource);
 
                         yield return null;
                     }
@@ -840,7 +886,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 
             IEnumerator SelectCardCoroutine(CardSource cardSource)
             {
-                selectedDigicrossCards.Add(cardSource);
+                AddSelectedCard(cardSource);
 
                 yield return null;
             }
@@ -872,6 +918,33 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
     }
     #endregion
 
+    #region Check if card was DigiXrosed
+    public bool WasDigiXrosed(CardSource card)
+    {
+        return GetTupleForCard(card) != null;
+    }
+    #endregion
+
+    #region Get Count of Digivolution Cards for Card
+    public int GetSelectedCardCount(CardSource card)
+    {
+        PlayCardTuple cardTuple = GetTupleForCard(card);
+        if (cardTuple != null)
+        {
+            return cardTuple.SelectedDigicrossCards.Count;
+        }
+        return 0;
+    }
+    #endregion
+
+    #region Get AddDigivolutionCardInfos
+    public List<AddDigivolutionCardsInfo> GetAddDigivolutionCardInfos(CardSource card)
+    {
+        PlayCardTuple cardTuple = GetOrMakeTupleForCard(card);
+        return cardTuple.AddDigivolutionCardInfos;
+    }
+    #endregion
+
     #region Add Digivolution Cards
     public IEnumerator AddDigivolutiuonCards(CardSource card)
     {
@@ -879,10 +952,13 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
         {
             if (card != null)
             {
-                if (card == playCard)
+                PlayCardTuple cardTuple = GetTupleForCard(card);
+                if (cardTuple != null)
                 {
                     if (card.PermanentOfThisCard() != null)
                     {
+                        selectedDigicrossCards = cardTuple.SelectedDigicrossCards;
+
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(selectedDigicrossCards, "Digixros Cards", true, true));
 
                         foreach (CardSource cardSource in selectedDigicrossCards)
@@ -927,81 +1003,83 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
     }
     #endregion
 
-    #region Œø‰Ê‚É‚æ‚Á‚Äi‰»Œ³‚ğ•t—^(“V–ìƒ†ƒE(BT10),ƒVƒƒƒEƒgƒ‚ƒ“X7ƒXƒyƒŠƒIƒ‹ƒ‚[ƒh(BT12))
+    #region åŠ¹æœã«ã‚ˆã£ã¦é€²åŒ–å…ƒã‚’ä»˜ä¸(å¤©é‡ãƒ¦ã‚¦(BT10),ã‚·ãƒ£ã‚¦ãƒˆãƒ¢ãƒ³X7ã‚¹ãƒšãƒªã‚ªãƒ«ãƒ¢ãƒ¼ãƒ‰(BT12))
     public IEnumerator AddDigivolutiuonCardsByEffect(CardSource card)
     {
-        if (addDigivolutionCardInfos.Count >= 1)
+        PlayCardTuple cardTuple = GetTupleForCard(card);
+        if (cardTuple != null)
         {
-            if (card != null)
+            List<AddDigivolutionCardsInfo> addDigivolutionCardInfos = cardTuple.AddDigivolutionCardInfos;
+            if (addDigivolutionCardInfos.Count >= 1)
             {
-                if (card.PermanentOfThisCard() != null)
+                if (card != null)
                 {
-                    List<CardSource> addedCards = new List<CardSource>();
-
-                    foreach (AddDigivolutionCardsInfo info in addDigivolutionCardInfos)
+                    if (card.PermanentOfThisCard() != null)
                     {
-                        List<CardSource> underTamerCards = new List<CardSource>();
-                        List<Permanent> digimonPermanents = new List<Permanent>();
-                        List<CardSource> trashCards = new List<CardSource>();
-                        List<CardSource> secuirtyCards = new List<CardSource>();
+                        List<CardSource> addedCards = new List<CardSource>();
 
-                        foreach (CardSource cardSource in info.cardSources)
+                        foreach (AddDigivolutionCardsInfo info in addDigivolutionCardInfos)
                         {
-                            if (isTamerDigivolutionCard(cardSource))
+                            List<CardSource> underTamerCards = new List<CardSource>();
+                            List<Permanent> digimonPermanents = new List<Permanent>();
+                            List<CardSource> trashCards = new List<CardSource>();
+                            List<CardSource> secuirtyCards = new List<CardSource>();
+
+                            foreach (CardSource cardSource in info.cardSources)
                             {
-                                underTamerCards.Add(cardSource);
-                                addedCards.Add(cardSource);
+                                if (isTamerDigivolutionCard(cardSource))
+                                {
+                                    underTamerCards.Add(cardSource);
+                                    addedCards.Add(cardSource);
+                                }
+
+                                else if (isBattleAreaCard(cardSource))
+                                {
+                                    digimonPermanents.Add(cardSource.PermanentOfThisCard());
+                                    addedCards.Add(cardSource);
+                                }
+                                else if (isTrashCard(cardSource))
+                                {
+                                    trashCards.Add(cardSource);
+                                    addedCards.Add(cardSource);
+                                }
+
+                                else if (isSecurityCard(cardSource))
+                                {
+                                    secuirtyCards.Add(cardSource);
+                                    addedCards.Add(cardSource);
+                                }
                             }
 
-                            else if (isBattleAreaCard(cardSource))
+                            if (underTamerCards.Count >= 1)
                             {
-                                digimonPermanents.Add(cardSource.PermanentOfThisCard());
-                                addedCards.Add(cardSource);
-                            }
-                            else if (isTrashCard(cardSource))
-                            {
-                                trashCards.Add(cardSource);
-                                addedCards.Add(cardSource);
+                                yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(underTamerCards, info.cardEffect));
                             }
 
-                            else if (isSecurityCard(cardSource))
+                            if (digimonPermanents.Count >= 1)
                             {
-                                secuirtyCards.Add(cardSource);
-                                addedCards.Add(cardSource);
+                                foreach (Permanent digimonPermanent in digimonPermanents)
+                                {
+                                    yield return ContinuousController.instance.StartCoroutine(new IPlacePermanentToDigivolutionCards(new List<Permanent[]>() { new Permanent[] { digimonPermanent, card.PermanentOfThisCard() } }, false, info.cardEffect).PlacePermanentToDigivolutionCards());
+                                }
+                            }
+
+                            if (trashCards.Count >= 1)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(trashCards, info.cardEffect));
+                            }
+
+                            if (secuirtyCards.Count >= 1)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(secuirtyCards, info.cardEffect));
                             }
                         }
 
-                        if (underTamerCards.Count >= 1)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(underTamerCards, info.cardEffect));
-                        }
-
-                        if (digimonPermanents.Count >= 1)
-                        {
-                            foreach (Permanent digimonPermanent in digimonPermanents)
-                            {
-                                yield return ContinuousController.instance.StartCoroutine(new IPlacePermanentToDigivolutionCards(new List<Permanent[]>() { new Permanent[] { digimonPermanent, card.PermanentOfThisCard() } }, false, info.cardEffect).PlacePermanentToDigivolutionCards());
-                            }
-                        }
-
-                        if (trashCards.Count >= 1)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(trashCards, info.cardEffect));
-                        }
-
-                        if (secuirtyCards.Count >= 1)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(secuirtyCards, info.cardEffect));
-                        }
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(addedCards, "Digivolution Cards", true, true));
                     }
-
-                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(addedCards, "Digivolution Cards", true, true));
                 }
             }
         }
-
-        addDigivolutionCardInfos = new List<AddDigivolutionCardsInfo>();
-
         yield return null;
     }
     #endregion


### PR DESCRIPTION
Basic idea is rather than each of these classes representing exactly 1 digixros or assembly, they maintain a mapping between a particular card and a digixros or assembly attempt for that card, since the last time the class was reset.

The classes now also maintain a history of all cardSources already selected to be placed under cards by either class so they do not get selected again and cause conflict.

This should enable multiple digixrosses when several cards are all played at once (BT5-087 Omnimon Zwart and 2 digixros capable black and purple can test, and EX9-047 Eyesmon can test Assembly while being played alongside something else, or even 2 Eyesmon with 8 Shatter mode in trash for full test)

Has been tested to ensure it does not break standard digixros and assembly. Will need to be tested with playing 2+ cards at once of which 1 or more has assembly or digixros, and a double check over the 4 cards that needed to be changed.