### PR TITLE
ST21-09 Unregister OPT use if no processing occured

### DIFF
--- a/Assets/Scripts/CardEffect/ST21/Green/ST21_09.cs
+++ b/Assets/Scripts/CardEffect/ST21/Green/ST21_09.cs
@@ -228,6 +228,7 @@ namespace DCGO.CardEffects.ST21
                 {
                     List<Permanent> etbPermanents = new List<Permanent>();
                     List<Hashtable> hashtables = CardEffectCommons.GetHashtablesFromHashtable(hashtable);
+                    bool activated = false;
 
                     if (hashtables != null)
                     {
@@ -246,6 +247,8 @@ namespace DCGO.CardEffects.ST21
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(MyDigimonAlliance))
                         {
+                            activated = true;
+
                             SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                             selectPermanentEffect.SetUp(
@@ -298,6 +301,8 @@ namespace DCGO.CardEffects.ST21
                         {
                             selectedPermanent = permanent;
 
+                            activated = true;
+
                             yield return null;
                         }
 
@@ -313,6 +318,11 @@ namespace DCGO.CardEffects.ST21
 
                             yield return ContinuousController.instance.StartCoroutine(selectAttackEffect.Activate());
                         }
+                    }
+
+                    if(!activated)
+                    {
+                        activateClass.RemoveUse();
                     }
                 }
             }

--- a/Assets/Scripts/Script/CEntity_EffectController.cs
+++ b/Assets/Scripts/Script/CEntity_EffectController.cs
@@ -273,6 +273,13 @@ public class CEntity_EffectController : MonoBehaviour
         UseEffectsThisTurn.Add(cardEffect);
     }
     #endregion
+
+    #region Remove a use of the effect this turn
+    public void RemoveUseEffectThisTurn(ICardEffect cardEffect)
+    {
+        UseEffectsThisTurn.Remove(cardEffect);
+    }
+    #endregion
 }
 
 public class EmptyEffectClass : CEntity_Effect

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -1199,6 +1199,13 @@ public static class ActivateICardEffectExtensionClass
     }
 
     #endregion
+
+    #region remove a usage of an X Per Turn
+    public static void RemoveUse(this ActivateICardEffect activateICardEffect)
+    {
+        ((ICardEffect)activateICardEffect).EffectSourceCard.cEntity_EffectController.RemoveUseEffectThisTurn((ICardEffect)activateICardEffect);
+    }
+    #endregion
 }
 
 #endregion


### PR DESCRIPTION
ST21-09 as the proof so we can test it then this can be applied to many more cards that need the option to reset OPT if no processing occurred