### PR TITLE
Fix remove default parameter to ensure it is always correctly set

### DIFF
--- a/Assets/Scripts/CardEffect/BT1/Yellow/BT1_087.cs
+++ b/Assets/Scripts/CardEffect/BT1/Yellow/BT1_087.cs
@@ -25,7 +25,7 @@ public class BT1_087 : CEntity_Effect
 
             string EffectDiscription()
             {
-                return "[On Play] Look at your security stackÅCthen reveal 1 card in it and add it to your hand. If that card is yellowÅCger <Recovery +1 (Deck)>. (Place the top card of your deck on top of your security stack.) Then shuffle your security stack.";
+                return "[On Play] Look at your security stack, then reveal 1 card in it and add it to your hand. If that card is yellow, <Recovery +1 (Deck)>. (Place the top card of your deck on top of your security stack.) Then shuffle your security stack.";
             }
 
             bool CanSelectCardCondition(CardSource cardSource)
@@ -92,7 +92,8 @@ public class BT1_087 : CEntity_Effect
                         {
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
                         }
 
                         yield return null;

--- a/Assets/Scripts/CardEffect/BT10/White/BT10_086.cs
+++ b/Assets/Scripts/CardEffect/BT10/White/BT10_086.cs
@@ -357,7 +357,8 @@ namespace DCGO.CardEffects.BT10
                                 {
                                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                         player: card.Owner.Enemy,
-                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                        activateClass).ReduceSecurity());
                                 }
                             }
 
@@ -539,7 +540,8 @@ namespace DCGO.CardEffects.BT10
                                 {
                                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                         player: card.Owner.Enemy,
-                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                        activateClass).ReduceSecurity());
                                 }
                             }
 

--- a/Assets/Scripts/CardEffect/BT11/Blue/BT11_033.cs
+++ b/Assets/Scripts/CardEffect/BT11/Blue/BT11_033.cs
@@ -136,7 +136,8 @@ namespace DCGO.CardEffects.BT11
 
                                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                         player: card.Owner.Enemy,
-                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                        activateClass).ReduceSecurity());
                                 }
                             }
                         }

--- a/Assets/Scripts/CardEffect/BT11/Yellow/BT11_042.cs
+++ b/Assets/Scripts/CardEffect/BT11/Yellow/BT11_042.cs
@@ -106,7 +106,8 @@ namespace DCGO.CardEffects.BT11
                             {
                                 yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                     player: card.Owner,
-                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                    activateClass).ReduceSecurity());
                             }
 
                             yield return null;

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_092.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_092.cs
@@ -180,7 +180,8 @@ namespace DCGO.CardEffects.BT13
 
                                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                         player: card.Owner.Enemy,
-                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                        activateClass).ReduceSecurity());
                                 }
                             }
                         }

--- a/Assets/Scripts/CardEffect/BT13/Red/BT13_012.cs
+++ b/Assets/Scripts/CardEffect/BT13/Red/BT13_012.cs
@@ -112,7 +112,8 @@ namespace DCGO.CardEffects.BT13
                             {
                                 yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                     player: card.Owner,
-                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                    activateClass).ReduceSecurity());
                             }
 
                             yield return null;

--- a/Assets/Scripts/CardEffect/BT15/Yellow/BT15_034.cs
+++ b/Assets/Scripts/CardEffect/BT15/Yellow/BT15_034.cs
@@ -160,7 +160,8 @@ namespace DCGO.CardEffects.BT15
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     if (card.Owner.SecurityCards.Count <= 2)

--- a/Assets/Scripts/CardEffect/BT15/Yellow/BT15_092.cs
+++ b/Assets/Scripts/CardEffect/BT15/Yellow/BT15_092.cs
@@ -152,7 +152,8 @@ namespace DCGO.CardEffects.BT15
                             {
                                 yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                     player: card.Owner,
-                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                    activateClass).ReduceSecurity());
                             }
 
                             yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(cardSources: selectedCards, activateClass: activateClass, payCost: false, isTapped: false, root: SelectCardEffect.Root.Security, activateETB: true));

