### PR TITLE
Fix EX11: 29, 33, 40, 42 Not showing 3 options correctly

### DIFF
--- a/Assets/Scripts/CardEffect/EX11/Black/EX11_040.cs
+++ b/Assets/Scripts/CardEffect/EX11/Black/EX11_040.cs
@@ -43,18 +43,15 @@ namespace DCGO.CardEffects.EX11
                 if (validHandCard || validDigivolutionCard)
                 {
                     List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>();
-                    int index = 0;
                     if (validHandCard)
                     {
-                        selectionElements.Add(new (message: $"Link Maquinamon from hand", value : 1, spriteIndex: index));
-                        index++;
+                        selectionElements.Add(new (message: $"Link Maquinamon from hand", value : 1, spriteIndex: 0));
                     }
                     if (validDigivolutionCard)
                     {
-                        selectionElements.Add(new (message: $"Link Maquinamon from this Digimon's Digivolution Cards", value : 2, spriteIndex: index));
-                        index++;
+                        selectionElements.Add(new (message: $"Link Maquinamon from this Digimon's Digivolution Cards", value : 2, spriteIndex: 0));
                     };
-                    selectionElements.Add(new (message: $"Don't link", value: 3, spriteIndex: index));
+                    selectionElements.Add(new (message: $"Don't link", value: 3, spriteIndex: 1));
 
                     string selectPlayerMessage = "Will you link a Maquinamon?";
                     string notSelectPlayerMessage = "The opponent is choosing from which area to select a card.";

--- a/Assets/Scripts/CardEffect/EX11/Black/EX11_042.cs
+++ b/Assets/Scripts/CardEffect/EX11/Black/EX11_042.cs
@@ -42,18 +42,15 @@ namespace DCGO.CardEffects.EX11
                 if (validHandCard || validLinkCard)
                 {
                     List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>();
-                    int index = 0;
                     if (validHandCard)
                     {
-                        selectionElements.Add(new (message: $"Play Maquinamon from hand", value : 1, spriteIndex: index));
-                        index++;
+                        selectionElements.Add(new (message: $"Play Maquinamon from hand", value : 1, spriteIndex: 0));
                     }
                     if (validLinkCard)
                     {
-                        selectionElements.Add(new (message: $"Play Maquinamon from this Digimon's Link Cards", value : 2, spriteIndex: index));
-                        index++;
+                        selectionElements.Add(new (message: $"Play Maquinamon from this Digimon's Link Cards", value : 2, spriteIndex: 0));
                     };
-                    selectionElements.Add( new (message: $"Don't link", value: 3, spriteIndex: index));
+                    selectionElements.Add( new (message: $"Don't link", value: 3, spriteIndex: 1));
 
                     string selectPlayerMessage = "Will you play a Maquinamon?";
                     string notSelectPlayerMessage = "The opponent is choosing from which area to select a card.";

--- a/Assets/Scripts/CardEffect/EX11/Green/EX11_029.cs
+++ b/Assets/Scripts/CardEffect/EX11/Green/EX11_029.cs
@@ -43,18 +43,15 @@ namespace DCGO.CardEffects.EX11
                 if (validHandCard || validDigivolutionCard)
                 {
                     List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>();
-                    int index = 0;
                     if (validHandCard)
                     {
-                        selectionElements.Add(new (message: $"Link Maquinamon from hand", value : 1, spriteIndex: index));
-                        index++;
+                        selectionElements.Add(new (message: $"Link Maquinamon from hand", value : 1, spriteIndex: 0));
                     }
                     if (validDigivolutionCard)
                     {
-                        selectionElements.Add(new (message: $"Link Maquinamon from this Digimon's Digivolution Cards", value : 2, spriteIndex: index));
-                        index++;
+                        selectionElements.Add(new (message: $"Link Maquinamon from this Digimon's Digivolution Cards", value : 2, spriteIndex: 0));
                     };
-                    selectionElements.Add(new (message: $"Don't link", value: 3, spriteIndex: index));
+                    selectionElements.Add(new (message: $"Don't link", value: 3, spriteIndex: 1));
 
                     string selectPlayerMessage = "Will you link a Maquinamon?";
                     string notSelectPlayerMessage = "The opponent is choosing from which area to select a card.";

--- a/Assets/Scripts/CardEffect/EX11/Green/EX11_033.cs
+++ b/Assets/Scripts/CardEffect/EX11/Green/EX11_033.cs
@@ -42,18 +42,15 @@ namespace DCGO.CardEffects.EX11
                 if (validHandCard || validLinkCard)
                 {
                     List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>();
-                    int index = 0;
                     if (validHandCard)
                     {
-                        selectionElements.Add(new (message: $"Play Maquinamon from hand", value : 1, spriteIndex: index));
-                        index++;
+                        selectionElements.Add(new (message: $"Play Maquinamon from hand", value : 1, spriteIndex: 0));
                     }
                     if (validLinkCard)
                     {
-                        selectionElements.Add(new (message: $"Play Maquinamon from this Digimon's Link Cards", value : 2, spriteIndex: index));
-                        index++;
+                        selectionElements.Add(new (message: $"Play Maquinamon from this Digimon's Link Cards", value : 2, spriteIndex: 0));
                     };
-                    selectionElements.Add( new (message: $"Don't link", value: 3, spriteIndex: index));
+                    selectionElements.Add( new (message: $"Don't link", value: 3, spriteIndex: 1));
 
                     string selectPlayerMessage = "Will you play a Maquinamon?";
                     string notSelectPlayerMessage = "The opponent is choosing from which area to select a card.";


### PR DESCRIPTION
Was caught and fixed for Maquinamon and ExMaquinamon in beta, but noticed it wasn't for the level 4s and 5s