### PR TITLE
Implement AD1-019 and SelectEffect.Mode.PlayForCost

### DIFF
--- a/Assets/Scripts/CardEffect/AD1/Blue/AD1_019.cs
+++ b/Assets/Scripts/CardEffect/AD1/Blue/AD1_019.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// Matt Ishida & T.K. Takaishi
+namespace DCGO.CardEffects.AD1
+{
+    public class AD1_019 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Start of Your Main Phase
+            if (timing == EffectTiming.OnStartMainPhase)
+            {
+                cardEffects.Add(CardEffectFactory.Gain1MemoryTamerOpponentDigimonEffect(card));
+            }
+            #endregion
+
+            #region Your Turn
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ();
+                activateClass.SetUpICardEffect("By suspending this tamer, you may play 1[ADVENTURE] Digimon for -1 cost per 2 colors on your Tamers.", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Your Turn] When any of your Digimon digivolve into an [ADVENTURE] trait Digimon, by suspending this Tamer, you may play 1 [ADVENTURE] trait card from your hand. For every 2 of your Tamers' colors, reduce this effect's play cost by 1.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.IsOwnerTurn(card)
+                        && CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, PermanentCondition);
+                }
+
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                        && permanent.TopCard.EqualsTraits("ADVENTURE");
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.CanActivateSuspendCostEffect(card);
+                }
+
+                bool IsAdventureDigimon(CardSource cardSource)
+                {
+                    return cardSource.HasPlayCost
+                        && cardSource.EqualsTraits("ADVENTURE");
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new SuspendPermanentsClass(
+                        new List<Permanent>() { card.PermanentOfThisCard() },
+                        CardEffectCommons.CardEffectHashtable(activateClass)).Tap());
+
+                    if (CardEffectCommons.HasMatchConditionOwnersHand(card, IsAdventureDigimon))
+                    {
+                        List<CardSource> tamerCards = new List<CardSource>();
+
+                        foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
+                        {
+                            if (permanent.IsTamer)
+                            {
+                                tamerCards.Add(permanent.TopCard);
+                            }
+                        }
+
+                        int reduceCost = Combinations.GetUniqueColorCardCount(tamerCards) / 2;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsAdventureDigimon,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.PlayForCost,
+                            cardEffect: activateClass);
+
+                        selectHandEffect.SetReducedCostTuple((reduceCost, null));
+
+                        selectHandEffect.SetUpCustomMessage("Select 1 digimon to play", "The opponent is selecting 1 digimon to play");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                    }
+                }
+            }
+            #endregion
+
+            #region Security 
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                cardEffects.Add(CardEffectFactory.PlaySelfTamerSecurityEffect(card));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/AD1/Blue/AD1_019.cs
+++ b/Assets/Scripts/CardEffect/AD1/Blue/AD1_019.cs
@@ -57,45 +57,50 @@ namespace DCGO.CardEffects.AD1
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    yield return ContinuousController.instance.StartCoroutine(new SuspendPermanentsClass(
+                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SuspendPeremanentAndProcessAccordingToResult(
                         new List<Permanent>() { card.PermanentOfThisCard() },
-                        CardEffectCommons.CardEffectHashtable(activateClass)).Tap());
+                        activateClass,
+                        SuccessProcess,
+                        null));
 
-                    if (CardEffectCommons.HasMatchConditionOwnersHand(card, IsAdventureDigimon))
+                    IEnumerator SuccessProcess(List<Permanent> suspendedPermaments)
                     {
-                        List<CardSource> tamerCards = new List<CardSource>();
-
-                        foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
+                        if (CardEffectCommons.HasMatchConditionOwnersHand(card, IsAdventureDigimon))
                         {
-                            if (permanent.IsTamer)
+                            List<CardSource> tamerCards = new List<CardSource>();
+
+                            foreach (Permanent permanent in card.Owner.GetBattleAreaPermanents())
                             {
-                                tamerCards.Add(permanent.TopCard);
+                                if (permanent.IsTamer)
+                                {
+                                    tamerCards.Add(permanent.TopCard);
+                                }
                             }
+
+                            int reduceCost = Combinations.GetUniqueColorCardCount(tamerCards) / 2;
+
+                            SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                            selectHandEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: IsAdventureDigimon,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: true,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                selectCardCoroutine: null,
+                                afterSelectCardCoroutine: null,
+                                mode: SelectHandEffect.Mode.PlayForCost,
+                                cardEffect: activateClass);
+
+                            selectHandEffect.SetReducedCostTuple((reduceCost, null));
+
+                            selectHandEffect.SetUpCustomMessage("Select 1 card to play", "The opponent is selecting 1 card to play");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
                         }
