### PR TITLE
Update BT5_109.cs

### DIFF
--- a/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
+++ b/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
@@ -30,11 +30,224 @@ public class BT5_109 : CEntity_Effect
 
             IEnumerator ActivateCoroutine(Hashtable _hashtable)
             {
-                Debug.Log("This card is banned.");
-                yield return null;
+                ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
+
+                yield return new WaitForSeconds(0.2f);
+
+                ActivateClass activateClass1 = new ActivateClass();
+                Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
+                activateClass1.SetUpICardEffect("Digivolution Cost -6", CanUseCondition1, card);
+                activateClass1.SetUpActivateClass(CanActivateCondition, ActivateCoroutine1, -1, true, EffectDiscription1());
+                CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect);
+
+                ActivateClass activateClass2 = new ActivateClass();
+                Func<EffectTiming, ICardEffect> getCardEffect1 = GetCardEffect1;
+                activateClass2.SetUpICardEffect("Remove Effect", CanUseCondition1, card);
+                activateClass2.SetUpActivateClass(null, ActivateCoroutine2, -1, false, "");
+                activateClass2.SetIsBackgroundProcess(true);
+                CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect1);
+
+                Permanent playedPermanent = ;
+
+                ActivateClass activateClass3 = new ActivateClass();
+                activateClass3.SetUpICardEffect("Bottom deck the Digimon", CanUseCondition2, playedPermanent.TopCard);
+                activateClass3.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine3, -1, false, EffectDiscription2());
+                activateClass3.SetEffectSourcePermanent(playedPermanent);
+                playedPermanent.UntilOwnerTurnEndEffects.Add(GetCardEffect);
+
+                #region Reduce evo cost
+
+                string EffectDiscription1()
+                {
+                    return "Reduce the memory cost of the digivolution by 6.";
+                }
+
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(targetPermanent, card)
+                        && targetPermanent.TopCard.IsLevel6;
+                }
+
+                bool CanUseCondition1(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.CanTriggerWhenPermanentWouldDigivolve(
+                        hashtable: hashtable,
+                        permanentCondition: PermanentCondition,
+                        cardCondition: null))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return true;
+                }
+
+                IEnumerator ActivateCoroutine1(Hashtable _hashtable1)
+                {
+                    ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
+
+                    ChangeCostClass changeCostClass = new ChangeCostClass();
+                    changeCostClass.SetUpICardEffect("Digivolution Cost -6", CanUseCondition3, card);
+                    changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true); card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable1));
+
+                    bool CanUseCondition3(Hashtable hashtable)
+                    {
+                        return true;
+                    }
+
+                    int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                    {
+                        if (CardSourceCondition(cardSource))
+                        {
+                            if (RootCondition(root))
+                            {
+                                if (PermanentsCondition(targetPermanents))
+                                {
+                                    Cost -= 6;
+                                }
+                            }
+                        }
+
+                        return Cost;
+                    }
+
+                    bool PermanentsCondition(List<Permanent> targetPermanents)
+                    {
+                        if (targetPermanents != null)
+                        {
+                            if (targetPermanents.Count(PermanentCondition) >= 1)
+                            {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+
+                    bool CardSourceCondition(CardSource cardSource)
+                    {
+                        return cardSource.HasLevel
+                            && cardSource.Level == 7;
+                    }
+
+                    bool RootCondition(SelectCardEffect.Root root)
+                    {
+                        return true;
+                    }
+
+                    bool isUpDown()
+                    {
+                        return true;
+                    }
+                }
+
+                ICardEffect GetCardEffect(EffectTiming _timing)
+                {
+                    if (_timing == EffectTiming.BeforePayCost)
+                    {
+                        return activateClass1;
+                    }
+
+                    return null;
+                }
+
+
+                IEnumerator ActivateCoroutine2(Hashtable _hashtable1)
+                {
+                    if (CardEffectCommons.CanTriggerWhenPermanentWouldDigivolve(
+                        hashtable: _hashtable1,
+                        permanentCondition: PermanentCondition,
+                        cardCondition: null))
+                    {
+                        card.Owner.UntilEachTurnEndEffects.Remove(getCardEffect);
+                        card.Owner.UntilEachTurnEndEffects.Remove(getCardEffect1);
+                        yield return null;
+                    }
+                }
+
+                ICardEffect GetCardEffect1(EffectTiming _timing)
+                {
+                    if (_timing == EffectTiming.AfterPayCost)
+                    {
+                        return activateClass2;
+                    }
+
+                    return null;
+                }
+
+                yield return new WaitForSeconds(0.2f);
+
+                #endregion
+
+                #region Bot deck end of turn
+
+                if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
+                {
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(playedPermanent));
+                }
+
+                string EffectDiscription2()
+                {
+                    return "[End of Your Turn] Return the Digimon that digivolved with this effect to the bottom of its owner's deck. (Trash all of the digivolution cards of that Digimon.)";
+                }
+
+                bool CanUseCondition2(Hashtable hashtable1)
+                {
+                    if (CardEffectCommons.IsOwnerTurn(card))
+                    {
+                        if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(playedPermanent, playedPermanent.TopCard))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                bool CanActivateCondition1(Hashtable hashtable1)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
+                    {
+                        if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                IEnumerator ActivateCoroutine3(Hashtable _hashtable1)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(new DeckBottomBounceClass(
+                        new List<Permanent>() { playedPermanent },
+                        CardEffectCommons.CardEffectHashtable(activateClass1)).DeckBounce());
+                    }
+                }
+
+                ICardEffect GetCardEffect(EffectTiming _timing)
+                {
+                    if (_timing == EffectTiming.OnEndTurn)
+                    {
+                        return activateClass1;
+                    }
+
+                    return null;
+                }
+
+                #endregion
             }
         }
 
