### PR TITLE
Fix clear attack arrow after every attack

### DIFF
--- a/Assets/Scripts/Script/AttackProcess.cs
+++ b/Assets/Scripts/Script/AttackProcess.cs
@@ -498,6 +498,8 @@ public class AttackProcess : MonoBehaviourPunCallbacks
         GManager.instance.turnStateMachine.IsSelecting = true;
         #endregion
 
+        GManager.instance.OffTargetArrow();
+
         DoSecurityCheck = false;
         IsBlocking = false;
         SecurityDigimon = null;


### PR DESCRIPTION
Currently only gets cleared in the main phase during open state, so if multiple attacks can chain without an open state, via an end of turn timing after the attack, the arrow is never cleared.