-
-                        int reduceCost = Combinations.GetUniqueColorCardCount(tamerCards) / 2;
-
-                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
-
-                        selectHandEffect.SetUp(
-                            selectPlayer: card.Owner,
-                            canTargetCondition: IsAdventureDigimon,
-                            canTargetCondition_ByPreSelecetedList: null,
-                            canEndSelectCondition: null,
-                            maxCount: 1,
-                            canNoSelect: true,
-                            canEndNotMax: false,
-                            isShowOpponent: true,
-                            selectCardCoroutine: null,
-                            afterSelectCardCoroutine: null,
-                            mode: SelectHandEffect.Mode.PlayForCost,
-                            cardEffect: activateClass);
-
-                        selectHandEffect.SetReducedCostTuple((reduceCost, null));
-
-                        selectHandEffect.SetUpCustomMessage("Select 1 digimon to play", "The opponent is selecting 1 digimon to play");
-
-                        yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
                     }
                 }
             }

--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -5111,7 +5111,13 @@ public class SuspendPermanentsClass
         _hashtable = hashtable;
     }
 
+    public bool IsSuspended(Permanent permanent)
+    {
+        return SuspendedPermanents.Contains(permanent);
+    }
+
     List<Permanent> _permanents { get; set; }
+    public List<Permanent> SuspendedPermanents { get; private set; } = new List<Permanent>();
     Hashtable _hashtable { get; set; }
 
     public IEnumerator Tap()
@@ -5165,6 +5171,8 @@ public class SuspendPermanentsClass
             {
                 permanent.ShowingPermanentCard.ShowPermanentData(true);
             }
+
+            SuspendedPermanents.Add(permanent);
         }
 
         if (suspendTargetPermanents.Count >= 1)

--- a/Assets/Scripts/Script/CardEffectCommons.cs
+++ b/Assets/Scripts/Script/CardEffectCommons.cs
@@ -415,6 +415,32 @@ public partial class CardEffectCommons
 
     #endregion
 
+    #region Suspend target permanents, and the effect determines whether the permanent has been suspended or not
+
+    public static IEnumerator SuspendPeremanentAndProcessAccordingToResult(List<Permanent> targetPermanents, ICardEffect activateClass, Func<List<Permanent>, IEnumerator> successProcess, Func<IEnumerator> failureProcess)
+    {
+        SuspendPermanentsClass suspendPermanentsClass = new SuspendPermanentsClass(targetPermanents, CardEffectHashtable(activateClass));
+
+        yield return ContinuousController.instance.StartCoroutine(suspendPermanentsClass.Tap());
+
+        if (targetPermanents.Some((permanent) => suspendPermanentsClass.IsSuspended(permanent)))
+        {
+            if (successProcess != null)
+            {
+                yield return ContinuousController.instance.StartCoroutine(successProcess(suspendPermanentsClass.SuspendedPermanents));
+            }
+        }
+        else
+        {
+            if (failureProcess != null)
+            {
+                yield return ContinuousController.instance.StartCoroutine(failureProcess());
+            }
+        }
+    }
+
+    #endregion
+
     #region Delete target permanents, and the effect determines whether the permanent has been deleted or not
 
     public static IEnumerator DeletePeremanentAndProcessAccordingToResult(List<Permanent> targetPermanents, ICardEffect activateClass, Func<List<Permanent>, IEnumerator> successProcess, Func<IEnumerator> failureProcess)

--- a/Assets/Scripts/Script/SelectCardEffect.cs
+++ b/Assets/Scripts/Script/SelectCardEffect.cs
@@ -113,6 +113,16 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
         _skillInfos = skillInfos.Clone();
     }
 