+        #region Security Effect
 
         if (timing == EffectTiming.SecuritySkill)
         {
@@ -58,6 +271,8 @@ public class BT5_109 : CEntity_Effect
                 yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.AddThisCardToHand(card, activateClass));
             }
         }
+
+        #endregion
 
         return cardEffects;
     }

--- a/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
+++ b/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
@@ -2,10 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
-using Photon;
 using System;
-using Photon.Pun;
 
+// Mega Digimon Fusion
 public class BT5_109 : CEntity_Effect
 {
     public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
@@ -53,7 +52,7 @@ public class BT5_109 : CEntity_Effect
                 activateClass3.SetUpICardEffect("Bottom deck the Digimon", CanUseCondition2, playedPermanent.TopCard);
                 activateClass3.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine3, -1, false, EffectDiscription2());
                 activateClass3.SetEffectSourcePermanent(playedPermanent);
-                playedPermanent.UntilOwnerTurnEndEffects.Add(GetCardEffect);
+                playedPermanent.UntilOwnerTurnEndEffects.Add(GetCardEffect2);
 
                 #region Reduce evo cost
 
@@ -229,15 +228,15 @@ public class BT5_109 : CEntity_Effect
                     {
                         yield return ContinuousController.instance.StartCoroutine(new DeckBottomBounceClass(
                         new List<Permanent>() { playedPermanent },
-                        CardEffectCommons.CardEffectHashtable(activateClass1)).DeckBounce());
+                        CardEffectCommons.CardEffectHashtable(activateClass3)).DeckBounce());
                     }
                 }
 
-                ICardEffect GetCardEffect(EffectTiming _timing)
+                ICardEffect GetCardEffect2(EffectTiming _timing)
                 {
                     if (_timing == EffectTiming.OnEndTurn)
                     {
-                        return activateClass1;
+                        return activateClass3;
                     }
 
                     return null;

--- a/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
+++ b/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
@@ -1,8 +1,9 @@
+using ExitGames.Client.Photon;
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
-using System;
+using UnityEngine;
 
 // Mega Digimon Fusion
 public class BT5_109 : CEntity_Effect
@@ -35,7 +36,7 @@ public class BT5_109 : CEntity_Effect
 
                 ActivateClass activateClass1 = new ActivateClass();
                 Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
-                activateClass1.SetUpICardEffect("Digivolution Cost -6", CanUseCondition1, card);
+                activateClass1.SetUpICardEffect("Digivolution Cost -6 and add self bounce", CanUseCondition1, card);
                 activateClass1.SetUpActivateClass(CanActivateCondition, ActivateCoroutine1, -1, true, EffectDiscription1());
                 CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect);
 