--- a/Assets/Scripts/CardEffect/BT17/Blue/BT17_028.cs
+++ b/Assets/Scripts/CardEffect/BT17/Blue/BT17_028.cs
@@ -289,7 +289,8 @@ namespace DCGO.CardEffects.BT17
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner.Enemy,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT18/Green/BT18_004.cs
+++ b/Assets/Scripts/CardEffect/BT18/Green/BT18_004.cs
@@ -81,7 +81,8 @@ namespace DCGO.CardEffects.BT18
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
 
                     }
                 }

--- a/Assets/Scripts/CardEffect/BT18/Green/BT18_044.cs
+++ b/Assets/Scripts/CardEffect/BT18/Green/BT18_044.cs
@@ -97,7 +97,8 @@ namespace DCGO.CardEffects.BT18
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT18/Yellow/BT18_037.cs
+++ b/Assets/Scripts/CardEffect/BT18/Yellow/BT18_037.cs
@@ -126,7 +126,8 @@ namespace DCGO.CardEffects.BT18
                         {
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
                         }
 
                         yield return null;

--- a/Assets/Scripts/CardEffect/BT18/Yellow/BT18_038.cs
+++ b/Assets/Scripts/CardEffect/BT18/Yellow/BT18_038.cs
@@ -106,7 +106,8 @@ namespace DCGO.CardEffects.BT18
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
                 }
             }
@@ -192,7 +193,7 @@ namespace DCGO.CardEffects.BT18
 
                         yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddHandCards(new List<CardSource>() { topCard }, false, activateClass));
 
-                        yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(player: card.Owner, refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                        yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(player: card.Owner, refSkillInfos: ref ContinuousController.instance.nullSkillInfos, activateClass).ReduceSecurity());
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT18/Yellow/BT18_042.cs
+++ b/Assets/Scripts/CardEffect/BT18/Yellow/BT18_042.cs
@@ -237,7 +237,8 @@ namespace DCGO.CardEffects.BT18
 
                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                         player: card.Owner,
-                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                        activateClass).ReduceSecurity());
 
                     yield return ContinuousController.instance.StartCoroutine(
                         new IUnsuspendPermanents(new List<Permanent>() { card.PermanentOfThisCard() }, activateClass).Unsuspend());

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_036.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_036.cs
@@ -71,7 +71,8 @@ namespace DCGO.CardEffects.BT19
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }                        
 
                     if (card.PermanentOfThisCard().DigivolutionCards.Count((cardSource) => cardSource.EqualsCardName("Wizardmon") || cardSource.EqualsCardName("X Antibody")) >= 1)
@@ -183,7 +184,8 @@ namespace DCGO.CardEffects.BT19
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     if (card.PermanentOfThisCard().DigivolutionCards.Count((cardSource) => cardSource.EqualsCardName("Wizardmon") || cardSource.EqualsCardName("X Antibody")) >= 1)

--- a/Assets/Scripts/CardEffect/BT20/Yellow/BT20_032.cs
+++ b/Assets/Scripts/CardEffect/BT20/Yellow/BT20_032.cs
@@ -76,7 +76,8 @@ namespace DCGO.CardEffects.BT20
 
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
                         }
                             
                     }
@@ -140,7 +141,8 @@ namespace DCGO.CardEffects.BT20
 
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
                         }
 
                     }

--- a/Assets/Scripts/CardEffect/BT23/Black/BT23_086.cs
+++ b/Assets/Scripts/CardEffect/BT23/Black/BT23_086.cs
@@ -60,7 +60,8 @@ namespace DCGO.CardEffects.BT23
 
                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                         player: card.Owner,
-                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                        activateClass).ReduceSecurity());
 
                     bool handSelected = true;
                     bool canAddHand = CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardSource);

--- a/Assets/Scripts/CardEffect/BT23/White/BT23_076.cs
+++ b/Assets/Scripts/CardEffect/BT23/White/BT23_076.cs
@@ -45,7 +45,8 @@ namespace DCGO.CardEffects.BT23
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());

