### PR TITLE
Implement AD1-011 with Can't Redirect attack Permanent Effect

### DIFF
--- a/Assets/Scripts/CardEffect/AD1/Blue/AD1_011.cs
+++ b/Assets/Scripts/CardEffect/AD1/Blue/AD1_011.cs
@@ -1,0 +1,159 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// Paildramon
+namespace DCGO.CardEffects.AD1
+{
+    public class AD1_011 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternative Digivolve Condition
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.IsLevel4
+                        && (targetPermanent.TopCard.EqualsTraits("Free")
+                            || targetPermanent.TopCard.EqualsTraits("Hero"));
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region DNA
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.GetJogressConditionClass(
+                    PermanentCondition1, 
+                    "a level 4 Blue Digimon", 
+                    PermanentCondition2, 
+                    "a level 4 Green Digimon", 
+                    card
+                ));
+
+                bool PermanentCondition1(Permanent permanent)
+                {
+                    return permanent.TopCard.CardColors.Contains(CardColor.Blue)
+                        && permanent.Levels_ForJogress(card).Contains(4);
+                }
+
+                bool PermanentCondition2(Permanent permanent)
+                {
+                    return permanent.TopCard.CardColors.Contains(CardColor.Green)
+                        && permanent.Levels_ForJogress(card).Contains(4);
+                }
+            }
+            #endregion
+
+            #region Shared Partition + Inherited
+
+            List<PartitionCondition> partitionConditions = new List<PartitionCondition>();
+            partitionConditions.Add(new PartitionCondition(4, CardColor.Blue));
+            partitionConditions.Add(new PartitionCondition(4, CardColor.Green));
+
+            if (timing == EffectTiming.WhenRemoveField)
+            {
+                cardEffects.Add(CardEffectFactory.PartitionSelfEffect
+                    (isInheritedEffect: false,
+                    card: card,
+                    condition: null,
+                    cardSourceConditions: partitionConditions));
+
+                cardEffects.Add(CardEffectFactory.PartitionSelfEffect
+                    (isInheritedEffect: true,
+                    card: card,
+                    condition: null,
+                    cardSourceConditions: partitionConditions));
+            }
+
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Can't be deleted in battle. If DNA: Attack target can't be changed", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[When Digivolving] Until your opponent's turn ends, this Digimon can't be deleted in battle. Then, if DNA digivolving, this Digimon's attack target can't change for the turn.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleArea(card);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool CanNotBeDestroyedByBattleCondition(Permanent permanent1, Permanent attackingPermanent,
+                                                    Permanent defendingPermanent, CardSource defendingCard)
+                    {
+                        return permanent1 == attackingPermanent || permanent1 == defendingPermanent;
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(
+                        CardEffectCommons.GainCanNotBeDeletedByBattle(
+                            targetPermanent: card.PermanentOfThisCard(),
+                            canNotBeDestroyedByBattleCondition: CanNotBeDestroyedByBattleCondition,
+                            effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                            activateClass: activateClass,
+                            effectName: "Can't be deleted in battle"));
+
+                    if (CardEffectCommons.IsJogress(hashtable))
+                    {
+                        card.PermanentOfThisCard().UntilEachTurnEndEffects.Add(_timing => PermanentEffectFactory.CanNotSwitchAttackTargetEffect(card.PermanentOfThisCard()));
+                    }
+                }
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Digivolve into Imperialdramon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[When Attacking] This Digimon may digivolve into a Digimon card with [Imperialdramon] in its name in the hand with the digivolution cost reduced by 2.";
+
+                bool CanSelectCardCondition(CardSource cardSource) => cardSource.CardNames.Contains("Imperialdramon");
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleArea(card);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                        targetPermanent: card.PermanentOfThisCard(),
+                        cardCondition: CanSelectCardCondition,
+                        payCost: true,
+                        reduceCostTuple: (reduceCost: 2, reduceCostCardCondition: null),
+                        fixedCostTuple: null,
+                        ignoreDigivolutionRequirementFixedCost: -1,
+                        isHand: true,
+                        activateClass: activateClass,
+                        successProcess: null));
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/Script/CardEffectCommons/DNADigivolveEffects.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/DNADigivolveEffects.cs
@@ -8,6 +8,8 @@ using Photon.Pun;
 
 public partial class CardEffectCommons
 {
+    #region DNA With Hand Or Trash Card into Hand or Trash Card
+
     /// <summary>
     /// Creates a temporary permanent. Calling method can later ensure clear the frame
     /// </summary>
@@ -448,6 +450,10 @@ public partial class CardEffectCommons
         }
     }
 
+    #endregion
+
+    #region digivolve Permanents on Field into Hand or Trash Card
+
     public static IEnumerator DNADigivolvePermanentsIntoHandOrTrashCard(
         Func<CardSource, bool> canSelectDNACardCondition,
         bool payCost,
@@ -598,6 +604,36 @@ public partial class CardEffectCommons
         }
     }
 
