### PR TITLE
Fix BT24-025 Can't ignore level on alt digivolution conditions

### DIFF
--- a/Assets/Scripts/CardEffect/BT13/Blue/BT13_028.cs
+++ b/Assets/Scripts/CardEffect/BT13/Blue/BT13_028.cs
@@ -172,7 +172,7 @@ namespace DCGO.CardEffects.BT13
                                         return true;
                                     }
 
-                                    int GetEvoCost(Permanent permanent, CardSource cardSource, bool checkAvailability)
+                                    int GetEvoCost(Permanent permanent, CardSource cardSource, CardEffectCommons.IgnoreRequirement ignore, bool checkAvailability)
                                     {
                                         if (card.Owner.CanIgnoreDigivolutionRequirement(permanent, cardSource))
                                         {

--- a/Assets/Scripts/CardEffect/BT13/Green/BT13_055.cs
+++ b/Assets/Scripts/CardEffect/BT13/Green/BT13_055.cs
@@ -184,7 +184,7 @@ namespace DCGO.CardEffects.BT13
                                         return true;
                                     }
 
-                                    int GetEvoCost(Permanent permanent, CardSource cardSource, bool checkAvailability)
+                                    int GetEvoCost(Permanent permanent, CardSource cardSource, CardEffectCommons.IgnoreRequirement ignore, bool checkAvailability)
                                     {
                                         if (card.Owner.CanIgnoreDigivolutionRequirement(permanent, cardSource))
                                         {

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_043.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_043.cs
@@ -18,10 +18,11 @@ namespace DCGO.CardEffects.BT19
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsCardName("Lucemon") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level >= 5;
+                    return targetPermanent.TopCard.ContainsCardName("Lucemon");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    minLevel: 5,
                     permanentCondition: PermanentCondition,
                     digivolutionCost: 3,
                     ignoreDigivolutionRequirement: false,

--- a/Assets/Scripts/CardEffect/BT24/Yellow/BT24_040.cs
+++ b/Assets/Scripts/CardEffect/BT24/Yellow/BT24_040.cs
@@ -18,11 +18,10 @@ namespace DCGO.CardEffects.BT24
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.IsLevel5
-                        && targetPermanent.TopCard.HasTSTraits;
+                    return targetPermanent.TopCard.HasTSTraits;
                 }
 
-                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(level: 5, permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
             }
 
             #endregion

--- a/Assets/Scripts/CardEffect/BT7/White/BT7_112.cs
+++ b/Assets/Scripts/CardEffect/BT7/White/BT7_112.cs
@@ -270,7 +270,7 @@ public class BT7_112 : CEntity_Effect
                             return true;
                         }
 
-                        int GetEvoCost(Permanent permanent, CardSource cardSource, bool ignoreDigivolutionCondition)
+                        int GetEvoCost(Permanent permanent, CardSource cardSource, CardEffectCommons.IgnoreRequirement ignore, bool ignoreDigivolutionCondition)
                         {
                             if ((CardSourceCondition(cardSource) && PermanentCondition(permanent)))
                             {

--- a/Assets/Scripts/CardEffect/EX6/Purple/EX6_073.cs
+++ b/Assets/Scripts/CardEffect/EX6/Purple/EX6_073.cs
@@ -17,10 +17,11 @@ namespace DCGO.CardEffects.EX6
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Seven Great Demon Lords") && targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level >= 5;
+                    return targetPermanent.TopCard.ContainsTraits("Seven Great Demon Lords");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    minLevel: 5,
                     permanentCondition: PermanentCondition, 
                     digivolutionCost: 6, 
                     ignoreDigivolutionRequirement: false, 

--- a/Assets/Scripts/Script/CardEffectFactory/AddDigivolutionRequirement.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/AddDigivolutionRequirement.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 public partial class CardEffectFactory
 {
     #region Static effect that adds one's own card's digivolution requirement
-    public static AddDigivolutionRequirementClass AddSelfDigivolutionRequirementStaticEffect(Func<Permanent, bool> permanentCondition, int digivolutionCost, bool ignoreDigivolutionRequirement, CardSource card, Func<bool> condition, string effectName = null, Func<CardSource, bool> cardCondition = null, Func<int> costEquation = null)
+    public static AddDigivolutionRequirementClass AddSelfDigivolutionRequirementStaticEffect(Func<Permanent, bool> permanentCondition, int digivolutionCost, bool ignoreDigivolutionRequirement, CardSource card, Func<bool> condition, string effectName = null, Func<CardSource, bool> cardCondition = null, Func<int> costEquation = null, CardColor cardColor = CardColor.None, int level = -1, int minLevel = -1, int maxLevel = -1)
     {
         bool CanUseCondition()
         {
@@ -23,12 +23,16 @@ public partial class CardEffectFactory
             card: card,
             condition: CanUseCondition,
             effectName: effectName ?? "Can digivolve to this card",
-            costEquation: costEquation);
+            costEquation: costEquation,
+            cardColor,
+            level,
+            minLevel,
+            maxLevel);
     }
     #endregion
 
     #region Static effect that adds digivolution requirement
-    public static AddDigivolutionRequirementClass AddDigivolutionRequirementStaticEffect(Func<Permanent, bool> permanentCondition, Func<CardSource, bool> cardCondition, bool ignoreDigivolutionRequirement, int digivolutionCost, bool isInheritedEffect, CardSource card, Func<bool> condition, string effectName, Func<int> costEquation = null)
+    public static AddDigivolutionRequirementClass AddDigivolutionRequirementStaticEffect(Func<Permanent, bool> permanentCondition, Func<CardSource, bool> cardCondition, bool ignoreDigivolutionRequirement, int digivolutionCost, bool isInheritedEffect, CardSource card, Func<bool> condition, string effectName, Func<int> costEquation = null, CardColor cardColor = CardColor.None, int level = -1, int minLevel = -1, int maxLevel = -1)
     {
         AddDigivolutionRequirementClass addDigivolutionRequirementClass = new AddDigivolutionRequirementClass();
         addDigivolutionRequirementClass.SetUpICardEffect(effectName, CanUseCondition, card);
@@ -44,7 +48,7 @@ public partial class CardEffectFactory
             return condition == null || condition();
         }
 
-        int GetEvoCost(Permanent permanent, CardSource cardSource, bool checkAvailability)
+        int GetEvoCost(Permanent permanent, CardSource cardSource, CardEffectCommons.IgnoreRequirement ignore, bool checkAvailability)
         {
             // �i�������𖳎����Đi�����悤�Ƃ��Ă���̂ɁA�i�������𖳎��ł��Ȃ��ꍇ
             if (ignoreDigivolutionRequirement && !cardSource.Owner.CanIgnoreDigivolutionRequirement(permanent, cardSource))
@@ -52,9 +56,26 @@ public partial class CardEffectFactory
                 return -1;
             }
 
-            if (CardCondition(cardSource) && PermanentCondition(permanent))
+            if (cardColor == CardColor.None
+                || ((ignore.Equals(CardEffectCommons.IgnoreRequirement.Color) || ignore.Equals(CardEffectCommons.IgnoreRequirement.All)) 
+                    && cardSource.Owner.CanIgnoreDigivolutionRequirement(permanent, cardSource))
+                || permanent.TopCard.CardColors.Contains(cardColor))
             {
-                return costEquation != null ? costEquation() : digivolutionCost;
+                bool ignoreLevel = (level < 0 && minLevel < 0 && maxLevel < 0) 
+                                || ((ignore.Equals(CardEffectCommons.IgnoreRequirement.Level) || ignore.Equals(CardEffectCommons.IgnoreRequirement.All))
+                                    && cardSource.Owner.CanIgnoreDigivolutionRequirement(permanent, cardSource));
+
+                //Level matters and doesn't have one
+                if(ignoreLevel //If not checking level or of Ignoring level requirements
+                    || (permanent.TopCard.HasLevel //all other checks will require the permanent has a level
+                        && (permanent.TopCard.Level == level //if equal for exact
+                            || ((minLevel < 0 || level >= minLevel) && (maxLevel < 0 || level <= maxLevel))))) //for "or higher", "or lower" conditons, Lucemon (X Antibody)
+                {
+                    if (CardCondition(cardSource) && PermanentCondition(permanent))
+                    {
+                        return costEquation != null ? costEquation() : digivolutionCost;
+                    }
+                }
             }
 
             return -1;

--- a/Assets/Scripts/Script/CardEffectInterfaces.cs
+++ b/Assets/Scripts/Script/CardEffectInterfaces.cs
@@ -317,7 +317,7 @@ public interface ICannotBlockEffect
 #region "Target permanent gets additional digivolution condition" effect
 public interface IAddDigivolutionRequirementEffect
 {
-    int GetEvoCost(Permanent permanent, CardSource cardSource, bool checkAvailability);
+    int GetEvoCost(Permanent permanent, CardSource cardSource, CardEffectCommons.IgnoreRequirement ignore, bool checkAvailability);
 }
 #endregion
 

--- a/Assets/Scripts/Script/CardEffects/AddEvolutionConditionClass.cs
+++ b/Assets/Scripts/Script/CardEffects/AddEvolutionConditionClass.cs
@@ -4,13 +4,13 @@ using UnityEngine;
 using System;
 public class AddDigivolutionRequirementClass : ICardEffect, IAddDigivolutionRequirementEffect
 {
-    Func<Permanent, CardSource, bool, int> _getEvoCost { get; set; }
-    public void SetUpAddDigivolutionRequirementClass(Func<Permanent, CardSource, bool, int> getEvoCost)
+    Func<Permanent, CardSource, CardEffectCommons.IgnoreRequirement, bool, int> _getEvoCost { get; set; }
+    public void SetUpAddDigivolutionRequirementClass(Func<Permanent, CardSource, CardEffectCommons.IgnoreRequirement, bool, int> getEvoCost)
     {
         _getEvoCost = getEvoCost;
     }
 
-    public int GetEvoCost(Permanent permanent, CardSource cardSource, bool isCheckAvailability)
+    public int GetEvoCost(Permanent permanent, CardSource cardSource, CardEffectCommons.IgnoreRequirement ignore, bool isCheckAvailability)
     {
         if (permanent != null && cardSource != null)
         {
@@ -18,7 +18,7 @@ public class AddDigivolutionRequirementClass : ICardEffect, IAddDigivolutionRequ
             {
                 if (_getEvoCost != null)
                 {
-                    return _getEvoCost(permanent, cardSource, isCheckAvailability);
+                    return _getEvoCost(permanent, cardSource, ignore, isCheckAvailability);
                 }
             }
         }

--- a/Assets/Scripts/Script/CardSource.cs
+++ b/Assets/Scripts/Script/CardSource.cs
@@ -426,7 +426,7 @@ public class CardSource : MonoBehaviour
                     .Flat()
                     .Filter(cardEffect => cardEffect is IAddDigivolutionRequirementEffect && cardEffect.CanUse(null))
                     .Map<ICardEffect, Func<Permanent, int>>(cardEffect =>
-                        (targetPermanent) => ((IAddDigivolutionRequirementEffect)cardEffect).GetEvoCost(targetPermanent, this, checkAvailability)))
+                        (targetPermanent) => ((IAddDigivolutionRequirementEffect)cardEffect).GetEvoCost(targetPermanent, this, ignore, checkAvailability)))
                     .ToList();
 
         #endregion
@@ -442,7 +442,7 @@ public class CardSource : MonoBehaviour
                     .Flat()
                     .Filter(cardEffect => cardEffect is IAddDigivolutionRequirementEffect && cardEffect.CanUse(null))
                     .Map<ICardEffect, Func<Permanent, int>>(cardEffect =>
-                        (targetPermanent) => ((IAddDigivolutionRequirementEffect)cardEffect).GetEvoCost(targetPermanent, this, checkAvailability)))
+                        (targetPermanent) => ((IAddDigivolutionRequirementEffect)cardEffect).GetEvoCost(targetPermanent, this, ignore, checkAvailability)))
                     .ToList();
 
         #endregion
@@ -456,7 +456,7 @@ public class CardSource : MonoBehaviour
                     EffectList(EffectTiming.None)
                         .Filter(cardEffect => cardEffect is IAddDigivolutionRequirementEffect && cardEffect.CanUse(null))
                         .Map<ICardEffect, Func<Permanent, int>>(cardEffect =>
-                            (targetPermanent) => ((IAddDigivolutionRequirementEffect)cardEffect).GetEvoCost(targetPermanent, this, checkAvailability)))
+                            (targetPermanent) => ((IAddDigivolutionRequirementEffect)cardEffect).GetEvoCost(targetPermanent, this, ignore, checkAvailability)))
                         .ToList();
         }
 


### PR DESCRIPTION
Alt digivolution conditions now have optional parameters for color, level, min level (for level X or higher conditions, which do already exist) and max level (does not exist yet but made sense while I was there.
I don't recommend we change all 800 current usages of level in alt condition, but we should use this approach moving forward and patch any relevant cards as they come up.
Only 2 cards use Level X or higher, so I have changed those now so any future cards will look at them as examples.