### PR TITLE
Fix Linked DP should apply with other plus and minus

### DIFF
--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -466,6 +466,8 @@ public class Permanent
                     }
                 }
             }
+            
+            DP += LinkedDP;
 
             foreach (ICardEffect cardEffect in cardEffects_ChangeDP_NotIsUpDown)
             {
@@ -485,8 +487,6 @@ public class Permanent
                 DP += boost.DP;
             }
             #endregion
-
-            DP += LinkedDP;
 
             if (DP < 0)
             {
@@ -635,6 +635,8 @@ public class Permanent
                         }
                     }
                 }
+                
+                DP += LinkedDP;
 
                 foreach (ICardEffect cardEffect in cardEffects_ChangeDP_NotIsUpDown)
                 {
@@ -654,8 +656,6 @@ public class Permanent
                     DP += boost.DP;
                 }
                 #endregion
-
-                DP += LinkedDP;
 
                 if (DP < 0)
                 {


### PR DESCRIPTION
Found on Unchained, the inherited effect to have a minimum of 1000 DP was applied, and then Link DP was being added. I have moved Linked DP being added to be alongside other + and - DP effects.

Can be tested with any Maquinamon in name, with Mind Linked Unchained and Linked Maquinamon