### PR TITLE
Fix Ending attack with effect puts End Of Attack out of order

### DIFF
--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_088.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_088.cs
@@ -428,9 +428,9 @@ namespace DCGO.CardEffects.BT13
                             mode: SelectHandEffect.Mode.Discard,
                             cardEffect: activateClass);
 
-                        yield return StartCoroutine(selectHandEffect.Activate());
+                        yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
 
-                        GManager.instance.attackProcess.IsEndAttack = true;
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT16/Yellow/BT16_032.cs
+++ b/Assets/Scripts/CardEffect/BT16/Yellow/BT16_032.cs
@@ -64,9 +64,7 @@ namespace DCGO.CardEffects.BT16
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    GManager.instance.attackProcess.IsEndAttack = true;
-
-                    yield return null;
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                 }
             }
 

--- a/Assets/Scripts/CardEffect/BT21/Black/BT21_060.cs
+++ b/Assets/Scripts/CardEffect/BT21/Black/BT21_060.cs
@@ -291,7 +291,7 @@ namespace DCGO.CardEffects.BT21
 
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(selectedCards, "Deck Bottom Cards", true, true));
 
-                        GManager.instance.attackProcess.IsEndAttack = true;
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_069.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_069.cs
@@ -276,7 +276,7 @@ namespace DCGO.CardEffects.BT23
 
                         if (endAttack)
                         {
-                            GManager.instance.attackProcess.IsEndAttack = true;
+                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/BT5/White/BT5_111.cs
+++ b/Assets/Scripts/CardEffect/BT5/White/BT5_111.cs
@@ -219,7 +219,7 @@ public class BT5_111 : CEntity_Effect
                             {
                                 if (selectedCards.Count == 2)
                                 {
-                                    GManager.instance.attackProcess.IsEndAttack = true;
+                                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                                 }
 
                                 yield return ContinuousController.instance.StartCoroutine(new ITrashDigivolutionCards(

--- a/Assets/Scripts/CardEffect/EX10/Black/EX10_003.cs
+++ b/Assets/Scripts/CardEffect/EX10/Black/EX10_003.cs
@@ -90,7 +90,7 @@ namespace DCGO.CardEffects.EX10
                     {
                         yield return ContinuousController.instance.StartCoroutine(new ITrashDigivolutionCards(permanent, selectedCards, activateClass).TrashDigivolutionCards());
 
-                        GManager.instance.attackProcess.IsEndAttack = true;
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                     }                        
                 }
             }

--- a/Assets/Scripts/CardEffect/EX11/Yellow/EX11_020.cs
+++ b/Assets/Scripts/CardEffect/EX11/Yellow/EX11_020.cs
@@ -176,9 +176,7 @@ namespace DCGO.CardEffects.EX11
 
                             IEnumerator SuccessProcess()
                             {
-                                GManager.instance.attackProcess.IsEndAttack = true;
-
-                                yield return null;
+                                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/EX11/Yellow/EX11_021.cs
+++ b/Assets/Scripts/CardEffect/EX11/Yellow/EX11_021.cs
@@ -162,9 +162,7 @@ namespace DCGO.CardEffects.EX11
 
                         IEnumerator SuccessProcess()
                         {
-                            GManager.instance.attackProcess.IsEndAttack = true;
-
-                            yield return null;
+                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/EX6/Purple/EX6_045.cs
+++ b/Assets/Scripts/CardEffect/EX6/Purple/EX6_045.cs
@@ -167,9 +167,7 @@ namespace DCGO.CardEffects.EX6
 
                             IEnumerator SuccessProcess()
                             {
-                                GManager.instance.attackProcess.IsEndAttack = true;
-
-                                yield return null;
+                                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/EX6/Purple/EX6_048.cs
+++ b/Assets/Scripts/CardEffect/EX6/Purple/EX6_048.cs
@@ -453,9 +453,7 @@ namespace DCGO.CardEffects.EX6
 
                             IEnumerator SuccessProcess()
                             {
-                                GManager.instance.attackProcess.IsEndAttack = true;
-
-                                yield return null;
+                                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/EX7/Purple/EX7_052.cs
+++ b/Assets/Scripts/CardEffect/EX7/Purple/EX7_052.cs
@@ -176,9 +176,7 @@ namespace DCGO.CardEffects.EX7
 
                             IEnumerator SuccessProcess()
                             {
-                                GManager.instance.attackProcess.IsEndAttack = true;
-
-                                yield return null;
+                                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/EX7/Purple/EX7_054.cs
+++ b/Assets/Scripts/CardEffect/EX7/Purple/EX7_054.cs
@@ -324,9 +324,7 @@ namespace DCGO.CardEffects.EX7
 
                             IEnumerator SuccessProcess()
                             {
-                                GManager.instance.attackProcess.IsEndAttack = true;
-
-                                yield return null;
+                                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/EX9/Yellow/EX9_024.cs
+++ b/Assets/Scripts/CardEffect/EX9/Yellow/EX9_024.cs
@@ -229,9 +229,7 @@ namespace DCGO.CardEffects.EX9
 
                             IEnumerator SuccessProcess()
                             {
-                                GManager.instance.attackProcess.IsEndAttack = true;
-
-                                yield return null;
+                                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/EX9/Yellow/EX9_027.cs
+++ b/Assets/Scripts/CardEffect/EX9/Yellow/EX9_027.cs
@@ -327,9 +327,7 @@ namespace DCGO.CardEffects.EX9
 
                             IEnumerator SuccessProcess()
                             {
-                                GManager.instance.attackProcess.IsEndAttack = true;
-
-                                yield return null;
+                                yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/P/Blue/P_089.cs
+++ b/Assets/Scripts/CardEffect/P/Blue/P_089.cs
@@ -296,7 +296,7 @@ public class P_089 : CEntity_Effect
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 
-                            GManager.instance.attackProcess.IsEndAttack = true;
+                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.attackProcess.EndAttack());
                         }
                     }
                 }

--- a/Assets/Scripts/Script/AttackProcess.cs
+++ b/Assets/Scripts/Script/AttackProcess.cs
@@ -28,7 +28,8 @@ public class AttackProcess : MonoBehaviourPunCallbacks
         Counter,
         Block,
         Battle,
-        End
+        End,
+        CleanUp
     }
 
     public bool ActiveAttack()
@@ -51,6 +52,9 @@ public class AttackProcess : MonoBehaviourPunCallbacks
                 break;
             case AttackState.End:
                 yield return ContinuousController.instance.StartCoroutine(EndAttack());
+                break;
+            case AttackState.CleanUp:
+                yield return ContinuousController.instance.StartCoroutine(Cleanup());
                 break;
             default:
                 yield break;
@@ -490,17 +494,21 @@ public class AttackProcess : MonoBehaviourPunCallbacks
 
 
     #region End Attack
-    IEnumerator EndAttack()
+    public IEnumerator EndAttack()
     {
+        IsEndAttack = true;
+
         // [On End Attack] effect
         if (AttackingPermanent != null && AttackingPermanent.TopCard != null)
         {
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(EffectHashtable, EffectTiming.OnEndAttack));
         }
-        
-        // activate cutin effects
-        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.AutoProcessCheck());
 
+        State = AttackState.CleanUp;
+    }
+
+    IEnumerator Cleanup()
+    {
         #region reset effects which continues until the end of attack
         foreach (Player player in GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer)
         {
@@ -521,6 +529,8 @@ public class AttackProcess : MonoBehaviourPunCallbacks
         IsEndAttack = false;
         CounterEffectHashtable = null;
         State = AttackState.None;
+
+        yield return null;
     }
 
     public IEnumerator SwitchDefender(ICardEffect cardEffect, bool isBlock, Permanent newDefendingPermanent)


### PR DESCRIPTION
When an effect ends the attack, this should immediately trigger End of Attack timing, simultaneous to anything caused by the same effect.
Example:
EX9-024 Hanumon in Digivolution cards, deleting a Puppet token to end the attack.
Expected Result:
End of Attack effect of the attacking digimon has turn player priority and goes before the -3k from the puppet
Actual Result:
End of attack effects are waiting until all current processing is completed to even trigger. Thus the -3K gets to activate first.

Similar to AttackProcess.Attack() being used to start an attack, AttackProcess.EndAttack() Ends the attack, triggering EndOfAttack and setting up that the attack will end after all pending effects are resolved, at which point cleanup will run to actually end the attack, thus ensuring that any End Of attack effects still process with an ongoing attack.