--- a/Assets/Scripts/CardEffect/BT23/Yellow/BT23_031.cs
+++ b/Assets/Scripts/CardEffect/BT23/Yellow/BT23_031.cs
@@ -248,7 +248,8 @@ namespace DCGO.CardEffects.BT23
 
                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                         player: card.Owner,
-                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                        activateClass).ReduceSecurity());
                 }                
 
                 #endregion

--- a/Assets/Scripts/CardEffect/BT24/Red/BT24_018.cs
+++ b/Assets/Scripts/CardEffect/BT24/Red/BT24_018.cs
@@ -140,7 +140,8 @@ namespace DCGO.CardEffects.BT24
                             {
                                 yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                     player: card.Owner.Enemy,
-                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                    activateClass).ReduceSecurity());
                             }
                         }
 

--- a/Assets/Scripts/CardEffect/BT24/Yellow/BT24_031.cs
+++ b/Assets/Scripts/CardEffect/BT24/Yellow/BT24_031.cs
@@ -145,7 +145,8 @@ namespace DCGO.CardEffects.BT24
 
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
                         }
                     }
 

--- a/Assets/Scripts/CardEffect/BT24/Yellow/BT24_034.cs
+++ b/Assets/Scripts/CardEffect/BT24/Yellow/BT24_034.cs
@@ -67,7 +67,7 @@ namespace DCGO.CardEffects.BT24
                 CardSource topCard = card.Owner.SecurityCards[0];
 
                 yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddHandCards(new List<CardSource>() { topCard }, false, activateClass));
-                yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(player: card.Owner, refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(player: card.Owner, refSkillInfos: ref ContinuousController.instance.nullSkillInfos, activateClass).ReduceSecurity());
 
                 if (card.Owner.HandCards.Contains(topCard) && card.Owner.HandCards.Count((cardSource) => ValidTamer(cardSource, activateClass)) >= 1)
                 {

--- a/Assets/Scripts/CardEffect/BT24/Yellow/BT24_093.cs
+++ b/Assets/Scripts/CardEffect/BT24/Yellow/BT24_093.cs
@@ -40,7 +40,8 @@ namespace DCGO.CardEffects.BT24
     
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
     
                     yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());

--- a/Assets/Scripts/CardEffect/BT4/Yellow/BT4_048.cs
+++ b/Assets/Scripts/CardEffect/BT4/Yellow/BT4_048.cs
@@ -58,7 +58,8 @@ public class BT4_048 : CEntity_Effect
 
                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                         player: card.Owner,
-                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                        activateClass).ReduceSecurity());
 
                     if (CardEffectCommons.IsExistOnBattleArea(card))
                     {

--- a/Assets/Scripts/CardEffect/BT5/Yellow/BT5_037.cs
+++ b/Assets/Scripts/CardEffect/BT5/Yellow/BT5_037.cs
@@ -106,7 +106,8 @@ public class BT5_037 : CEntity_Effect
                         {
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
                         }
 
                         yield return null;

--- a/Assets/Scripts/CardEffect/BT7/Yellow/BT7_088.cs
+++ b/Assets/Scripts/CardEffect/BT7/Yellow/BT7_088.cs
@@ -106,7 +106,8 @@ public class BT7_088 : CEntity_Effect
                     {
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     yield return null;

--- a/Assets/Scripts/CardEffect/BT9/Yellow/BT9_034.cs
+++ b/Assets/Scripts/CardEffect/BT9/Yellow/BT9_034.cs
@@ -95,7 +95,8 @@ public class BT9_034 : CEntity_Effect
 
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
 
                             yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
                         }

--- a/Assets/Scripts/CardEffect/BT9/Yellow/BT9_043.cs
+++ b/Assets/Scripts/CardEffect/BT9/Yellow/BT9_043.cs
@@ -31,7 +31,7 @@ public class BT9_043 : CEntity_Effect
 
             string EffectDiscription()
             {
-                return "[When Digivolving] If [Magnadramon] or [X Antibody] is in this DigimonÅfs digivolution cards, all of your opponentÅfs Digimon and Security Digimon get -1000 DP for the turn for each card in your security stack.";
+                return "[When Digivolving] If [Magnadramon] or [X Antibody] is in this DigimonÔøΩfs digivolution cards, all of your opponentÔøΩfs Digimon and Security Digimon get -1000 DP for the turn for each card in your security stack.";
             }
 
             bool CanUseCondition(Hashtable hashtable)
@@ -122,7 +122,8 @@ public class BT9_043 : CEntity_Effect
 
                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                         player: card.Owner,
-                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                        activateClass).ReduceSecurity());
 
                     if (CardEffectCommons.IsExistOnBattleArea(card))
                     {

--- a/Assets/Scripts/CardEffect/EX11/Green/EX11_025.cs
+++ b/Assets/Scripts/CardEffect/EX11/Green/EX11_025.cs
@@ -95,7 +95,8 @@ namespace DCGO.CardEffects.EX11
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
 
                         break;
                     }