@@ -45,17 +46,8 @@ public class BT5_109 : CEntity_Effect
                 activateClass2.SetUpActivateClass(null, ActivateCoroutine2, -1, false, "");
                 activateClass2.SetIsBackgroundProcess(true);
                 CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect1);
-
-                Permanent playedPermanent = ;
-
-                ActivateClass activateClass3 = new ActivateClass();
-                activateClass3.SetUpICardEffect("Bottom deck the Digimon", CanUseCondition2, playedPermanent.TopCard);
-                activateClass3.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine3, -1, false, EffectDiscription2());
-                activateClass3.SetEffectSourcePermanent(playedPermanent);
-                playedPermanent.UntilOwnerTurnEndEffects.Add(GetCardEffect2);
-
+                
                 #region Reduce evo cost
-
                 string EffectDiscription1()
                 {
                     return "Reduce the memory cost of the digivolution by 6.";
@@ -90,7 +82,7 @@ public class BT5_109 : CEntity_Effect
                     ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
 
                     ChangeCostClass changeCostClass = new ChangeCostClass();
-                    changeCostClass.SetUpICardEffect("Digivolution Cost -6", CanUseCondition3, card);
+                    changeCostClass.SetUpICardEffect("Digivolution Cost -6 and add self bounce", CanUseCondition3, card);
                     changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true); card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
 
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable1));
@@ -144,6 +136,72 @@ public class BT5_109 : CEntity_Effect
                     {
                         return true;
                     }
+
+                    Permanent playedPermanent = CardEffectCommons.GetPermanentsFromHashtable(hashtable)[0];
+
+                    ActivateClass activateClass3 = new ActivateClass();
+                    activateClass3.SetUpICardEffect("Bottom deck the Digimon", CanUseCondition2, playedPermanent.TopCard);
+                    activateClass3.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine3, -1, false, EffectDiscription2());
+                    activateClass3.SetEffectSourcePermanent(playedPermanent);
+                    playedPermanent.UntilOwnerTurnEndEffects.Add(GetCardEffect2);
+
+                    #region Bot deck end of turn
+                    if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(playedPermanent));
+                    }
+
+                    string EffectDiscription2()
+                    {
+                        return "[End of Your Turn] Return the Digimon that digivolved with this effect to the bottom of its owner's deck. (Trash all of the digivolution cards of that Digimon.)";
+                    }
+
+                    bool CanUseCondition2(Hashtable hashtable1)
+                    {
+                        if (CardEffectCommons.IsOwnerTurn(card))
+                        {
+                            if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(playedPermanent, playedPermanent.TopCard))
+                            {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+
+                    bool CanActivateCondition1(Hashtable hashtable1)
+                    {
+                        if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
+                        {
+                            if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
+                            {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+
+                    IEnumerator ActivateCoroutine3(Hashtable _hashtable1)
+                    {
+                        if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(new DeckBottomBounceClass(
+                            new List<Permanent>() { playedPermanent },
+                            CardEffectCommons.CardEffectHashtable(activateClass3)).DeckBounce());
+                        }
+                    }
+
+                    ICardEffect GetCardEffect2(EffectTiming _timing)
+                    {
+                        if (_timing == EffectTiming.OnEndTurn)
+                        {
+                            return activateClass3;
+                        }
+
+                        return null;
+                    }
+                    #endregion
                 }
 
                 ICardEffect GetCardEffect(EffectTiming _timing)
@@ -181,73 +239,11 @@ public class BT5_109 : CEntity_Effect
                 }
 
                 yield return new WaitForSeconds(0.2f);
-
-                #endregion
-
-                #region Bot deck end of turn
-
-                if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
-                {
-                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(playedPermanent));
-                }
-
-                string EffectDiscription2()
-                {
-                    return "[End of Your Turn] Return the Digimon that digivolved with this effect to the bottom of its owner's deck. (Trash all of the digivolution cards of that Digimon.)";
-                }
-
-                bool CanUseCondition2(Hashtable hashtable1)
-                {
-                    if (CardEffectCommons.IsOwnerTurn(card))
-                    {
-                        if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(playedPermanent, playedPermanent.TopCard))
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                }
-
-                bool CanActivateCondition1(Hashtable hashtable1)
-                {
-                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
-                    {
-                        if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                }
-
-                IEnumerator ActivateCoroutine3(Hashtable _hashtable1)
-                {
-                    if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(new DeckBottomBounceClass(
-                        new List<Permanent>() { playedPermanent },
-                        CardEffectCommons.CardEffectHashtable(activateClass3)).DeckBounce());
-                    }
-                }
-
-                ICardEffect GetCardEffect2(EffectTiming _timing)
-                {
-                    if (_timing == EffectTiming.OnEndTurn)
-                    {
-                        return activateClass3;
-                    }
-
-                    return null;
-                }
-
                 #endregion
             }
         }
 
         #region Security Effect