+    public void SetReducedCostTuple((int reduceCost, Func<CardSource, bool> reduceCostCardCondition)? reduceCostTuple)
+    {
+        _reduceCostTuple = reduceCostTuple;
+    }
+
+    public void SetFixedCostTuple((int fixedCost, Func<CardSource, bool> fixedCostCardCondition)? fixedCostTuple)
+    {
+        _fixedCostTuple = fixedCostTuple;
+    }
+
     public void SetUpCustomMessage(string CustomMessage, string CustomMessage_Enemy)
     {
         _customMessage = CustomMessage;
@@ -168,15 +178,18 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
     bool _isAssembly = false;
     bool _isSecurity = false;
     bool _allowFaceDown = false;
+    (int reduceCost, Func<CardSource, bool> reduceCostCardCondition)? _reduceCostTuple = null;
+    (int fixedCost, Func<CardSource, bool> fixedCostCardCondition)? _fixedCostTuple = null;
 
     public enum Mode
     {
         AddHand,
         Discard,
-        PlayForFree,
 
         // PutLibraryTop,
         // PutLibraryBottom,
+        PlayForFree,
+        PlayForCost,
         Custom,
     }
 
@@ -410,6 +423,10 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
 
                             case Mode.PlayForFree:
                                 message = "Select cards to play without paying the cost.";
+                                break;
+
+                            case Mode.PlayForCost:
+                                message = "Select cards to play.";
                                 break;
 
                             case Mode.Custom:
@@ -679,7 +696,9 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
                                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(_targetCards, "Cards put on the trash", true, true));
                                     break;
 
+
                                 case Mode.PlayForFree:
+                                case Mode.PlayForCost:
                                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(_targetCards, "Played cards", true, true));
                                     break;
 
@@ -765,7 +784,7 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
                     break;
 
                 case Mode.PlayForFree:
