### PR TITLE
Make effect optional only when can't do mandatory processing

### DIFF
--- a/Assets/Scripts/CardEffect/AD1/Yellow/AD1_021.cs
+++ b/Assets/Scripts/CardEffect/AD1/Yellow/AD1_021.cs
@@ -122,6 +122,7 @@ namespace DCGO.CardEffects.AD1
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("1 Marcus Damon is also a 6k Digimon, gains Rush & can't digivolve. Then, 1 of your Digimon may attack", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsOptionalOverride(_ => !CardEffectCommons.HasMatchConditionOwnersPermanent(card, PermanentCondition));//Effect is optional while you do not have an Agumon or Greymon
                 activateClass.SetHashString("AD1_021_EoYT");
                 cardEffects.Add(activateClass);
 

--- a/Assets/Scripts/Script/CEntity_EffectController.cs
+++ b/Assets/Scripts/Script/CEntity_EffectController.cs
@@ -273,13 +273,6 @@ public class CEntity_EffectController : MonoBehaviour
         UseEffectsThisTurn.Add(cardEffect);
     }
     #endregion
-
-    #region Remove a use of the effect this turn
-    public void RemoveUseEffectThisTurn(ICardEffect cardEffect)
-    {
-        UseEffectsThisTurn.Remove(cardEffect);
-    }
-    #endregion
 }
 
 public class EmptyEffectClass : CEntity_Effect

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -26,6 +26,7 @@ public abstract class ICardEffect
         SetCanActivateCondition(null);
 
         SetIsOptional(false);
+        SetIsOptionalOverride(null);
         SetUseOptional(false);
         SetIsDeclarative(false);
         SetIsInheritedEffect(false);
@@ -293,6 +294,29 @@ public abstract class ICardEffect
     }
 
     #endregion
+
+    #region Override IsOptional with a function
+
+    Func<Hashtable, bool> _isOptionalFunction = null;
+
+    public Func<Hashtable, bool> IsOptionalOverride
+    {
+        get { return _isOptionalFunction; }
+        private set { _isOptionalFunction = value; }
+    }
+
+    public void SetIsOptionalOverride(Func<Hashtable, bool> isOptionalOverride)
+    {
+        _isOptionalFunction = isOptionalOverride;
+    }
+
+    #endregion
+
+    public bool IsOptionalCondition(Hashtable hashtable)
+    {
+        if (IsOptionalOverride != null) return IsOptionalOverride(hashtable);
+        return IsOptional;
+    }
 
     #region Whether this triggering effect triggers
 
@@ -986,7 +1010,7 @@ public static class ActivateICardEffectExtensionClass
 
     public static IEnumerator Activate_Optional(this ActivateICardEffect activateICardEffect, Hashtable hash)
     {
-        if (((ICardEffect)activateICardEffect).IsOptional)
+        if (((ICardEffect)activateICardEffect).IsOptionalCondition(hash))
         {
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<OptionalSkill>().SelectOptional((ICardEffect)activateICardEffect, hash));
         }
@@ -1052,7 +1076,7 @@ public static class ActivateICardEffectExtensionClass
 
     public static IEnumerator Activate_Execute(this ActivateICardEffect activateICardEffect, Hashtable hash)
     {
-        if (((ICardEffect)activateICardEffect).UseOptional || !((ICardEffect)activateICardEffect).IsOptional)
+        if (((ICardEffect)activateICardEffect).UseOptional || !((ICardEffect)activateICardEffect).IsOptionalCondition(hash))
         {
             ((ICardEffect)activateICardEffect).OnProcessCallbuck?.Invoke();
             ((ICardEffect)activateICardEffect).SetOnProcessCallbuck(null);
@@ -1126,7 +1150,7 @@ public static class ActivateICardEffectExtensionClass
         {
             UnityEngine.Debug.Log($"Activate_Optional_Effect_Execute: {((ICardEffect)activateICardEffect).EffectSourceCard.BaseENGCardNameFromEntity}");
             //Optional effect activation selection
-            if (((ICardEffect)activateICardEffect).IsOptional)
+            if (((ICardEffect)activateICardEffect).IsOptionalCondition(hash))
             {
                 if (isCheckOptional)
                 {
@@ -1181,7 +1205,7 @@ public static class ActivateICardEffectExtensionClass
     public static IEnumerator Activate_Effect_Execute(this ActivateICardEffect activateICardEffect, Hashtable hash, UnityAction<ICardEffect> useEffectCallback)
     {
         //cost → effect processing
-        if (((ICardEffect)activateICardEffect).UseOptional || !((ICardEffect)activateICardEffect).IsOptional)
+        if (((ICardEffect)activateICardEffect).UseOptional || !((ICardEffect)activateICardEffect).IsOptionalCondition(hash))
         {
             useEffectCallback?.Invoke((ICardEffect)activateICardEffect);
 
@@ -1209,13 +1233,6 @@ public static class ActivateICardEffectExtensionClass
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.RuleProcess());
     }
 
-    #endregion
-
-    #region remove a usage of an X Per Turn
-    public static void RemoveUse(this ActivateICardEffect activateICardEffect)
-    {
-        ((ICardEffect)activateICardEffect).EffectSourceCard.cEntity_EffectController.RemoveUseEffectThisTurn((ICardEffect)activateICardEffect);
-    }
     #endregion
 }
 

--- a/Assets/Scripts/Script/MultipleSkills.cs
+++ b/Assets/Scripts/Script/MultipleSkills.cs
@@ -15,7 +15,7 @@ public class MultipleSkills : MonoBehaviourPunCallbacks
     public bool IsOnlyHandEffectStacked => StackedSkillInfos.Every(skillInfo =>
         skillInfo.CardEffect != null && skillInfo.CardEffect.EffectSourceCard != null && CardEffectCommons.IsExistOnHand(skillInfo.CardEffect.EffectSourceCard) && skillInfo.CardEffect.EffectDiscription.Contains("[Hand]"));
 
-    bool IsOnlyOptionalEffectStacked => StackedSkillInfos.Every(skillInfo => skillInfo.CardEffect != null && skillInfo.CardEffect.IsOptional);
+    bool IsOnlyOptionalEffectStacked => StackedSkillInfos.Every(skillInfo => skillInfo.CardEffect != null && skillInfo.CardEffect.IsOptionalCondition(null));
     bool IsEachStackedEffectHasDistinctSourceCard => StackedSkillInfos.Filter(skillInfo1 => skillInfo1.CardEffect != null && skillInfo1.CardEffect.EffectSourceCard != null)
         .Every(skillInfo => StackedSkillInfos.Filter(skillInfo1 => skillInfo1.CardEffect != null && skillInfo1.CardEffect.EffectSourceCard != null)
             .Count(otherSkillInfo => otherSkillInfo != skillInfo && skillInfo.CardEffect.EffectSourceCard == otherSkillInfo.CardEffect.EffectSourceCard) == 0);


### PR DESCRIPTION
Not the ideal solution, but is a way we can ensure correct behaviour for methods with mandatory and optional sections.

Did some testing. Was optional and not using OPT when not activated when no yellow agumon or greymon present, and was mandatory as soon as an agumon was present