### PR TITLE
Partial Fix - Playing 2 digimon at once + Digixros/Assembly

### DIFF
--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -1613,12 +1613,13 @@ public class PlayPermanentClass
                 }
             }
 
-            GManager.instance.GetComponent<SelectDigiXrosClass>().ResetSelectDigiXrosClass();
-            GManager.instance.GetComponent<SelectAssemblyClass>().ResetSelectAssemblyClass();
             GManager.instance.GetComponent<SelectDNACondition>().ResetSelectDNAConditionClass();
 
             yield return GManager.instance.photonWaitController.StartWait("EndPlayPermanent");
         }
+
+        GManager.instance.GetComponent<SelectDigiXrosClass>().ResetSelectDigiXrosClass();
+        GManager.instance.GetComponent<SelectAssemblyClass>().ResetSelectAssemblyClass();
 
         // except [On Play] effect
         bool CardEffectCondition(ICardEffect cardEffect)


### PR DESCRIPTION
This should make it so if you are playing 2 digimon at once and at most 1 has assembly and at most 1 has digixros, it should behave properly. (Millenniummon playing Assembly DM Kimeramon and any 1 other digimon that does not have assembly)
I believe it should work if exactly 1 has assembly and exactly 1 has digixros also.
When playing 2 or more with digixros, all but the last one will still fail. Fixing that will need a bigger approach that so far has not worked.