### PR TITLE
Fix turn passing during attack and execute deleting at wrong step

### DIFF
--- a/Assets/Scripts/Script/AutoProcessing.cs
+++ b/Assets/Scripts/Script/AutoProcessing.cs
@@ -621,7 +621,7 @@ public class AutoProcessing : MonoBehaviourPunCallbacks
     #region Check end of turn
     public IEnumerator EndTurnCheck()
     {
-        if (GManager.instance.turnStateMachine.gameContext.TurnPhase != GameContext.phase.End)
+        if (GManager.instance.turnStateMachine.gameContext.TurnPhase != GameContext.phase.End && !GManager.instance.attackProcess.ActiveAttack())
         {
             if (GManager.instance.turnStateMachine.gameContext.NonTurnPlayer.MemoryForPlayer >= TurnEndMinMemory)
             {
@@ -693,6 +693,16 @@ public class AutoProcessing : MonoBehaviourPunCallbacks
 
             //Automatic processing check timing
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+
+            //Handle attack steps
+            while (GManager.instance.attackProcess.ActiveAttack())
+            {
+                Debug.Log($"Active Attack, {Enum.GetName(typeof(AttackProcess.AttackState),GManager.instance.attackProcess.State)} Step");
+                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.ProcessNextState());
+
+                //自動処理チェックタイミング
+                yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
+            }
 
             if (GManager.instance.turnStateMachine.gameContext.NonTurnPlayer.MemoryForPlayer >= TurnEndMinMemory)
             {

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Execute.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Execute.cs
@@ -65,18 +65,21 @@ public partial class CardEffectCommons
                 defenderCondition: _ => true,
                 cardEffect: activateClass);
 
-            selectAttackEffect.SetAfterOnAttackCoroutine(AfterAttackCoroutine);
-
             yield return ContinuousController.instance.StartCoroutine(selectAttackEffect.Activate());
 
             #endregion
 
             #region Delete this Digimon
 
-            IEnumerator AfterAttackCoroutine()
+            selectedPermanent.UntilEndAttackEffects.Add(GetCardEffect);
+
+            ICardEffect GetCardEffect(EffectTiming timing)
             {
-                yield return ContinuousController.instance.StartCoroutine(
-                    new DestroyPermanentsClass(new List<Permanent>() { selectedPermanent }, CardEffectHashtable(activateClass)).Destroy());
+                if (timing == EffectTiming.OnEndAttack)
+                {
+                    return CardEffectFactory.DeleteSelfEffect(selectedPermanent);
+                }
+                return null;
             }
 
             #endregion

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -715,4 +715,44 @@ public partial class CardEffectFactory
     }
 
     #endregion
+
+    #region Effect of a Permanent to Delete Itself
+
+    public static ActivateClass DeleteSelfEffect(Permanent permanent, bool deleteOnOwnturn = true, bool deleteOnOpponentsTurn = true)
+    {
+        ActivateClass activateClass = new ActivateClass();
+        activateClass.SetUpICardEffect("Delete this Digimon", CanUseCondition, permanent.TopCard);
+        activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, "");
+        activateClass.SetEffectSourcePermanent(permanent);
+        return activateClass;
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            if (permanent.TopCard != null && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard))
+            {
+                if (CardEffectCommons.IsOwnerTurn(permanent.TopCard))
+                {
+                    return deleteOnOwnturn;
+                }
+                else
+                {
+                    return deleteOnOpponentsTurn;
+                }
+            }
+            return false;
+        }
+
+        bool CanActivateCondition(Hashtable hashtable)
+        {
+            return permanent.TopCard != null
+                && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard);
+        }
+
+        IEnumerator ActivateCoroutine(Hashtable hashtable)
+        {
+            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(new List<Permanent>() { permanent }, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Tested by attacking with execute, delete was at correct time, and the turn did not pass so my attacks correctly checked opponent's security and not my own.