### PR TITLE
Implement different method for self deleting at turn end

### DIFF
--- a/Assets/Scripts/CardEffect/BT23/Blue/BT23_017.cs
+++ b/Assets/Scripts/CardEffect/BT23/Blue/BT23_017.cs
@@ -235,67 +235,8 @@ namespace DCGO.CardEffects.BT23
 
                                 #region Delete Digimon Played
 
-                                ActivateClass activateClass1 = new ActivateClass();
-                                activateClass1.SetUpICardEffect("Delete the Digimon", CanUseCondition2, playedDigimon.TopCard);
-                                activateClass1.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine1, -1, false, EffectDiscription1());
-                                activateClass1.SetEffectSourcePermanent(playedDigimon);
-                                playedDigimon.UntilOpponentTurnEndEffects.Add(GetCardEffect);
-
-                                if (!playedDigimon.TopCard.CanNotBeAffected(activateClass))
-                                {
-                                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(playedDigimon));
-                                }
-
-                                string EffectDiscription1()
-                                {
-                                    return "[End of Opponents Turn] Delete this Digimon.";
-                                }
-
-                                bool CanUseCondition2(Hashtable hashtable1)
-                                {
-                                    if (CardEffectCommons.IsOpponentTurn(card))
-                                    {
-                                        if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(playedDigimon, playedDigimon.TopCard))
-                                        {
-                                            return true;
-                                        }
-                                    }
-
-                                    return false;
-                                }
-
-                                bool CanActivateCondition1(Hashtable hashtable1)
-                                {
-                                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedDigimon))
-                                    {
-                                        if (!playedDigimon.TopCard.CanNotBeAffected(activateClass))
-                                        {
-                                            return true;
-                                        }
-                                    }
-
-                                    return false;
-                                }
-
-                                IEnumerator ActivateCoroutine1(Hashtable _hashtable1)
-                                {
-                                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedDigimon))
-                                    {
-                                        yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(
-                                        new List<Permanent>() { playedDigimon },
-                                        CardEffectCommons.CardEffectHashtable(activateClass1)).Destroy());
-                                    }
-                                }
-
-                                ICardEffect GetCardEffect(EffectTiming _timing)
-                                {
-                                    if (_timing == EffectTiming.OnEndTurn)
-                                    {
-                                        return activateClass1;
-                                    }
-
-                                    return null;
-                                }
+                                yield return ContinuousController.instance.StartCoroutine(
+                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd));
 
                                 #endregion
                             }

--- a/Assets/Scripts/CardEffect/BT23/Green/BT23_037.cs
+++ b/Assets/Scripts/CardEffect/BT23/Green/BT23_037.cs
@@ -175,68 +175,9 @@ namespace DCGO.CardEffects.BT23
 
                                 #region Delete Digimon Played
 
-                                ActivateClass activateClass1 = new ActivateClass();
-                                activateClass1.SetUpICardEffect("Delete the Digimon", CanUseCondition2, playedDigimon.TopCard);
-                                activateClass1.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine1, -1, false, EffectDiscription1());
-                                activateClass1.SetEffectSourcePermanent(playedDigimon);
-                                playedDigimon.UntilOpponentTurnEndEffects.Add(GetCardEffect);
-
-                                if (!playedDigimon.TopCard.CanNotBeAffected(activateClass1))
-                                {
-                                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(playedDigimon));
-                                }
-
-                                string EffectDiscription1()
-                                {
-                                    return "[End of Opponents Turn] Delete this Digimon.";
-                                }
-
-                                bool CanUseCondition2(Hashtable hashtable1)
-                                {
-                                    if (CardEffectCommons.IsOpponentTurn(card))
-                                    {
-                                        if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(playedDigimon, playedDigimon.TopCard))
-                                        {
-                                            return true;
-                                        }
-                                    }
-
-                                    return false;
-                                }
-
-                                bool CanActivateCondition1(Hashtable hashtable1)
-                                {
-                                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedDigimon))
-                                    {
-                                        if (!playedDigimon.TopCard.CanNotBeAffected(activateClass))
-                                        {
-                                            return true;
-                                        }
-                                    }
-
-                                    return false;
-                                }
-
-                                IEnumerator ActivateCoroutine1(Hashtable _hashtable1)
-                                {
-                                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedDigimon))
-                                    {
-                                        yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(
-                                        new List<Permanent>() { playedDigimon },
-                                        CardEffectCommons.CardEffectHashtable(activateClass1)).Destroy());
-                                    }
-                                }
-
-                                ICardEffect GetCardEffect(EffectTiming _timing)
-                                {
-                                    if (_timing == EffectTiming.OnEndTurn)
-                                    {
-                                        return activateClass1;
-                                    }
-
-                                    return null;
-                                }
-
+                                yield return ContinuousController.instance.StartCoroutine(
+                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd));
+                                
                                 #endregion
                             }
                             #endregion

