### PR TITLE
Simplify CanActivateCondition logic

### DIFF
--- a/Assets/Scripts/CardEffect/EX8/Black/EX8_052.cs
+++ b/Assets/Scripts/CardEffect/EX8/Black/EX8_052.cs
@@ -294,8 +294,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return card.Owner.Enemy.SecurityCards.Count > 0 &&
-                           CardEffectCommons.HasMatchConditionPermanent(IsDeviceTrait);
+                    return CardEffectCommons.HasMatchConditionPermanent(IsDeviceTrait);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)


### PR DESCRIPTION
Fix ESS not trigger if oppo had 0 cards in sec.