### PR TITLE
Update BT16_028.cs

### DIFF
--- a/Assets/Scripts/CardEffect/BT16/Blue/BT16_028.cs
+++ b/Assets/Scripts/CardEffect/BT16/Blue/BT16_028.cs
@@ -84,12 +84,8 @@ namespace DCGO.CardEffects.BT16
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card))
-                    {
-                        return true;
-                    }
-
-                    return false;
+                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card)
+                        && CardEffectCommons.IsExistOnBattleArea(card);
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)


### PR DESCRIPTION
Fix the following:

When digivolved via Return of the Primo, can see digimon that were played by the effect that would have deleted the Paildramon. - same issue as BT17 Eosmon
https://discord.com/channels/1095717982522585098/1339294336579272835
