### PR TITLE
Fix gaining immunity should prevent deletion

### DIFF
--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -3472,7 +3472,8 @@ public class DestroyPermanentsClass
         List<Permanent> destroyTargetPermanents_Fixed = _destroytargetPermanents.Filter(permanent =>
             permanent != null
             && permanent.TopCard != null
-            && permanent.willBeRemoveField);
+            && permanent.willBeRemoveField
+            && permanent.CanBeDestroyedBySkill(cardEffect));
 
         #region "When permanents are deleted" effect
 


### PR DESCRIPTION
If after immediate effects the Digimon now has immunity to deletion, it should not be deleted, but CanBeDestroyedBySkill was not being checked again.

Example scenario: Lucemon: Satan Mode with Lucemon: Larva mode in breeding. Satan mode is reduced to 0 DP and would be deleted. as an immediate effect, Larva Mode is raised and it's All turns starts applying: 0 DP Lucemon Digimon may not be deleted.

In progress DestroyPermanentsClass.Destroy() was proceeding to the deletion as Larva mode had not explicitly removed Satan Mode from deletion