--- a/Assets/Scripts/CardEffect/BT23/Red/BT23_048.cs
+++ b/Assets/Scripts/CardEffect/BT23/Red/BT23_048.cs
@@ -204,68 +204,9 @@ namespace DCGO.CardEffects.BT23
 
                                 #region Delete Digimon Played
 
-                                ActivateClass activateClass1 = new ActivateClass();
-                                activateClass1.SetUpICardEffect("Delete the Digimon", CanUseCondition2, playedDigimon.TopCard);
-                                activateClass1.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine1, -1, false, EffectDiscription1());
-                                activateClass1.SetEffectSourcePermanent(playedDigimon);
-                                playedDigimon.UntilOpponentTurnEndEffects.Add(GetCardEffect);
-
-                                if (!playedDigimon.TopCard.CanNotBeAffected(activateClass))
-                                {
-                                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(playedDigimon));
-                                }
-
-                                string EffectDiscription1()
-                                {
-                                    return "[End of Opponents Turn] Delete this Digimon.";
-                                }
-
-                                bool CanUseCondition2(Hashtable hashtable1)
-                                {
-                                    if (CardEffectCommons.IsOpponentTurn(card))
-                                    {
-                                        if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(playedDigimon, playedDigimon.TopCard))
-                                        {
-                                            return true;
-                                        }
-                                    }
-
-                                    return false;
-                                }
-
-                                bool CanActivateCondition1(Hashtable hashtable1)
-                                {
-                                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedDigimon))
-                                    {
-                                        if (!playedDigimon.TopCard.CanNotBeAffected(activateClass))
-                                        {
-                                            return true;
-                                        }
-                                    }
-
-                                    return false;
-                                }
-
-                                IEnumerator ActivateCoroutine1(Hashtable _hashtable1)
-                                {
-                                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedDigimon))
-                                    {
-                                        yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(
-                                        new List<Permanent>() { playedDigimon },
-                                        CardEffectCommons.CardEffectHashtable(activateClass1)).Destroy());
-                                    }
-                                }
-
-                                ICardEffect GetCardEffect(EffectTiming _timing)
-                                {
-                                    if (_timing == EffectTiming.OnEndTurn)
-                                    {
-                                        return activateClass1;
-                                    }
-
-                                    return null;
-                                }
-
+                                yield return ContinuousController.instance.StartCoroutine(
+                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd));
+                                
                                 #endregion
                             }
                             #endregion

