### PR TITLE
Reset used blitz if a new open state is reached in main phase

### DIFF
--- a/Assets/Scripts/Script/TurnStateMachine.cs
+++ b/Assets/Scripts/Script/TurnStateMachine.cs
@@ -920,6 +920,14 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
             ResetMainPhaseParameter();
             #endregion
 
+            #region resetting used blitz
+            if (GManager.instance.attackProcess.UsedBlitz)
+            {
+                if (GManager.instance.turnStateMachine.gameContext.Memory <= 0)
+                    GManager.instance.attackProcess.UsedBlitz = false;
+            }
+            #endregion
+
             yield return GManager.instance.photonWaitController.StartWait("SetMainPhase");
 
             if (gameContext.TurnPhase == GameContext.phase.Main)


### PR DESCRIPTION
Blitz couldn't be activated twice in one turn even in valid scenarios