-                        yield return ContinuousController.instance.StartCoroutine(
+                    yield return ContinuousController.instance.StartCoroutine(
                             CardEffectCommons.PlayPermanentCards(
                                 cardSources: _targetCards, 
                                 activateClass: _cardEffect, 
@@ -773,7 +792,143 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
                                 isTapped: false, 
                                 root: _root, 
                                 activateETB: true));
+                    break;
+
+                case Mode.PlayForCost:
+                    {
+                        bool PermanentsCondition(List<Permanent> targetPermanents)
+                        {
+                            if (targetPermanents == null)
+                            {
+                                return true;
+                            }
+
+                            else
+                            {
+                                if (targetPermanents.Count((targetPermanent) => targetPermanent != null) == 0)
+                                {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        }
+
+                        bool SharedCardCondition(CardSource cardSource) => _targetCards.Contains(cardSource);
+                        bool RootCondition(SelectCardEffect.Root root) => true;
+                        bool CanUseCondition(Hashtable hashtable) => true;
+
+                        #region reduce cost
+
+                        Func<EffectTiming, ICardEffect> getChangeCostEffect = null;
+
+                        if (_reduceCostTuple != null)
+                        {
+                            bool CardCondition(CardSource cardSource)
+                            {
+                                return SharedCardCondition(cardSource)
+                                    && (_reduceCostTuple.Value.reduceCostCardCondition == null || _reduceCostTuple.Value.reduceCostCardCondition(cardSource));
+                            }
+
+                            int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                            {
+                                if (PermanentsCondition(targetPermanents))
+                                {
+                                    Cost += _reduceCostTuple.Value.reduceCost;
+                                }
+
+                                return Cost;
+                            }
+
+                            bool isUpDown() => true;
+
+                            ChangeCostClass changeCostClass = new ChangeCostClass();
+                            changeCostClass.SetUpICardEffect($"Play Cost -{_reduceCostTuple.Value.reduceCost}", CanUseCondition, _cardEffect.EffectSourceCard);
+                            changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
+
+                            ICardEffect GetCardEffect(EffectTiming _timing)
+                            {
+                                if (_timing == EffectTiming.None)
+                                {
+                                    return changeCostClass;
+                                }
+
+                                return null;
+                            }
+
+                            if (getChangeCostEffect != null)
+                            {
+                                _selectPlayer.UntilCalculateFixedCostEffect.Add(GetCardEffect);
+                            }
+                        }
+
+                        #endregion
+
+                        #region set fixed cost
+
+                        Func<EffectTiming, ICardEffect> getFixedCostEffect = null;
+
+                        if (_fixedCostTuple != null)
+                        {
+                            bool CardCondition(CardSource cardSource)
+                            {
+                                return SharedCardCondition(cardSource)
+                                    && (_fixedCostTuple.Value.fixedCostCardCondition == null || _fixedCostTuple.Value.fixedCostCardCondition(cardSource));
+                            }
+
+                            int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                            {
+                                if (PermanentsCondition(targetPermanents))
+                                {
+                                    Cost = _fixedCostTuple.Value.fixedCost;
+                                }
+
+                                return Cost;
+                            }
+
+                            bool isUpDown() => false;
+
+                            ChangeCostClass changeCostClass = new ChangeCostClass();
+                            changeCostClass.SetUpICardEffect($"Play Cost -{_reduceCostTuple.Value.reduceCost}", CanUseCondition, _cardEffect.EffectSourceCard);
+                            changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
+
+                            ICardEffect GetCardEffect(EffectTiming _timing)
+                            {
+                                if (_timing == EffectTiming.None)
+                                {
+                                    return changeCostClass;
+                                }
+
+                                return null;
+                            }
+
+                            if (getChangeCostEffect != null)
+                            {
+                                _selectPlayer.UntilCalculateFixedCostEffect.Add(GetCardEffect);
+                            }
+                        }
+
+                        #endregion
+
+                        yield return ContinuousController.instance.StartCoroutine(
+                            CardEffectCommons.PlayPermanentCards(
+                                cardSources: _targetCards, 
+                                activateClass: _cardEffect, 
+                                payCost: true, 
+                                isTapped: false, 
+                                root: SelectCardEffect.Root.Hand, 
+                                activateETB: true));
+                        
+                        #region release effect
+                        if (getChangeCostEffect != null) _selectPlayer.UntilCalculateFixedCostEffect.Remove(getChangeCostEffect);
+                        #endregion
+
+                        #region release effect
+                        if (getFixedCostEffect != null) _selectPlayer.UntilCalculateFixedCostEffect.Remove(getFixedCostEffect);
+                        #endregion
+
                         break;
+                    }
 
                 case Mode.Custom:
                     if (_selectCardCoroutine != null)

--- a/Assets/Scripts/Script/SelectHandEffect.cs
+++ b/Assets/Scripts/Script/SelectHandEffect.cs
@@ -65,6 +65,16 @@ public class SelectHandEffect : MonoBehaviourPunCallbacks
         _isFaceUp = true;
     }
 
+    public void SetReducedCostTuple((int reduceCost, Func<CardSource, bool> reduceCostCardCondition)? reduceCostTuple)
+    {
+        _reduceCostTuple = reduceCostTuple;
+    }
+
+    public void SetFixedCostTuple((int fixedCost, Func<CardSource, bool> fixedCostCardCondition)? fixedCostTuple)
+    {
+        _fixedCostTuple = fixedCostTuple;
+    }
+
     public void SetUpCustomMessage_ShowCard(string CustomMessage_ShowCard)
     {
         _customMessage_ShowCard = CustomMessage_ShowCard;
@@ -109,6 +119,8 @@ public class SelectHandEffect : MonoBehaviourPunCallbacks
     bool _digiXros = false;
     bool _isLocal = false;
     bool _isFaceUp = false;
+    (int reduceCost, Func<CardSource, bool> reduceCostCardCondition)? _reduceCostTuple = null;
+    (int fixedCost, Func<CardSource, bool> fixedCostCardCondition)? _fixedCostTuple = null;
 
     public enum Mode
     {
@@ -117,6 +129,7 @@ public class SelectHandEffect : MonoBehaviourPunCallbacks
         PutLibraryBottom,
         PutSecurityBottom,
         PlayForFree,
+        PlayForCost,
         Custom
     }
 
@@ -225,7 +238,11 @@ public class SelectHandEffect : MonoBehaviourPunCallbacks
                             break;
 
                         case Mode.PlayForFree:
-                            message = "Select cards to play for free.";
+                            message = "Select cards to play for without paying the cost.";
+                            break;
+
+                        case Mode.PlayForCost:
+                            message = "Select cards to play.";
                             break;
 
                         case Mode.Custom:
@@ -656,6 +673,7 @@ public class SelectHandEffect : MonoBehaviourPunCallbacks
                                     break;
 
                                 case Mode.PlayForFree:
+                                case Mode.PlayForCost:
 
                                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(_targetCards, "Played cards", true, true));
 
@@ -725,7 +743,143 @@ public class SelectHandEffect : MonoBehaviourPunCallbacks
                                 root: SelectCardEffect.Root.Hand, 
                                 activateETB: true));
                         break;