-
         if (timing == EffectTiming.SecuritySkill)
         {
             ActivateClass activateClass = new ActivateClass();
@@ -270,7 +266,6 @@ public class BT5_109 : CEntity_Effect
                 yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.AddThisCardToHand(card, activateClass));
             }
         }
-
         #endregion
 
         return cardEffects;

--- a/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
+++ b/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
@@ -40,7 +40,7 @@ namespace DCGO.CardEffects.BT5
                     ActivateClass activateClass1 = new ActivateClass();
                     Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
                     activateClass1.SetUpICardEffect("Digivolution Cost -6 and add self bounce", CanUseCondition1, card);
-                    activateClass1.SetUpActivateClass(CanActivateCondition, ActivateCoroutine1, -1, true, EffectDiscription1());
+                    activateClass1.SetUpActivateClass(CanActivateCondition, ActivateCoroutine1, -1, false, EffectDescription1());
                     CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect);
 
                     ActivateClass activateClass2 = new ActivateClass();
@@ -51,7 +51,7 @@ namespace DCGO.CardEffects.BT5
                     CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect1);
 
                     #region Reduce evo cost
-                    string EffectDiscription1()
+                    string EffectDescription1()
                     {
                         return "Reduce the memory cost of the digivolution by 6.";
                     }
