### PR TITLE
Vortexdramon with Digimon Immunity as a Permanent Effect, instead of card effect

### DIFF
--- a/Assets/Scripts/CardEffect/EX11/Green/EX11_074.cs
+++ b/Assets/Scripts/CardEffect/EX11/Green/EX11_074.cs
@@ -124,31 +124,13 @@ namespace DCGO.CardEffects.EX11
 
                 if (ownDigimon)
                 {
+                    Permanent thisPermanent = card.PermanentOfThisCard();
+
                     #region Give Digimon Effect Immunity
 
-                    bool CanUseCondition1(Hashtable hashtable)
-                    {
-                        return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
-                    }
+                    thisPermanent.UntilOpponentTurnEndEffects.Add((_timing) => PermanentEffectFactory.DigimonEffectImmunity(thisPermanent));
 
-                    bool CardCondition(CardSource cardSource)
-                    {
-                        return cardSource == card
-                            && CardEffectCommons.IsExistOnBattleAreaDigimon(card);
-                    }
-
-                    bool SkillCondition(ICardEffect cardEffect)
-                    {
-                        return CardEffectCommons.IsOpponentEffect(cardEffect, card)
-                            && cardEffect.IsDigimonEffect;
-                    }
-
-                    CanNotAffectedClass canNotAffectedClass = new CanNotAffectedClass();
-                    canNotAffectedClass.SetUpICardEffect("Not affected by opponent's Digimon's effects", CanUseCondition1, card);
-                    canNotAffectedClass.SetUpCanNotAffectedClass(CardCondition: CardCondition, SkillCondition: SkillCondition);
-                    card.PermanentOfThisCard().UntilOpponentTurnEndEffects.Add((_timing) => canNotAffectedClass);
-
-                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateBuffEffect(card.PermanentOfThisCard()));
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateBuffEffect(thisPermanent));
 
                     #endregion
 
@@ -156,7 +138,7 @@ namespace DCGO.CardEffects.EX11
 
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP
                     (
-                        card.PermanentOfThisCard(),
+                        thisPermanent,
                         6000,
                         EffectDuration.UntilOpponentTurnEnd,
                         activateClass

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Execute.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Execute.cs
@@ -77,7 +77,7 @@ public partial class CardEffectCommons
             {
                 if (timing == EffectTiming.OnEndAttack)
                 {
-                    return CardEffectFactory.DeleteSelfEffect(selectedPermanent);
+                    return PermanentEffectFactory.DeleteSelfEffect(selectedPermanent);
                 }
                 return null;
             }

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -716,43 +716,4 @@ public partial class CardEffectFactory
 
     #endregion
 
-    #region Effect of a Permanent to Delete Itself
-
-    public static ActivateClass DeleteSelfEffect(Permanent permanent, bool deleteOnOwnturn = true, bool deleteOnOpponentsTurn = true)
-    {
-        ActivateClass activateClass = new ActivateClass();
-        activateClass.SetUpICardEffect("Delete this Digimon", CanUseCondition, permanent.TopCard);
-        activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, "");
-        activateClass.SetEffectSourcePermanent(permanent);
-        return activateClass;
-
-        bool CanUseCondition(Hashtable hashtable)
-        {
-            if (permanent.TopCard != null && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard))
-            {
-                if (CardEffectCommons.IsOwnerTurn(permanent.TopCard))
-                {
-                    return deleteOnOwnturn;
-                }
-                else
-                {
-                    return deleteOnOpponentsTurn;
-                }
-            }
-            return false;
-        }
-
-        bool CanActivateCondition(Hashtable hashtable)
-        {
-            return permanent.TopCard != null
-                && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard);
-        }
-
-        IEnumerator ActivateCoroutine(Hashtable hashtable)
-        {
-            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(new List<Permanent>() { permanent }, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
-        }
-    }
-
-    #endregion
 }

--- a/Assets/Scripts/Script/PermanentEffectFactory.cs
+++ b/Assets/Scripts/Script/PermanentEffectFactory.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+/// Class for given effects for Permanents, applying to the entire stack even if any specific card is removed from it
+/// </summary>
+public partial class PermanentEffectFactory
+{
+    #region Effect of a Permanent to Delete Itself
+    public static ActivateClass DeleteSelfEffect(Permanent permanent, bool deleteOnOwnturn = true, bool deleteOnOpponentsTurn = true)
+    {
+        ActivateClass activateClass = new ActivateClass();
+        activateClass.SetUpICardEffect("Delete this Digimon", CanUseCondition, permanent.TopCard);
+        activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, "");
+        activateClass.SetEffectSourcePermanent(permanent);
+        return activateClass;
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            if (permanent.TopCard != null && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard))
+            {
+                if (CardEffectCommons.IsOwnerTurn(permanent.TopCard))
+                {
+                    return deleteOnOwnturn;
+                }
+                else
+                {
+                    return deleteOnOpponentsTurn;
+                }
+            }
+            return false;
+        }
+
+        bool CanActivateCondition(Hashtable hashtable)
+        {
+            return permanent.TopCard != null
+                && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard);
+        }
+
+        IEnumerator ActivateCoroutine(Hashtable hashtable)
+        {
+            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(new List<Permanent>() { permanent }, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
+        }
+    }
+    #endregion
+
+    #region Digimon Effect Immunity
+    public static CanNotAffectedClass DigimonEffectImmunity(Permanent permanent)
+    {
+        bool CanUseCondition1(Hashtable hashtable)
+        {
+            return CardEffectCommons.IsExistOnBattleAreaDigimon(permanent.TopCard);
+        }
+
+        bool CardCondition(CardSource cardSource)
+        {
+            return cardSource == permanent.TopCard
+                && CardEffectCommons.IsExistOnBattleAreaDigimon(permanent.TopCard);
+        }
+
+        bool SkillCondition(ICardEffect cardEffect)
+        {
+            return CardEffectCommons.IsOpponentEffect(cardEffect, permanent.TopCard)
+                && cardEffect.IsDigimonEffect;
+        }
+
+        CanNotAffectedClass canNotAffectedClass = new CanNotAffectedClass();
+        canNotAffectedClass.SetUpICardEffect("Not affected by opponent's Digimon's effects", CanUseCondition1, permanent.TopCard);
+        canNotAffectedClass.SetUpCanNotAffectedClass(CardCondition: CardCondition, SkillCondition: SkillCondition);
+        canNotAffectedClass.SetEffectSourcePermanent(permanent);
+        return canNotAffectedClass;
+    }
+    #endregion
+}


### PR DESCRIPTION
PermanentEffectFactory for given effects on Permanents, which then should continue to work correctly through de-digivolution as long as the permanent remains for the effect given duration.

Having tested the pattern works on Execute granting a given self delete effect, next test will be on Vortexdramon's digimon immunity. Once proofed there we can copy the pattern and apply to other effects being granted to the entire stack.