+    #endregion
+
+    #region Create Jogress Conditions from Permanent Conditions
+
+    public static JogressCondition GetJogressConditions(Func<Permanent, bool> permanentCondition1, string description1, Func<Permanent, bool> permanentCondition2, string description2, CardSource card, int cost = 0)
+    {
+        JogressConditionElement[] elements = 
+            {
+                new JogressConditionElement(permanentCondition1, description1),
+                new JogressConditionElement(permanentCondition2, description2)
+            };
+
+        JogressCondition jogressCondition = new (elements, cost);
+
+        return jogressCondition;
+
+        bool PermanentCondition(Permanent permanent)
+        {
+            return permanent != null
+                && permanent.TopCard != null
+                && permanent.TopCard.Owner == card.Owner
+                && permanent.IsDigimon
+                && CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card);
+        }
+
+        bool FullPermanentCondition1(Permanent permanent) => PermanentCondition(permanent) && permanentCondition1 != null && permanentCondition1(permanent);
+
+        bool FullPermanentCondition2(Permanent permanent) => PermanentCondition(permanent) && permanentCondition2 != null && permanentCondition2(permanent);
+    }
+
     //Private class used to register the callback so this doesn't need to be defined in every card that uses DNA by effect
     private class SetJogressEvoRootsController : MonoBehaviourPunCallbacks
     {
@@ -611,4 +647,6 @@ public partial class CardEffectCommons
             EndSelect = true;
         }
     } 
+
+    #endregion
 }

--- a/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/DeleteSelf.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/DeleteSelf.cs
@@ -21,7 +21,7 @@ public partial class CardEffectCommons
         {
             if (timing == EffectTiming.OnEndTurn)
             {
-                return CardEffectFactory.DeleteSelfEffect(permanent, deleteOnOwnturn, deleteOnOpponentsTurn);
+                return PermanentEffectFactory.DeleteSelfEffect(permanent, deleteOnOwnturn, deleteOnOpponentsTurn);
             }
             return null;
         }

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -717,7 +717,7 @@ public partial class CardEffectFactory
     #endregion
 
     #region Use Requirements
-    public static ActivateClass UseRequirements(CardSource card, Func<Permanent, bool> permanentCondition)
+    public static IgnoreColorConditionClass UseRequirements(CardSource card, Func<Permanent, bool> permanentCondition)
     {
         IgnoreColorConditionClass ignoreColorConditionClass = new IgnoreColorConditionClass();
         ignoreColorConditionClass.SetUpICardEffect("Ignore color requirements", CanUseCondition, card);
@@ -732,6 +732,38 @@ public partial class CardEffectFactory
         bool CardCondition(CardSource cardSource)
         {
             return cardSource == card;
+        }
+    }
+    #endregion
+
+    #region Jogress Condition Class
+    public static AddJogressConditionClass GetJogressConditionClass(Func<Permanent, bool> permanentCondition1, string description1, Func<Permanent, bool> permanentCondition2, string description2, CardSource card, int cost = 0, Func<Hashtable, bool> canUseCondition = null)
+    {
+        AddJogressConditionClass addJogressConditionClass = new AddJogressConditionClass();
+        addJogressConditionClass.SetUpICardEffect($"DNA Digivolution", CanUseCondition, card);
+        addJogressConditionClass.SetUpAddJogressConditionClass(getJogressCondition: GetJogress);
+        addJogressConditionClass.SetNotShowUI(true);
+        return addJogressConditionClass;
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            return canUseCondition == null || canUseCondition(hashtable);
+        }
+
+        JogressCondition GetJogress(CardSource cardSource)
+        {
+            if (cardSource == card)
+            {
+                return CardEffectCommons.GetJogressConditions(
+                    permanentCondition1, 
+                    description1, 
+                    permanentCondition2, 
+                    description2, 
+                    card
+                    );
+            }
+
+            return null;
         }
     }
     #endregion

--- a/Assets/Scripts/Script/PermanentEffectFactory.cs
+++ b/Assets/Scripts/Script/PermanentEffectFactory.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 /// </summary>
 public partial class PermanentEffectFactory
 {
+
     #region Effect of a Permanent to Delete Itself
     public static ActivateClass DeleteSelfEffect(Permanent permanent, bool deleteOnOwnturn = true, bool deleteOnOpponentsTurn = true)
     {
@@ -72,6 +73,28 @@ public partial class PermanentEffectFactory
         canNotAffectedClass.SetUpCanNotAffectedClass(CardCondition: CardCondition, SkillCondition: SkillCondition);
         canNotAffectedClass.SetEffectSourcePermanent(permanent);
         return canNotAffectedClass;
+
+    }
+    #endregion
+
+    #region Cannot change Attack Target Effect
+    public static CanNotSwitchAttackTargetClass CanNotSwitchAttackTargetEffect(Permanent targetPermanent)
+    {
+        CanNotSwitchAttackTargetClass canNotSwitchAttackTargetClass = new CanNotSwitchAttackTargetClass();
+        canNotSwitchAttackTargetClass.SetUpICardEffect("This Digimon's attack target can't be switched.", CanUseCondition, targetPermanent.TopCard);
+        canNotSwitchAttackTargetClass.SetUpCanNotSwitchAttackTargetClass(PermanentCondition: PermanentCondition);
+        return canNotSwitchAttackTargetClass;
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            return CardEffectCommons.IsPermanentExistsOnBattleArea(targetPermanent) &&
+                    CardEffectCommons.IsOwnerTurn(targetPermanent.TopCard);
+        }
+
+        bool PermanentCondition(Permanent permanent)
+        {
+            return permanent != null && permanent.TopCard && permanent == targetPermanent;
+        }
     }
     #endregion
 }


### PR DESCRIPTION
Interestingly GainCanNotBeDestroyedInBattle was already written in a way that should work through de-digivolution, so it was not reworked here