### PR TITLE
Fix EX11-030 can place security under Kongou

### DIFF
--- a/Assets/Scripts/CardEffect/EX11/Green/EX11_030.cs
+++ b/Assets/Scripts/CardEffect/EX11/Green/EX11_030.cs
@@ -82,7 +82,7 @@ namespace DCGO.CardEffects.EX11
                     break;
                 }
 
-                if (CardEffectCommons.HasMatchConditionOwnersHand(card, IsRoyalBaseDigimon))
+                if (CardEffectCommons.HasMatchConditionOwnersHand(card, IsRoyalBaseDigimon) && card.Owner.CanAddSecurity(activateClass))
                 {
                     SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
 


### PR DESCRIPTION
Apparently SelectHandEffect does not check if it can before it does add security cards. Don't want to touch that right this moment so just updated the card itself to check, which also saves the player having to select a card only for it to do nothing. This may be why it isn't checked in the select hand effect