@@ -82,6 +82,8 @@ namespace DCGO.CardEffects.BT5
 
                     IEnumerator ActivateCoroutine1(Hashtable _hashtable1)
                     {
+                        Permanent playedPermanent = null;
+
                         ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
 
                         ChangeCostClass changeCostClass = new ChangeCostClass();
@@ -115,6 +117,8 @@ namespace DCGO.CardEffects.BT5
                         {
                             if (targetPermanents != null)
                             {
+                                playedPermanent = targetPermanents[0];
+
                                 if (targetPermanents.Count(PermanentCondition) >= 1)
                                 {
                                     return true;
@@ -139,9 +143,6 @@ namespace DCGO.CardEffects.BT5
                         {
                             return true;
                         }
-
-                        List<Permanent> Permanents = CardEffectCommons.GetPermanentsFromHashtable(_hashtable);
-                        Permanent playedPermanent = Permanents[0];
 
                         ActivateClass activateClass3 = new ActivateClass();
                         activateClass3.SetUpICardEffect("Bottom deck the Digimon", CanUseCondition2, playedPermanent.TopCard);

--- a/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
+++ b/Assets/Scripts/CardEffect/BT5/White/BT5_109.cs
@@ -1,273 +1,279 @@
-using ExitGames.Client.Photon;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
+
 // Mega Digimon Fusion
-public class BT5_109 : CEntity_Effect
+namespace DCGO.CardEffects.BT5
 {
-    public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+    public class BT5_109 : CEntity_Effect
     {
-        List<ICardEffect> cardEffects = new List<ICardEffect>();
-
-        if (timing == EffectTiming.OptionSkill)
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
         {
-            ActivateClass activateClass = new ActivateClass();
-            activateClass.SetUpICardEffect(card.BaseENGCardNameFromEntity, CanUseCondition, card);
-            activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDiscription());
-            cardEffects.Add(activateClass);
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            string EffectDiscription()
+            #region Main
+            if (timing == EffectTiming.OptionSkill)
             {
-                return "[Main] The next time one of your Digimon digivolves from level 6 to level 7 this turn, reduce the memory cost of the digivolution by 6. At the end of the turn, return the Digimon that digivolved with this effect to the bottom of its owner's deck. Trash all of the digivolution cards of that Digimon.";
-            }
-            bool CanUseCondition(Hashtable hashtable)
-            {
-                return CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
-            }
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(card.BaseENGCardNameFromEntity, CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDiscription());
+                cardEffects.Add(activateClass);
 
-            IEnumerator ActivateCoroutine(Hashtable _hashtable)
-            {
-                ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
-
-                yield return new WaitForSeconds(0.2f);
-
-                ActivateClass activateClass1 = new ActivateClass();
-                Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
-                activateClass1.SetUpICardEffect("Digivolution Cost -6 and add self bounce", CanUseCondition1, card);
-                activateClass1.SetUpActivateClass(CanActivateCondition, ActivateCoroutine1, -1, true, EffectDiscription1());
-                CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect);
-
-                ActivateClass activateClass2 = new ActivateClass();
-                Func<EffectTiming, ICardEffect> getCardEffect1 = GetCardEffect1;
-                activateClass2.SetUpICardEffect("Remove Effect", CanUseCondition1, card);
-                activateClass2.SetUpActivateClass(null, ActivateCoroutine2, -1, false, "");
-                activateClass2.SetIsBackgroundProcess(true);
-                CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect1);
-                
-                #region Reduce evo cost
-                string EffectDiscription1()
+                string EffectDiscription()
                 {
-                    return "Reduce the memory cost of the digivolution by 6.";
+                    return "[Main] The next time one of your Digimon digivolves from level 6 to level 7 this turn, reduce the memory cost of the digivolution by 6. At the end of the turn, return the Digimon that digivolved with this effect to the bottom of its owner's deck. Trash all of the digivolution cards of that Digimon.";
+                }
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
                 }
 
-                bool PermanentCondition(Permanent targetPermanent)
-                {
-                    return CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(targetPermanent, card)
-                        && targetPermanent.TopCard.IsLevel6;
-                }
-
-                bool CanUseCondition1(Hashtable hashtable)
-                {
-                    if (CardEffectCommons.CanTriggerWhenPermanentWouldDigivolve(
-                        hashtable: hashtable,
-                        permanentCondition: PermanentCondition,
-                        cardCondition: null))
-                    {
-                        return true;
-                    }
-
-                    return false;
-                }
-
-                bool CanActivateCondition(Hashtable hashtable)
-                {
-                    return true;
-                }
-
-                IEnumerator ActivateCoroutine1(Hashtable _hashtable1)
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
                     ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
 
-                    ChangeCostClass changeCostClass = new ChangeCostClass();
-                    changeCostClass.SetUpICardEffect("Digivolution Cost -6 and add self bounce", CanUseCondition3, card);
-                    changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true); card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
+                    yield return new WaitForSeconds(0.2f);
 
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable1));
+                    ActivateClass activateClass1 = new ActivateClass();
+                    Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
+                    activateClass1.SetUpICardEffect("Digivolution Cost -6 and add self bounce", CanUseCondition1, card);
+                    activateClass1.SetUpActivateClass(CanActivateCondition, ActivateCoroutine1, -1, true, EffectDiscription1());
+                    CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect);
 
-                    bool CanUseCondition3(Hashtable hashtable)
+                    ActivateClass activateClass2 = new ActivateClass();
+                    Func<EffectTiming, ICardEffect> getCardEffect1 = GetCardEffect1;
+                    activateClass2.SetUpICardEffect("Remove Effect", CanUseCondition1, card);
+                    activateClass2.SetUpActivateClass(null, ActivateCoroutine2, -1, false, "");
+                    activateClass2.SetIsBackgroundProcess(true);
+                    CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilEachTurnEnd, card: card, cardEffect: null, timing: EffectTiming.None, getCardEffect: getCardEffect1);
+
+                    #region Reduce evo cost
+                    string EffectDiscription1()
+                    {
+                        return "Reduce the memory cost of the digivolution by 6.";
+                    }
+
+                    bool PermanentCondition(Permanent targetPermanent)
+                    {
+                        return CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(targetPermanent, card)
+                            && targetPermanent.TopCard.IsLevel6;
+                    }
+
+                    bool CanUseCondition1(Hashtable hashtable)
+                    {
+                        if (CardEffectCommons.CanTriggerWhenPermanentWouldDigivolve(
+                            hashtable: hashtable,
+                            permanentCondition: PermanentCondition,
+                            cardCondition: null))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    }
+
+                    bool CanActivateCondition(Hashtable hashtable)
                     {
                         return true;
                     }
 
