### PR TITLE
Set Correct Source Card for Added Effects

### DIFF
--- a/Assets/Scripts/Script/CardEffects/AddSkillClass.cs
+++ b/Assets/Scripts/Script/CardEffects/AddSkillClass.cs
@@ -19,7 +19,10 @@ public class AddSkillClass : ICardEffect, IAddSkillEffect
             getCardEffect = _getEffects(card, getCardEffect, timing);
         }
 
-        SetEffectSourceCard(card);
+        foreach (ICardEffect effect in getCardEffect)
+        {
+            effect.SetEffectSourceCard(card);
+        }
 
         return getCardEffect;
     }


### PR DESCRIPTION
An attempt to fix the issue where effects from other cards were incorrectly sharing timing even if you have multiple of them. The Gammamon level 5s being big sufferers of this.

Testing example: BT10-011 or BT21-077 as top card and/or via inheritable. with 2 EX10-042 for example, and add a card to digivolution cards via BT21-069.
Expected result: both EX10-042 shared effects trigger