### PR TITLE
Fix remove UsedBlitz flag which was preventign valid scenarios

### DIFF
--- a/Assets/Scripts/Script/AttackProcess.cs
+++ b/Assets/Scripts/Script/AttackProcess.cs
@@ -18,7 +18,6 @@ public class AttackProcess : MonoBehaviourPunCallbacks
     public bool DoSecurityCheck { get; set; } = false;
     public bool IsEndAttack { get; set; } = false;
 
-    public bool UsedBlitz { get; set; } = false;
     public Hashtable EffectHashtable { get; set; } = null;
 
     public Hashtable CounterEffectHashtable { get; set; } = null;

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Blitz.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Blitz.cs
@@ -17,10 +17,7 @@ public partial class CardEffectCommons
                 {
                     if (!GManager.instance.attackProcess.IsAttacking)
                     {
-                        if (!GManager.instance.attackProcess.UsedBlitz)
-                        {
-                            return true;
-                        }                                                
+                        return true;                                         
                     }
                 }
             }
@@ -46,8 +43,6 @@ public partial class CardEffectCommons
             selectAttackEffect.SetBeforeOnAttackCoroutine(beforeOnAttackCoroutine);
 
             yield return ContinuousController.instance.StartCoroutine(selectAttackEffect.Activate());
-
-            GManager.instance.attackProcess.UsedBlitz = true;
         }
     }
     #endregion

--- a/Assets/Scripts/Script/MemoryObject.cs
+++ b/Assets/Scripts/Script/MemoryObject.cs
@@ -102,7 +102,7 @@ public class MemoryObject : MonoBehaviour
                 }
 
 
-                #region ƒAƒjƒ[ƒVƒ‡ƒ“
+                #region ï¿½Aï¿½jï¿½ï¿½ï¿½[ï¿½Vï¿½ï¿½ï¿½ï¿½
                 bool end = false;
                 var sequence = DOTween.Sequence();
 
@@ -121,15 +121,6 @@ public class MemoryObject : MonoBehaviour
 
                 yield return new WaitWhile(() => !end);
                 end = false;
-                #endregion
-
-                #region setting used blitz
-                if (GManager.instance.attackProcess.UsedBlitz)
-                {
-                    if (GManager.instance.turnStateMachine.gameContext.Memory <= 0)
-                        GManager.instance.attackProcess.UsedBlitz = false;
-                }
-                    
                 #endregion
             }
         }

--- a/Assets/Scripts/Script/TurnStateMachine.cs
+++ b/Assets/Scripts/Script/TurnStateMachine.cs
@@ -968,14 +968,6 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
             ResetMainPhaseParameter();
             #endregion
 
-            #region resetting used blitz
-            if (GManager.instance.attackProcess.UsedBlitz)
-            {
-                if (GManager.instance.turnStateMachine.gameContext.Memory <= 0)
-                    GManager.instance.attackProcess.UsedBlitz = false;
-            }
-            #endregion
-
             yield return GManager.instance.photonWaitController.StartWait("SetMainPhase");
 
             if (gameContext.TurnPhase == GameContext.phase.Main)


### PR DESCRIPTION
UsedBlitz was needed before the Attack Process rework as 2 copies of Blitz would wait to take turns and both attack. This is no longer needed as the second blitz will correctly activate and fail due to an ongoing attack, but the UsedBlitz flag is also preventing valid scenarios for using blitz multiple times during a single turn. Removing entirely since no longer needed.