### PR TITLE
Fix cannot tell which Digivolution card is currently processing

### DIFF
--- a/Assets/Scripts/CardEffect/BT22/White/BT22_007.cs
+++ b/Assets/Scripts/CardEffect/BT22/White/BT22_007.cs
@@ -99,7 +99,7 @@ namespace DCGO.CardEffects.BT22
                                     canEndNotMax: false,
                                     isShowOpponent: true,
                                     mode: SelectCardEffect.Mode.Custom,
-                                    root: SelectCardEffect.Root.Custom,
+                                    root: SelectCardEffect.Root.DigivolutionCards,
                                     customRootCardList: thisPermanent.DigivolutionCards,
                                     canLookReverseCard: true,
                                     selectPlayer: card.Owner,

--- a/Assets/Scripts/CardEffect/BT23/White/BT23_072.cs
+++ b/Assets/Scripts/CardEffect/BT23/White/BT23_072.cs
@@ -239,7 +239,7 @@ namespace DCGO.CardEffects.BT23
                                 canEndNotMax: false,
                                 isShowOpponent: true,
                                 mode: SelectCardEffect.Mode.Custom,
-                                root: SelectCardEffect.Root.Custom,
+                                root: SelectCardEffect.Root.DigivolutionCards,
                                 customRootCardList: selectedPermanent.DigivolutionCards,
                                 canLookReverseCard: false,
                                 selectPlayer: card.Owner,

--- a/Assets/Scripts/CardEffect/EX5/White/EX5_070.cs
+++ b/Assets/Scripts/CardEffect/EX5/White/EX5_070.cs
@@ -256,7 +256,7 @@ public class EX5_070 : CEntity_Effect
                                     canEndNotMax: false,
                                     isShowOpponent: true,
                                     mode: SelectCardEffect.Mode.AddHand,
-                                    root: SelectCardEffect.Root.Custom,
+                                    root: SelectCardEffect.Root.DigivolutionCards,
                                     customRootCardList: card.PermanentOfThisCard().DigivolutionCards,
                                     canLookReverseCard: true,
                                     selectPlayer: card.Owner,

--- a/Assets/Scripts/Script/SelectCardEffect.cs
+++ b/Assets/Scripts/Script/SelectCardEffect.cs
@@ -471,7 +471,7 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
                         {
                             if (_skillInfos.Count == 0)
                             {
-                                if (_root == Root.Trash)
+                                if (_root == Root.Trash || _root == Root.DigivolutionCards)
                                 {
                                     SkillInfo[] skillInfoArray = new SkillInfo[RootCards.Count];
 


### PR DESCRIPTION
If 2 King Drasil under Mother Eater for example, or 2 X Antibody Protoform after a DNa digivolve trigger at once, currently you cannot tell which you are currently resolving and risk removing the pending one from the stack, getting only 1 effect