### PR TITLE
Fix AD1-017 & AD-018 play cost reduction should show in hand

### DIFF
--- a/Assets/Scripts/CardEffect/AD1/Purple/AD1_018.cs
+++ b/Assets/Scripts/CardEffect/AD1/Purple/AD1_018.cs
@@ -96,7 +96,7 @@ namespace DCGO.CardEffects.AD1
             {
                 ChangeCostClass changeCostClass = new ChangeCostClass();
                 changeCostClass.SetUpICardEffect("Play Cost -5", CanUseCondition, card);
-                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => true, isChangePayingCost: () => true);
+                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
                 changeCostClass.SetNotShowUI(true);
                 cardEffects.Add(changeCostClass);
 

--- a/Assets/Scripts/CardEffect/AD1/Yellow/AD1_017.cs
+++ b/Assets/Scripts/CardEffect/AD1/Yellow/AD1_017.cs
@@ -95,7 +95,7 @@ namespace DCGO.CardEffects.AD1
             {
                 ChangeCostClass changeCostClass = new ChangeCostClass();
                 changeCostClass.SetUpICardEffect("Play Cost -5", CanUseCondition, card);
-                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => true, isChangePayingCost: () => true);
+                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
                 changeCostClass.SetNotShowUI(true);
                 cardEffects.Add(changeCostClass);
 


### PR DESCRIPTION
This is the difference I can see between this and the likes of DeathX and Promo gallantmon. There's the possibility I need to remove the Activate class version as well, as it might cause a double cost reduction, but I am leaving it for now so I can learn for sure if that is the case.