-                    int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                    IEnumerator ActivateCoroutine1(Hashtable _hashtable1)
                     {
-                        if (CardSourceCondition(cardSource))
+                        ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
+
+                        ChangeCostClass changeCostClass = new ChangeCostClass();
+                        changeCostClass.SetUpICardEffect("Digivolution Cost -6 and add self bounce", CanUseCondition3, card);
+                        changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true); card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable1));
+
+                        bool CanUseCondition3(Hashtable hashtable)
                         {
-                            if (RootCondition(root))
+                            return true;
+                        }
+
+                        int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                        {
+                            if (CardSourceCondition(cardSource))
                             {
-                                if (PermanentsCondition(targetPermanents))
+                                if (RootCondition(root))
                                 {
-                                    Cost -= 6;
+                                    if (PermanentsCondition(targetPermanents))
+                                    {
+                                        Cost -= 6;
+                                    }
                                 }
                             }
+
+                            return Cost;
                         }
 
-                        return Cost;
-                    }
-
-                    bool PermanentsCondition(List<Permanent> targetPermanents)
-                    {
-                        if (targetPermanents != null)
+                        bool PermanentsCondition(List<Permanent> targetPermanents)
                         {
-                            if (targetPermanents.Count(PermanentCondition) >= 1)
+                            if (targetPermanents != null)
                             {
-                                return true;
+                                if (targetPermanents.Count(PermanentCondition) >= 1)
+                                {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        }
+
+                        bool CardSourceCondition(CardSource cardSource)
+                        {
+                            return cardSource.HasLevel
+                                && cardSource.Level == 7;
+                        }
+
+                        bool RootCondition(SelectCardEffect.Root root)
+                        {
+                            return true;
+                        }
+
+                        bool isUpDown()
+                        {
+                            return true;
+                        }
+
+                        List<Permanent> Permanents = CardEffectCommons.GetPermanentsFromHashtable(_hashtable);
+                        Permanent playedPermanent = Permanents[0];
+
+                        ActivateClass activateClass3 = new ActivateClass();
+                        activateClass3.SetUpICardEffect("Bottom deck the Digimon", CanUseCondition2, playedPermanent.TopCard);
+                        activateClass3.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine3, -1, false, EffectDiscription2());
+                        activateClass3.SetEffectSourcePermanent(playedPermanent);
+                        playedPermanent.UntilOwnerTurnEndEffects.Add(GetCardEffect2);
+
+                        #region Bot deck end of turn
+                        if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(playedPermanent));
+                        }
+
+                        string EffectDiscription2()
+                        {
+                            return "[End of Your Turn] Return the Digimon that digivolved with this effect to the bottom of its owner's deck. (Trash all of the digivolution cards of that Digimon.)";
+                        }
+
+                        bool CanUseCondition2(Hashtable hashtable1)
+                        {
+                            if (CardEffectCommons.IsOwnerTurn(card))
+                            {
+                                if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(playedPermanent, playedPermanent.TopCard))
+                                {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        }
+
+                        bool CanActivateCondition1(Hashtable hashtable1)
+                        {
+                            if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
+                            {
+                                if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
+                                {
+                                    return true;
+                                }
+                            }
+
+                            return false;
+                        }
+
+                        IEnumerator ActivateCoroutine3(Hashtable _hashtable1)
+                        {
+                            if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(new DeckBottomBounceClass(
+                                new List<Permanent>() { playedPermanent },
+                                CardEffectCommons.CardEffectHashtable(activateClass3)).DeckBounce());
                             }
                         }
 
