### PR TITLE
Update EX11_066.cs

### DIFF
--- a/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
+++ b/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
@@ -293,7 +293,7 @@ namespace DCGO.CardEffects.EX11
                             revealCount: 2,
                             simplifiedSelectCardCondition:
                             new SimplifiedSelectCardConditionClass(
-                                    canTargetCondition: null,
+                                    canTargetCondition: cardSource => cardSource.EqualsCardName("Vemmon") && !cardSource.EqualsCardName("Vemmon"),
                                     message: "",
                                     mode: SelectCardEffect.Mode.Custom,
                                     maxCount: -1,

--- a/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
+++ b/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
@@ -293,7 +293,7 @@ namespace DCGO.CardEffects.EX11
                             revealCount: 2,
                             simplifiedSelectCardCondition:
                             new SimplifiedSelectCardConditionClass(
-                                    canTargetCondition: cardSource => cardSource.EqualsCardName("Vemmon") && !cardSource.EqualsCardName("Vemmon"),
+                                    canTargetCondition: _ => false,
                                     message: "",
                                     mode: SelectCardEffect.Mode.Custom,
                                     maxCount: -1,

--- a/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
+++ b/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
@@ -234,7 +234,6 @@ namespace DCGO.CardEffects.EX11
                                     if (selectedPermament != null)
                                     {
                                         List<CardSource> digivolutionCards_fixed = new List<CardSource>();
-                                        digivolutionCards_fixed.Clear(); // Clear here in cases of multiple loops
                                         if (selectedCards.Count > 1)
                                         {
                                             SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();

--- a/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
+++ b/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
@@ -177,19 +177,16 @@ namespace DCGO.CardEffects.EX11
                         List<CardSource> selectedCards = new List<CardSource>();
 
                         if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, targetPermanents.Contains))
-                        { 
-                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SimplifiedRevealDeckTopCardsAndSelect(
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.RevealDeckTopCardsAndProcessForAll(
                                 revealCount: 2,
-                                simplifiedSelectCardConditions:
-                                new SimplifiedSelectCardConditionClass[]
-                                {
-                                    new(
-                                    canTargetCondition: cardSource => cardSource.EqualsCardName("Vemmon"),
-                                    message: "Select all Vemmon",
-                                    mode: SelectCardEffect.Mode.Custom,
-                                    maxCount: 2,
-                                    selectCardCoroutine: SelectCardCoroutine),
-                                },
+                                simplifiedSelectCardCondition:
+                                new SimplifiedSelectCardConditionClass(
+                                        canTargetCondition: cardSource => cardSource.EqualsCardName("Vemmon"),
+                                        message: "",
+                                        mode: SelectCardEffect.Mode.Custom,
+                                        maxCount: -1,
+                                        selectCardCoroutine: SelectCardCoroutine),
                                 remainingCardsPlace: RemainingCardsPlace.Trash,
                                 activateClass: activateClass
                             ));
@@ -234,62 +231,64 @@ namespace DCGO.CardEffects.EX11
                                     }
                                     else selectedPermament = targetPermanents[0];
 
-                                    List<CardSource> digivolutionCards_fixed = new List<CardSource>();
-                                    digivolutionCards_fixed.Clear(); // Clear here in cases of multiple loops
-
-                                    if (selectedCards.Count > 1)
+                                    if (selectedPermament != null)
                                     {
-                                        SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
-
-                                        selectCardEffect.SetUp(
-                                            canTargetCondition: (cardSource) => true,
-                                            canTargetCondition_ByPreSelecetedList: null,
-                                            canEndSelectCondition: CanEndSelectCondition,
-                                            canNoSelect: () => false,
-                                            selectCardCoroutine: null,
-                                            afterSelectCardCoroutine: AfterSelectCardCoroutine,
-                                            message: "Specify the order to place the cards in the digivolution cards\n(cards will be placed so that cards with lower numbers are on top).",
-                                            maxCount: selectedCards.Count,
-                                            canEndNotMax: true,
-                                            isShowOpponent: true,
-                                            mode: SelectCardEffect.Mode.Custom,
-                                            root: SelectCardEffect.Root.Custom,
-                                            customRootCardList: selectedCards,
-                                            canLookReverseCard: true,
-                                            selectPlayer: card.Owner,
-                                            cardEffect: activateClass);
-
-                                        selectCardEffect.SetUpCustomMessage_ShowCard("Digivolution Cards");
-
-                                        bool CanEndSelectCondition(List<CardSource> cardSources)
+                                        List<CardSource> digivolutionCards_fixed = new List<CardSource>();
+                                        digivolutionCards_fixed.Clear(); // Clear here in cases of multiple loops
+                                        if (selectedCards.Count > 1)
                                         {
-                                            return !CardEffectCommons.HasNoElement(cardSources);
+                                            SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                                            selectCardEffect.SetUp(
+                                                canTargetCondition: (cardSource) => true,
+                                                canTargetCondition_ByPreSelecetedList: null,
+                                                canEndSelectCondition: CanEndSelectCondition,
+                                                canNoSelect: () => false,
+                                                selectCardCoroutine: null,
+                                                afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                                                message: "Specify the order to place the cards in the digivolution cards\n(cards will be placed so that cards with lower numbers are on top).",
+                                                maxCount: selectedCards.Count,
+                                                canEndNotMax: true,
+                                                isShowOpponent: true,
+                                                mode: SelectCardEffect.Mode.Custom,
+                                                root: SelectCardEffect.Root.Custom,
+                                                customRootCardList: selectedCards,
+                                                canLookReverseCard: true,
+                                                selectPlayer: card.Owner,
+                                                cardEffect: activateClass);
+
+                                            selectCardEffect.SetUpCustomMessage_ShowCard("Digivolution Cards");
+
+                                            bool CanEndSelectCondition(List<CardSource> cardSources)
+                                            {
+                                                return !CardEffectCommons.HasNoElement(cardSources);
+                                            }
+
+                                            yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+
+                                            IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                                            {
+                                                digivolutionCards_fixed.AddRange(cardSources);
+                                                selectedCards.RemoveAll(cardSources.Contains);
+                                                yield return null;
+                                            }
+
+                                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(digivolutionCards_fixed, "Digivolution Cards", true, true));
+                                            yield return ContinuousController.instance.StartCoroutine(selectedPermament.AddDigivolutionCardsBottom(digivolutionCards_fixed, activateClass));
                                         }
-
-                                        yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
-
-                                        IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                                        else
                                         {
-                                            digivolutionCards_fixed.AddRange(cardSources);
-                                            selectedCards.RemoveAll(cardSources.Contains);
-                                            yield return null;
+                                            digivolutionCards_fixed.AddRange(selectedCards);
+                                            selectedCards.Clear();
+
+                                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(digivolutionCards_fixed, "Digivolution Cards", true, true));
+                                            yield return ContinuousController.instance.StartCoroutine(selectedPermament.AddDigivolutionCardsBottom(digivolutionCards_fixed, activateClass));
                                         }
-
-                                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(digivolutionCards_fixed, "Digivolution Cards", true, true));
-                                        yield return ContinuousController.instance.StartCoroutine(selectedPermament.AddDigivolutionCardsBottom(digivolutionCards_fixed, activateClass));
-                                    }
-                                    else
-                                    {
-                                        digivolutionCards_fixed.AddRange(selectedCards);
-                                        selectedCards.Clear();
-
-                                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(digivolutionCards_fixed, "Digivolution Cards", true, true));
-                                        yield return ContinuousController.instance.StartCoroutine(selectedPermament.AddDigivolutionCardsBottom(digivolutionCards_fixed, activateClass));
                                     }
                                 }
                             }
                         }
-                        else 
+                        else
                         {
                             yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.RevealDeckTopCardsAndProcessForAll(
                             revealCount: 2,


### PR DESCRIPTION
Ran into one of the Vemmon not being selectable issue once in version 1.14.3. It's damn near impossible to consistently recreate though. Since doing the normal method is bringing up additional dialogue boxes, I'm using the fancy version again. I did narrow down the problem to the selection that starts on line 240 or so of this code. As the next test for that, I'll be removing the clear code as will be shown in the next commit.