--- a/Assets/Scripts/CardEffect/EX11/Yellow/EX11_022.cs
+++ b/Assets/Scripts/CardEffect/EX11/Yellow/EX11_022.cs
@@ -161,31 +161,8 @@ namespace DCGO.CardEffects.EX11
 
                     if (selectedCard != null)
                     {
-
-                        Permanent selectedPermanent = selectedCard.PermanentOfThisCard();
-
-                        ActivateClass activateClass1 = new ActivateClass();
-                        activateClass1.SetUpICardEffect("Delete this Digimon", CanUseCondition2, card);
-                        activateClass1.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine1, -1, false, "");
-                        activateClass1.SetEffectSourcePermanent(selectedPermanent);
-                        CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: activateClass1, timing: EffectTiming.OnEndTurn);
-
-                        bool CanUseCondition2(Hashtable hashtable)
-                        {
-                            return true;
-                        }
-
-                        bool CanActivateCondition1(Hashtable hashtable)
-                        {
-                            return selectedPermanent.TopCard != null
-                                && selectedPermanent.CanBeDestroyedBySkill(activateClass1)
-                                && !selectedPermanent.TopCard.CanNotBeAffected(activateClass1);
-                        }
-
-                        IEnumerator ActivateCoroutine1(Hashtable _hashtable1)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(new List<Permanent>() { selectedPermanent }, CardEffectCommons.CardEffectHashtable(activateClass1)).Destroy());
-                        }
+                        yield return ContinuousController.instance.StartCoroutine(
+                            CardEffectCommons.AddSelfDeleteEffect(selectedCard.PermanentOfThisCard(), CardEffectCommons.DeleteTiming.AtTurnEnd));
                     }
 
                     #endregion

--- a/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/DeleteSelf.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/DeleteSelf.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public partial class CardEffectCommons
+{
+    public enum DeleteTiming
+    {
+        AtTurnEnd,
+        AtOwnTurnEnd,
+        AtOpponentTurnEnd
+    }
+
+    public static IEnumerator AddSelfDeleteEffect(Permanent permanent, DeleteTiming deleteTiming)
+    {
+        bool deleteOnOwnturn = deleteTiming != DeleteTiming.AtOpponentTurnEnd;
+        bool deleteOnOpponentsTurn = deleteTiming != DeleteTiming.AtOwnTurnEnd;
+        permanent.PermanentEffects.Add(GetCardEffect);
+
+        ICardEffect GetCardEffect(EffectTiming timing)
+        {
+            if (timing == EffectTiming.OnEndTurn)
+            {
+                return CardEffectFactory.DeleteSelfEffect(permanent, deleteOnOwnturn, deleteOnOpponentsTurn);
+            }
+            return null;
+        }
+
+        yield return null;
+    }
+}

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -715,4 +715,44 @@ public partial class CardEffectFactory
     }
 
     #endregion
+
+    #region Effect of a Permanent to Delete Itself
+
+    public static ActivateClass DeleteSelfEffect(Permanent permanent, bool deleteOnOwnturn = true, bool deleteOnOpponentsTurn = true)
+    {
+        ActivateClass activateClass = new ActivateClass();
+        activateClass.SetUpICardEffect("Delete this Digimon", CanUseCondition, permanent.TopCard);
+        activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, "");
+        activateClass.SetEffectSourcePermanent(permanent);
+        return activateClass;
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            if (permanent.TopCard != null && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard))
+            {
+                if (CardEffectCommons.IsOwnerTurn(permanent.TopCard))
+                {
+                    return deleteOnOwnturn;
+                }
+                else
+                {
+                    return deleteOnOpponentsTurn;
+                }
+            }
+            return false;
+        }
+
+        bool CanActivateCondition(Hashtable hashtable)
+        {
+            return permanent.TopCard != null
+                && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard);
+        }
+
+        IEnumerator ActivateCoroutine(Hashtable hashtable)
+        {
+            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(new List<Permanent>() { permanent }, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Attempt to put the effect to delete on the permanent itself but not on any specific card in the stack.
If this works, the approach could be useful for many other effects that should effect the stack, such as immunity to digimon effect which currently is lost if de-digivolved.

This effect should now attempt to delete the Digimon every time the valid timing occurs, as the rulings state they should, without slowing the game down with player effects that never get cleared.

This can be tested by digivolving the played card into something with Armor Purge.