### PR TITLE
Implement Mode.Degenerate with AD1-018 to test

### DIFF
--- a/Assets/Scripts/CardEffect/AD1/Purple/AD1_018.cs
+++ b/Assets/Scripts/CardEffect/AD1/Purple/AD1_018.cs
@@ -263,8 +263,6 @@ namespace DCGO.CardEffects.AD1
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    Permanent selectedPermanent = null;
-
                     int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOpponentsPermanentCount(card, CanSelectPermanentCondition));
 
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
@@ -276,22 +274,15 @@ namespace DCGO.CardEffects.AD1
                         maxCount: 1,
                         canNoSelect: false,
                         canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                            afterSelectPermanentCoroutine: null,
-                            mode: SelectPermanentEffect.Mode.Custom,
-                            cardEffect: activateClass);
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Degenerate,
+                        cardEffect: activateClass);
 
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        selectedPermanent = permanent;
-                        yield return null;
-                    }
+                    selectPermanentEffect.SetDegenerationCount(2);
 
                     selectPermanentEffect.SetUpCustomMessage("Select 1 opponent's Digimon to De-Digivolve", "The opponent is selecting 1 Digimon to De-Digivolve");
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    if (selectedPermanent != null) yield return ContinuousController.instance.StartCoroutine(
-                        new IDegeneration(selectedPermanent, 2, activateClass).Degeneration());
                 }
             }
             #endregion
@@ -334,8 +325,6 @@ namespace DCGO.CardEffects.AD1
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    Permanent selectedPermanent = null;
-
                     int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOpponentsPermanentCount(card, CanSelectPermanentCondition));
 
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
@@ -347,22 +336,13 @@ namespace DCGO.CardEffects.AD1
                         maxCount: maxCount,
                         canNoSelect: false,
                         canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                            afterSelectPermanentCoroutine: null,
-                            mode: SelectPermanentEffect.Mode.Custom,
-                            cardEffect: activateClass);
-
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        selectedPermanent = permanent;
-                        yield return null;
-                    }
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Degenerate,
+                        cardEffect: activateClass);
 
                     selectPermanentEffect.SetUpCustomMessage("Select 1 opponent's Digimon to De-Digivolve", "The opponent is selecting 1 Digimon to De-Digivolve");
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    if (selectedPermanent != null) yield return ContinuousController.instance.StartCoroutine(
-                        new IDegeneration(selectedPermanent, 1, activateClass).Degeneration());
 
                     int maxCount1 = Math.Min(1, CardEffectCommons.MatchConditionOpponentsPermanentCount(card, CanSelectPermanentCondition1));
 

--- a/Assets/Scripts/Script/SelectPermanentEffect.cs
+++ b/Assets/Scripts/Script/SelectPermanentEffect.cs
@@ -73,6 +73,11 @@ public class SelectPermanentEffect : MonoBehaviourPunCallbacks
         _customBackButtonMessage = CustomBackButtonMessage;
     }
 
+    public void SetDegenerationCount(int degenerationCount)
+    {
+        _degenerationCount = degenerationCount;
+    }
+
     //Player to select
     Player _selectPlayer = null;
     //Conditions of units that can be selected
@@ -97,6 +102,7 @@ public class SelectPermanentEffect : MonoBehaviourPunCallbacks
     ICardEffect _cardEffect = null;
     bool _isLocal = false;
     bool _isdigiXros = false;
+    int _degenerationCount = 1;
 
     public enum Mode
     {
@@ -106,6 +112,7 @@ public class SelectPermanentEffect : MonoBehaviourPunCallbacks
         Bounce,
         PutLibraryBottom,
         PutLibraryTop,
+        Degenerate,
         Custom
     }
 
@@ -224,6 +231,7 @@ public class SelectPermanentEffect : MonoBehaviourPunCallbacks
         List<Permanent> libraryBottomPermanents = new List<Permanent>();
         List<Permanent> libraryTopPermanents = new List<Permanent>();
         List<Permanent> handBouncePermanents = new List<Permanent>();
+        List<Permanent> degeneratePermanents = new List<Permanent>();
 
         _noSelect = false;
 
@@ -302,6 +310,10 @@ public class SelectPermanentEffect : MonoBehaviourPunCallbacks
 
                         case Mode.PutLibraryTop:
                             message = "Select cards to put on top of the deck.";
+                            break;
+
+                        case Mode.Degenerate:
+                            message = $"Select cards to De-Digivolve {_degenerationCount}.";
                             break;
 
                         case Mode.Custom:
@@ -831,6 +843,10 @@ public class SelectPermanentEffect : MonoBehaviourPunCallbacks
                             case Mode.PutLibraryTop:
                                 libraryTopPermanents.Add(targetPermanent);
                                 break;
+
+                            case Mode.Degenerate:
+                                degeneratePermanents.Add(targetPermanent);
+                                break;
                         }
                         #endregion
 
@@ -883,6 +899,14 @@ public class SelectPermanentEffect : MonoBehaviourPunCallbacks
                     if (handBouncePermanents.Count > 0)
                     {
                         yield return ContinuousController.instance.StartCoroutine(new HandBounceClaass(handBouncePermanents, hashtable).Bounce());
+                    }
+
+                    if (degeneratePermanents.Count > 0)
+                    {
+                        foreach (Permanent selectedPermanent in degeneratePermanents)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(new IDegeneration(selectedPermanent, _degenerationCount, _cardEffect).Degeneration());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Saw an opportunity for another Mode to reduce the code we have to write which we can test on one of the new cards.

Called "Degenerate" to match to existing method, and as that method is not just for De-digivolve but also other effects that remove the top digivolution card of a stack.