--- a/Assets/Scripts/CardEffect/EX11/Green/EX11_030.cs
+++ b/Assets/Scripts/CardEffect/EX11/Green/EX11_030.cs
@@ -77,7 +77,8 @@ namespace DCGO.CardEffects.EX11
 
                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                         player: card.Owner,
-                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                        activateClass).ReduceSecurity());
 
                     break;
                 }

--- a/Assets/Scripts/CardEffect/EX11/Green/EX11_063.cs
+++ b/Assets/Scripts/CardEffect/EX11/Green/EX11_063.cs
@@ -54,7 +54,8 @@ namespace DCGO.CardEffects.EX11
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
 
                         break;
                     }

--- a/Assets/Scripts/CardEffect/EX4/Purple/EX4_058.cs
+++ b/Assets/Scripts/CardEffect/EX4/Purple/EX4_058.cs
@@ -230,7 +230,8 @@ namespace DCGO.CardEffects.EX4
 
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner.Enemy,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/EX5/Yellow/EX5_027.cs
+++ b/Assets/Scripts/CardEffect/EX5/Yellow/EX5_027.cs
@@ -96,7 +96,8 @@ public class EX5_027 : CEntity_Effect
                     {
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     yield return null;

--- a/Assets/Scripts/CardEffect/EX6/Yellow/EX6_003.cs
+++ b/Assets/Scripts/CardEffect/EX6/Yellow/EX6_003.cs
@@ -76,7 +76,8 @@ namespace DCGO.CardEffects.EX6
                         
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                         
                         if (card.Owner.HandCards.Count(CanSelectCardCondition) >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX6/Yellow/EX6_021.cs
+++ b/Assets/Scripts/CardEffect/EX6/Yellow/EX6_021.cs
@@ -128,7 +128,8 @@ namespace DCGO.CardEffects.EX6
                             
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
                             
                             if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentSharedCondition))
                             {
@@ -284,7 +285,8 @@ namespace DCGO.CardEffects.EX6
 
                             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                 player: card.Owner,
-                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
 
                             if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentSharedCondition))
                             {

--- a/Assets/Scripts/CardEffect/EX6/Yellow/EX6_030.cs
+++ b/Assets/Scripts/CardEffect/EX6/Yellow/EX6_030.cs
@@ -112,7 +112,8 @@ namespace DCGO.CardEffects.EX6
                             {
                                 yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                     player: card.Owner,
-                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                    activateClass).ReduceSecurity());
                             }
 
                             yield return null;

--- a/Assets/Scripts/CardEffect/EX6/Yellow/EX6_068.cs
+++ b/Assets/Scripts/CardEffect/EX6/Yellow/EX6_068.cs
@@ -200,7 +200,8 @@ namespace DCGO.CardEffects.EX6
                             {
                                 yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                     player: card.Owner,
-                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                    activateClass).ReduceSecurity());
                             }
                             
                             yield return null;