-                        return false;
-                    }
-
-                    bool CardSourceCondition(CardSource cardSource)
-                    {
-                        return cardSource.HasLevel
-                            && cardSource.Level == 7;
-                    }
-
-                    bool RootCondition(SelectCardEffect.Root root)
-                    {
-                        return true;
-                    }
-
-                    bool isUpDown()
-                    {
-                        return true;
-                    }
-
-                    Permanent playedPermanent = CardEffectCommons.GetPermanentsFromHashtable(hashtable)[0];
-
-                    ActivateClass activateClass3 = new ActivateClass();
-                    activateClass3.SetUpICardEffect("Bottom deck the Digimon", CanUseCondition2, playedPermanent.TopCard);
-                    activateClass3.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine3, -1, false, EffectDiscription2());
-                    activateClass3.SetEffectSourcePermanent(playedPermanent);
-                    playedPermanent.UntilOwnerTurnEndEffects.Add(GetCardEffect2);
-
-                    #region Bot deck end of turn
-                    if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(playedPermanent));
-                    }
-
-                    string EffectDiscription2()
-                    {
-                        return "[End of Your Turn] Return the Digimon that digivolved with this effect to the bottom of its owner's deck. (Trash all of the digivolution cards of that Digimon.)";
-                    }
-
-                    bool CanUseCondition2(Hashtable hashtable1)
-                    {
-                        if (CardEffectCommons.IsOwnerTurn(card))
+                        ICardEffect GetCardEffect2(EffectTiming _timing)
                         {
-                            if (CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(playedPermanent, playedPermanent.TopCard))
+                            if (_timing == EffectTiming.OnEndTurn)
                             {
-                                return true;
+                                return activateClass3;
                             }
-                        }
 
-                        return false;
+                            return null;
+                        }
+                        #endregion
                     }
 
-                    bool CanActivateCondition1(Hashtable hashtable1)
+                    ICardEffect GetCardEffect(EffectTiming _timing)
                     {
-                        if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
+                        if (_timing == EffectTiming.BeforePayCost)
                         {
-                            if (!playedPermanent.TopCard.CanNotBeAffected(activateClass))
-                            {
-                                return true;
-                            }
-                        }
-
-                        return false;
-                    }
-
-                    IEnumerator ActivateCoroutine3(Hashtable _hashtable1)
-                    {
-                        if (CardEffectCommons.IsPermanentExistsOnBattleArea(playedPermanent))
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(new DeckBottomBounceClass(
-                            new List<Permanent>() { playedPermanent },
-                            CardEffectCommons.CardEffectHashtable(activateClass3)).DeckBounce());
-                        }
-                    }
-
-                    ICardEffect GetCardEffect2(EffectTiming _timing)
-                    {
-                        if (_timing == EffectTiming.OnEndTurn)
-                        {
-                            return activateClass3;
+                            return activateClass1;
                         }
 
                         return null;
                     }
+
+
+                    IEnumerator ActivateCoroutine2(Hashtable _hashtable1)
+                    {
+                        if (CardEffectCommons.CanTriggerWhenPermanentWouldDigivolve(
+                            hashtable: _hashtable1,
+                            permanentCondition: PermanentCondition,
+                            cardCondition: null))
+                        {
+                            card.Owner.UntilEachTurnEndEffects.Remove(getCardEffect);
+                            card.Owner.UntilEachTurnEndEffects.Remove(getCardEffect1);
+                            yield return null;
+                        }
+                    }
+
+                    ICardEffect GetCardEffect1(EffectTiming _timing)
+                    {
+                        if (_timing == EffectTiming.AfterPayCost)
+                        {
+                            return activateClass2;
+                        }
+
+                        return null;
+                    }
+
+                    yield return new WaitForSeconds(0.2f);
                     #endregion
                 }
-
-                ICardEffect GetCardEffect(EffectTiming _timing)
-                {
-                    if (_timing == EffectTiming.BeforePayCost)
-                    {
-                        return activateClass1;
-                    }
-
-                    return null;
-                }
-
-
-                IEnumerator ActivateCoroutine2(Hashtable _hashtable1)
-                {
-                    if (CardEffectCommons.CanTriggerWhenPermanentWouldDigivolve(
-                        hashtable: _hashtable1,
-                        permanentCondition: PermanentCondition,
-                        cardCondition: null))
-                    {
-                        card.Owner.UntilEachTurnEndEffects.Remove(getCardEffect);
-                        card.Owner.UntilEachTurnEndEffects.Remove(getCardEffect1);
-                        yield return null;
-                    }
-                }
-
-                ICardEffect GetCardEffect1(EffectTiming _timing)
-                {
-                    if (_timing == EffectTiming.AfterPayCost)
-                    {
-                        return activateClass2;
-                    }
-
-                    return null;
-                }
-
-                yield return new WaitForSeconds(0.2f);
-                #endregion
             }