-                }  
+
+                    case Mode.PlayForCost:
+                        {
+                            bool PermanentsCondition(List<Permanent> targetPermanents)
+                            {
+                                if (targetPermanents == null)
+                                {
+                                    return true;
+                                }
+
+                                else
+                                {
+                                    if (targetPermanents.Count((targetPermanent) => targetPermanent != null) == 0)
+                                    {
+                                        return true;
+                                    }
+                                }
+
+                                return false;
+                            }
+
+                            bool SharedCardCondition(CardSource cardSource) => _targetCards.Contains(cardSource);
+                            bool RootCondition(SelectCardEffect.Root root) => true;
+                            bool CanUseCondition(Hashtable hashtable) => true;
+
+                            #region reduce cost
+
+                            Func<EffectTiming, ICardEffect> getChangeCostEffect = null;
+
+                            if (_reduceCostTuple != null)
+                            {
+                                bool CardCondition(CardSource cardSource)
+                                {
+                                    return SharedCardCondition(cardSource)
+                                        && (_reduceCostTuple.Value.reduceCostCardCondition == null || _reduceCostTuple.Value.reduceCostCardCondition(cardSource));
+                                }
+
+                                int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                                {
+                                    if (PermanentsCondition(targetPermanents))
+                                    {
+                                        Cost += _reduceCostTuple.Value.reduceCost;
+                                    }
+
+                                    return Cost;
+                                }
+
+                                bool isUpDown() => true;
+
+                                ChangeCostClass changeCostClass = new ChangeCostClass();
+                                changeCostClass.SetUpICardEffect($"Play Cost -{_reduceCostTuple.Value.reduceCost}", CanUseCondition, _cardEffect.EffectSourceCard);
+                                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
+
+                                ICardEffect GetCardEffect(EffectTiming _timing)
+                                {
+                                    if (_timing == EffectTiming.None)
+                                    {
+                                        return changeCostClass;
+                                    }
+
+                                    return null;
+                                }
+
+                                if (getChangeCostEffect != null)
+                                {
+                                    _selectPlayer.UntilCalculateFixedCostEffect.Add(GetCardEffect);
+                                }
+                            }
+
+                            #endregion
+
+                            #region set fixed cost
+
+                            Func<EffectTiming, ICardEffect> getFixedCostEffect = null;
+
+                            if (_fixedCostTuple != null)
+                            {
+                                bool CardCondition(CardSource cardSource)
+                                {
+                                    return SharedCardCondition(cardSource)
+                                        && (_fixedCostTuple.Value.fixedCostCardCondition == null || _fixedCostTuple.Value.fixedCostCardCondition(cardSource));
+                                }
+
+                                int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                                {
+                                    if (PermanentsCondition(targetPermanents))
+                                    {
+                                        Cost = _fixedCostTuple.Value.fixedCost;
+                                    }
+
+                                    return Cost;
+                                }
+
+                                bool isUpDown() => false;
+
+                                ChangeCostClass changeCostClass = new ChangeCostClass();
+                                changeCostClass.SetUpICardEffect($"Play Cost -{_reduceCostTuple.Value.reduceCost}", CanUseCondition, _cardEffect.EffectSourceCard);
+                                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
+
+                                ICardEffect GetCardEffect(EffectTiming _timing)
+                                {
+                                    if (_timing == EffectTiming.None)
+                                    {
+                                        return changeCostClass;
+                                    }
+
+                                    return null;
+                                }
+
+                                if (getChangeCostEffect != null)
+                                {
+                                    _selectPlayer.UntilCalculateFixedCostEffect.Add(GetCardEffect);
+                                }
+                            }
+
+                            #endregion
+
+                            yield return ContinuousController.instance.StartCoroutine(
+                                CardEffectCommons.PlayPermanentCards(
+                                    cardSources: _targetCards, 
+                                    activateClass: _cardEffect, 
+                                    payCost: true, 
+                                    isTapped: false, 
+                                    root: SelectCardEffect.Root.Hand, 
+                                    activateETB: true));
+                            
+                            #region release effect
+                            if (getChangeCostEffect != null) _selectPlayer.UntilCalculateFixedCostEffect.Remove(getChangeCostEffect);
+                            #endregion
+
+                            #region release effect
+                            if (getFixedCostEffect != null) _selectPlayer.UntilCalculateFixedCostEffect.Remove(getFixedCostEffect);
+                            #endregion
+
+                            break;
+                        }
+                }
                 #endregion
 
                 if (discardHands.Count > 0)


### PR DESCRIPTION
Similar to https://github.com/DCGO2/DCGO/pull/687, implements a shorthand way to play the cards selected.
Uses reduceCostTuple and fixedCostTuple in case of a discount, as in the case of this card.