--- a/Assets/Scripts/CardEffect/LM/Blue/LM_041.cs
+++ b/Assets/Scripts/CardEffect/LM/Blue/LM_041.cs
@@ -233,7 +233,8 @@ namespace DCGO.CardEffects.LM
                         yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddHandCards(new List<CardSource>() { topCard }, false, activateClass));
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner.Enemy,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     if (card.Owner.MemoryForPlayer <= 1 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectPermanentCondition))
@@ -332,7 +333,8 @@ namespace DCGO.CardEffects.LM
                         yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddHandCards(new List<CardSource>() { topCard }, false, activateClass));
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner.Enemy,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     if (card.Owner.MemoryForPlayer <= 1 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, CanSelectPermanentCondition))

--- a/Assets/Scripts/CardEffect/LM/Yellow/LM_020.cs
+++ b/Assets/Scripts/CardEffect/LM/Yellow/LM_020.cs
@@ -135,7 +135,8 @@ namespace DCGO.CardEffects.LM
                                 {
                                     yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                         player: card.Owner.Enemy,
-                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                        activateClass).ReduceSecurity());
                                 }
                             }
 

--- a/Assets/Scripts/CardEffect/P/Green/P_181.cs
+++ b/Assets/Scripts/CardEffect/P/Green/P_181.cs
@@ -114,7 +114,8 @@ namespace DCGO.CardEffects.P
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     // Place this card face up as the bottom security card

--- a/Assets/Scripts/CardEffect/P/Red/P_137.cs
+++ b/Assets/Scripts/CardEffect/P/Red/P_137.cs
@@ -91,7 +91,8 @@ namespace DCGO.CardEffects.P
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner.Enemy,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/P/Yellow/P_122.cs
+++ b/Assets/Scripts/CardEffect/P/Yellow/P_122.cs
@@ -100,7 +100,8 @@ public class P_122 : CEntity_Effect
                     {
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: card.Owner,
-                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                            activateClass).ReduceSecurity());
                     }
 
                     yield return null;

--- a/Assets/Scripts/CardEffect/ST10/Yellow/ST10_06.cs
+++ b/Assets/Scripts/CardEffect/ST10/Yellow/ST10_06.cs
@@ -264,7 +264,8 @@ public class ST10_06 : CEntity_Effect
                             {
                                 yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                                     player: card.Owner,
-                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                                    refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                    activateClass).ReduceSecurity());
                             }
 
                             yield return null;

--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -3710,7 +3710,8 @@ public class ISecurityCheck
 
                         yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                             player: brokenSecurityCard.Owner,
-                            refSkillInfos: ref triggeredSkillInfos).ReduceSecurity());
+                            refSkillInfos: ref triggeredSkillInfos,
+                            null).ReduceSecurity());
 
                         #region security effect
 
@@ -4959,7 +4960,7 @@ public class ReturnToLibraryBottomDigivolutionCardsClass
 
 public class IReduceSecurity
 {
-    public IReduceSecurity(Player player, ref List<SkillInfo> refSkillInfos, ICardEffect cardEffect = null)
+    public IReduceSecurity(Player player, ref List<SkillInfo> refSkillInfos, ICardEffect cardEffect)
     {
         _player = player;
         _refSkillInfos = refSkillInfos;

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -655,7 +655,8 @@ public partial class CardEffectFactory
 
             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                 player: card.Owner,
-                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                activateClass).ReduceSecurity());
 
             #endregion
         }
@@ -693,7 +694,8 @@ public partial class CardEffectFactory
 
             yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
                 player: card.Owner,
-                refSkillInfos: ref ContinuousController.instance.nullSkillInfos).ReduceSecurity());
+                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                activateClass).ReduceSecurity());
 
             #endregion
         }


### PR DESCRIPTION
Initially removed the default as a way to track down all files with this bug, but given there is exactly 1 place where a null is correct, it is better to just always expect the parameter and pass a null in that one case. As such, I have removed the default for the cardEffect parameter. This prevents us from recreating the bug in the future.