+            #endregion
+
+            #region Security Effect
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect($"Add this card to hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDiscription());
+                activateClass.SetIsSecurityEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                {
+                    return "[Security] Add this card to its owner's hand.";
+                }
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.CanTriggerSecurityEffect(hashtable, card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.AddThisCardToHand(card, activateClass));
+                }
+            }
+            #endregion
+
+            return cardEffects;
         }
-
-        #region Security Effect
-        if (timing == EffectTiming.SecuritySkill)
-        {
-            ActivateClass activateClass = new ActivateClass();
-            activateClass.SetUpICardEffect($"Add this card to hand", CanUseCondition, card);
-            activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDiscription());
-            activateClass.SetIsSecurityEffect(true);
-            cardEffects.Add(activateClass);
-
-            string EffectDiscription()
-            {
-                return "[Security] Add this card to its owner's hand.";
-            }
-            bool CanUseCondition(Hashtable hashtable)
-            {
-                return CardEffectCommons.CanTriggerSecurityEffect(hashtable, card);
-            }
-
-            IEnumerator ActivateCoroutine(Hashtable _hashtable)
-            {
-                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.AddThisCardToHand(card, activateClass));
-            }
-        }
-        #endregion
-
-        return cardEffects;
     }
 }


### PR DESCRIPTION
Notes from previous reviews in old Repo:

hooperk reviewed on Jan 16
CardEffect/BT5/White/BT5_109.cs
                    {
                        if (targetPermanents != null)
                        {
                            if (targetPermanents.Count(PermanentCondition) >= 1)
Member
@hooperk
hooperk
on Jan 16
I think this should be ==1 in order to correctly be "when 1 of your level 6 digimon..."

Member
Author
@x89rt2
x89rt2
on Jan 16
Doesn't matter cause you can only do 1 digivolution at a time. Also, this "one" might be an "any".

Member
@hooperk
hooperk
on Jan 16
Jogress would count and is 2 permanents. Although currently there isn't a jogress with a non-0 cost for this to matter for, it does mean that jogressed digimon would be given the deck bounce effect despite not meeting this card's condition

Member
Author
@x89rt2
x89rt2
on Jan 16
• 
Am I still missing something or isn't that fine? since one means any? For the record, my brain is not really on right now. https://discord.com/channels/681578268729540663/749146995708395601/1461739750250647623

@x89rt2	Reply...
hooperk
hooperk reviewed on Jan 16
CardEffect/BT5/White/BT5_109.cs

                ICardEffect GetCardEffect(EffectTiming _timing)
                {
                    if (_timing == EffectTiming.BeforePayCost)
Member
@hooperk
hooperk
on Jan 16
If this effect goes off here, it will remove the cost reduction just before you would use int. Instead maybe this could go to when digivolving timing and remove the effect just after digivolution? EffectTiming.OnEnterFieldAnyone

@x89rt2	Reply...
hooperk
hooperk reviewed on Jan 16
CardEffect/BT5/White/BT5_109.cs

                IEnumerator ActivateCoroutine2(Hashtable _hashtable1)
                {
                    if (CardEffectCommons.CanTriggerWhenPermanentWouldDigivolve(
Member
@hooperk
hooperk
on Jan 16
If this does move to when digivolving timing, this will need to change with it

@x89rt2	Reply...
hooperk
hooperk reviewed on Jan 16
CardEffect/BT5/White/BT5_109.cs
                        cardCondition: null))
                    {
                        card.Owner.UntilEachTurnEndEffects.Remove(getCardEffect);
                        card.Owner.UntilEachTurnEndEffects.Remove(getCardEffect1);
Member
@hooperk
hooperk
on Jan 16
You should probably also add the deck bottom effect as part of this effect.