### PR TITLE
Fix BT7-091 inherited effect not counted as digimon effect

### DIFF
--- a/Assets/Scripts/Script/AutoProcessing.cs
+++ b/Assets/Scripts/Script/AutoProcessing.cs
@@ -64,35 +64,43 @@ public class AutoProcessing : MonoBehaviourPunCallbacks
         CardSource card = skillInfo.CardEffect.EffectSourceCard;
         Permanent permanent = card.PermanentOfThisCard();
 
-        #region set the flag whether it is Digimon's effect
-        if (permanent != null)
-        {
-            if (permanent.IsDigimon)
-            {
-                skillInfo.CardEffect.SetIsDigimonEffect(true);
-            }
-        }
-
-        if (card == GManager.instance.attackProcess.SecurityDigimon)
+        //Inherited and Link effects can only ever be digimon effects
+        if (skillInfo.CardEffect.IsInheritedEffect || skillInfo.CardEffect.IsLinkedEffect)
         {
             skillInfo.CardEffect.SetIsDigimonEffect(true);
         }
-        #endregion
-
-        #region set the flag whether it is Tamer's effect
-        if (permanent != null)
+        else
         {
-            if (permanent.IsTamer)
+            #region set the flag whether it is Digimon's effect
+            if (permanent != null)
+            {
+                if (permanent.IsDigimon)
+                {
+                    skillInfo.CardEffect.SetIsDigimonEffect(true);
+                }
+            }
+
+            if (card == GManager.instance.attackProcess.SecurityDigimon)
+            {
+                skillInfo.CardEffect.SetIsDigimonEffect(true);
+            }
+            #endregion
+
+            #region set the flag whether it is Tamer's effect
+            if (permanent != null)
+            {
+                if (permanent.IsTamer)
+                {
+                    skillInfo.CardEffect.SetIsTamerEffect(true);
+                }
+            }
+
+            else if (card.IsTamer)
             {
                 skillInfo.CardEffect.SetIsTamerEffect(true);
             }
+            #endregion
         }
-
-        else if (card.IsTamer)
-        {
-            skillInfo.CardEffect.SetIsTamerEffect(true);
-        }
-        #endregion
 
         #region set permanent and topCard when triggered
         ((ActivateICardEffect)skillInfo.CardEffect).PermanentWhenTriggered = permanent;

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -40,8 +40,15 @@ public abstract class ICardEffect
 
         if (!(this is ActivateICardEffect))
         {
-            SetIsDigimonEffect(card != null && CardEffectCommons.IsExistOnBattleArea(card) && card.PermanentOfThisCard().IsDigimon);
-            SetIsTamerEffect(card != null && CardEffectCommons.IsExistOnBattleArea(card) && card.PermanentOfThisCard().IsTamer);
+            if (IsInheritedEffect || IsLinkedEffect)
+            {
+                SetIsDigimonEffect(true);
+            }
+            else if (card != null && CardEffectCommons.IsExistOnBattleArea(card))
+            {
+                SetIsDigimonEffect(card.PermanentOfThisCard().IsDigimon);
+                SetIsTamerEffect(card.PermanentOfThisCard().IsTamer);
+            }
         }
     }
 

--- a/Assets/Scripts/Script/MultipleSkills.cs
+++ b/Assets/Scripts/Script/MultipleSkills.cs
@@ -92,20 +92,27 @@ public class MultipleSkills : MonoBehaviourPunCallbacks
 
                         if (card != null)
                         {
-                            if (card.PermanentOfThisCard() != null)
-                            {
-                                skillInfo.CardEffect.SetIsDigimonEffect(card.PermanentOfThisCard().IsDigimon);
-                                skillInfo.CardEffect.SetIsTamerEffect(card.PermanentOfThisCard().IsTamer);
-                            }
-
-                            else
-                            {
-                                skillInfo.CardEffect.SetIsTamerEffect(card.IsTamer);
-                            }
-
-                            if (card == GManager.instance.attackProcess.SecurityDigimon)
+                            if (skillInfo.CardEffect.IsInheritedEffect || skillInfo.CardEffect.IsLinkedEffect)
                             {
                                 skillInfo.CardEffect.SetIsDigimonEffect(true);
+                            }
+                            else
+                            {
+                                if (card.PermanentOfThisCard() != null)
+                                {
+                                    skillInfo.CardEffect.SetIsDigimonEffect(card.PermanentOfThisCard().IsDigimon);
+                                    skillInfo.CardEffect.SetIsTamerEffect(card.PermanentOfThisCard().IsTamer);
+                                }
+
+                                else
+                                {
+                                    skillInfo.CardEffect.SetIsTamerEffect(card.IsTamer);
+                                }
+
+                                if (card == GManager.instance.attackProcess.SecurityDigimon)
+                                {
+                                    skillInfo.CardEffect.SetIsDigimonEffect(true);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Every location that currently sets IsTamer has been altered here. If the effect is inherited or Link it can only be a Digimon effect, so this sets it to Digimon effect and does not run any of the other current checks.

Some options were using IsInherited as a way for their effects to work while under a card, they should now use activateClass.SetIsEffectOfCard(true); instead. (As a follow up to this PR, Check Three Musketeers options)