### PR TITLE
Fix 0 DP Digimon being deleted in breeding

### DIFF
--- a/Assets/Scripts/Script/AutoProcessing.cs
+++ b/Assets/Scripts/Script/AutoProcessing.cs
@@ -460,7 +460,7 @@ public class AutoProcessing : MonoBehaviourPunCallbacks
     IEnumerator DigimonLackDPProcess()
     {
         List<Permanent> LackPowerPermanents = GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer
-            .Map(player => player.GetFieldPermanents()
+            .Map(player => player.GetBattleAreaPermanents()
             .Filter(IsDigimonLackDP)).Flat();
 
         if (LackPowerPermanents.Count >= 1)


### PR DESCRIPTION
The check for if 0 DP Digimon should be deleted correctly checks only battle area digimon, but if such a deletion occurs the actual process deletes 0 DP Digimon in the breeding area as well.

Example: Lucemon: Larva Mode and any Digimon in the battle area being deleted for having 0 DP.