### PR TITLE
Fix Select X and Y effects taking 1 card as both

### DIFF
--- a/Assets/Scripts/CardEffect/BT10/Green/BT10_046.cs
+++ b/Assets/Scripts/CardEffect/BT10/Green/BT10_046.cs
@@ -75,7 +75,8 @@ namespace DCGO.CardEffects.BT10
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT10/Purple/BT10_073.cs
+++ b/Assets/Scripts/CardEffect/BT10/Purple/BT10_073.cs
@@ -98,7 +98,8 @@ namespace DCGO.CardEffects.BT10
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT10/Red/BT10_008.cs
+++ b/Assets/Scripts/CardEffect/BT10/Red/BT10_008.cs
@@ -101,7 +101,8 @@ namespace DCGO.CardEffects.BT10
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT10/Yellow/BT10_032.cs
+++ b/Assets/Scripts/CardEffect/BT10/Yellow/BT10_032.cs
@@ -91,7 +91,8 @@ namespace DCGO.CardEffects.BT10
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT11/Black/BT11_062.cs
+++ b/Assets/Scripts/CardEffect/BT11/Black/BT11_062.cs
@@ -99,7 +99,8 @@ namespace DCGO.CardEffects.BT11
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT11/Blue/BT11_020.cs
+++ b/Assets/Scripts/CardEffect/BT11/Blue/BT11_020.cs
@@ -87,7 +87,8 @@ namespace DCGO.CardEffects.BT11
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.Trash,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT11/Blue/BT11_023.cs
+++ b/Assets/Scripts/CardEffect/BT11/Blue/BT11_023.cs
@@ -86,7 +86,8 @@ namespace DCGO.CardEffects.BT11
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT11/Red/BT11_007.cs
+++ b/Assets/Scripts/CardEffect/BT11/Red/BT11_007.cs
@@ -89,7 +89,8 @@ namespace DCGO.CardEffects.BT11
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT12/Black/BT12_059.cs
+++ b/Assets/Scripts/CardEffect/BT12/Black/BT12_059.cs
@@ -101,7 +101,8 @@ namespace DCGO.CardEffects.BT12
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT12/Blue/BT12_021.cs
+++ b/Assets/Scripts/CardEffect/BT12/Blue/BT12_021.cs
@@ -95,7 +95,8 @@ namespace DCGO.CardEffects.BT12
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT12/Green/BT12_047.cs
+++ b/Assets/Scripts/CardEffect/BT12/Green/BT12_047.cs
@@ -95,7 +95,8 @@ namespace DCGO.CardEffects.BT12
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT12/White/BT12_098.cs
+++ b/Assets/Scripts/CardEffect/BT12/White/BT12_098.cs
@@ -80,7 +80,8 @@ namespace DCGO.CardEffects.BT12
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT12/Yellow/BT12_034.cs
+++ b/Assets/Scripts/CardEffect/BT12/Yellow/BT12_034.cs
@@ -99,7 +99,8 @@ namespace DCGO.CardEffects.BT12
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT13/Yellow/BT13_034.cs
+++ b/Assets/Scripts/CardEffect/BT13/Yellow/BT13_034.cs
@@ -90,7 +90,8 @@ namespace DCGO.CardEffects.BT13
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }
@@ -106,7 +107,7 @@ namespace DCGO.CardEffects.BT13
 
                 string EffectDiscription()
                 {
-                    return "[When Attacking][Once per Turn] If there're 6 or fewer total cards in both players' security stacks, 1 of your opponentÅf Digimon gets -2000 DP for the turn.";
+                    return "[When Attacking][Once per Turn] If there're 6 or fewer total cards in both players' security stacks, 1 of your opponentÔøΩf Digimon gets -2000 DP for the turn.";
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/BT3/Blue/BT3_093.cs
+++ b/Assets/Scripts/CardEffect/BT3/Blue/BT3_093.cs
@@ -94,7 +94,8 @@ public class BT3_093 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT3/Green/BT3_051.cs
+++ b/Assets/Scripts/CardEffect/BT3/Green/BT3_051.cs
@@ -96,7 +96,8 @@ public class BT3_051 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.Trash,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT3/Red/BT3_008.cs
+++ b/Assets/Scripts/CardEffect/BT3/Red/BT3_008.cs
@@ -99,7 +99,8 @@ public class BT3_008 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
 
                 #region old
@@ -114,7 +115,7 @@ public class BT3_008 : CEntity_Effect
 
                                             int maxCount = 2;
 
-                                            #region Å‘å–‡”
+                                            #region ï¿½Å‘å–‡ï¿½ï¿½
                                             List<CardSource[]> cardsList = ParameterComparer.Enumerate(revealLibrary.revealedCards, maxCount).ToList();
 
                                             List<int> maxCounts = new List<int>() { 0 };
@@ -212,7 +213,7 @@ public class BT3_008 : CEntity_Effect
 
                                             yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
 
-                                            #region ƒŠƒXƒg‚É‚æ‚é‘I‘ğğŒ
+                                            #region ï¿½ï¿½ï¿½Xï¿½gï¿½É‚ï¿½ï¿½Iï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
                                             bool CanTargetCondition_ByPreSelecetedList(List<CardSource> cardSources, CardSource cardSource)
                                             {
                                                 List<CardSource> _cardSources = new List<CardSource>();
@@ -264,7 +265,7 @@ public class BT3_008 : CEntity_Effect
                                             }
                                             #endregion
 
-                                            #region ‘I‘ğğŒ
+                                            #region ï¿½Iï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
                                             bool CanEndSelectCondition(List<CardSource> cardSources)
                                             {
                                                 List<CardSource[]> cardsList = ParameterComparer.Enumerate(cardSources, cardSources.Count).ToList();

--- a/Assets/Scripts/CardEffect/BT5/Black/BT5_059.cs
+++ b/Assets/Scripts/CardEffect/BT5/Black/BT5_059.cs
@@ -92,7 +92,8 @@ public class BT5_059 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT5/Blue/BT5_020.cs
+++ b/Assets/Scripts/CardEffect/BT5/Blue/BT5_020.cs
@@ -89,7 +89,8 @@ public class BT5_020 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT5/Red/BT5_007.cs
+++ b/Assets/Scripts/CardEffect/BT5/Red/BT5_007.cs
@@ -88,7 +88,8 @@ public class BT5_007 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT6/Green/BT6_047.cs
+++ b/Assets/Scripts/CardEffect/BT6/Green/BT6_047.cs
@@ -81,7 +81,8 @@ public class BT6_047 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT7/Green/BT7_046.cs
+++ b/Assets/Scripts/CardEffect/BT7/Green/BT7_046.cs
@@ -98,7 +98,8 @@ public class BT7_046 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT8/Black/BT8_058.cs
+++ b/Assets/Scripts/CardEffect/BT8/Black/BT8_058.cs
@@ -73,7 +73,8 @@ public class BT8_058 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT8/Black/BT8_060.cs
+++ b/Assets/Scripts/CardEffect/BT8/Black/BT8_060.cs
@@ -83,7 +83,8 @@ public class BT8_060 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT9/Black/BT9_090.cs
+++ b/Assets/Scripts/CardEffect/BT9/Black/BT9_090.cs
@@ -81,7 +81,8 @@ public class BT9_090 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT9/Blue/BT9_020.cs
+++ b/Assets/Scripts/CardEffect/BT9/Blue/BT9_020.cs
@@ -103,7 +103,8 @@ public class BT9_020 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT9/Green/BT9_046.cs
+++ b/Assets/Scripts/CardEffect/BT9/Green/BT9_046.cs
@@ -102,7 +102,8 @@ public class BT9_046 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT9/Red/BT9_008.cs
+++ b/Assets/Scripts/CardEffect/BT9/Red/BT9_008.cs
@@ -103,7 +103,8 @@ public class BT9_008 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/BT9/White/BT9_092.cs
+++ b/Assets/Scripts/CardEffect/BT9/White/BT9_092.cs
@@ -89,7 +89,8 @@ public class BT9_092 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/CardEffect/EX2/Purple/EX2_039.cs
+++ b/Assets/Scripts/CardEffect/EX2/Purple/EX2_039.cs
@@ -172,7 +172,8 @@ namespace DCGO.CardEffects.EX2
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX2/Red/EX2_008.cs
+++ b/Assets/Scripts/CardEffect/EX2/Red/EX2_008.cs
@@ -91,7 +91,8 @@ namespace DCGO.CardEffects.EX2
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX2/White/EX2_047.cs
+++ b/Assets/Scripts/CardEffect/EX2/White/EX2_047.cs
@@ -80,7 +80,8 @@ namespace DCGO.CardEffects.EX2
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX2/Yellow/EX2_019.cs
+++ b/Assets/Scripts/CardEffect/EX2/Yellow/EX2_019.cs
@@ -95,7 +95,8 @@ namespace DCGO.CardEffects.EX2
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX3/Black/EX3_048.cs
+++ b/Assets/Scripts/CardEffect/EX3/Black/EX3_048.cs
@@ -133,7 +133,8 @@ namespace DCGO.CardEffects.EX3
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX3/Green/EX3_037.cs
+++ b/Assets/Scripts/CardEffect/EX3/Green/EX3_037.cs
@@ -93,7 +93,8 @@ namespace DCGO.CardEffects.EX3
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX3/Red/EX3_007.cs
+++ b/Assets/Scripts/CardEffect/EX3/Red/EX3_007.cs
@@ -134,7 +134,8 @@ namespace DCGO.CardEffects.EX3
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX3/Yellow/EX3_028.cs
+++ b/Assets/Scripts/CardEffect/EX3/Yellow/EX3_028.cs
@@ -88,7 +88,8 @@ namespace DCGO.CardEffects.EX3
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX3/Yellow/EX3_030.cs
+++ b/Assets/Scripts/CardEffect/EX3/Yellow/EX3_030.cs
@@ -89,7 +89,8 @@ namespace DCGO.CardEffects.EX3
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX3/Yellow/EX3_031.cs
+++ b/Assets/Scripts/CardEffect/EX3/Yellow/EX3_031.cs
@@ -89,7 +89,8 @@ namespace DCGO.CardEffects.EX3
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX4/Black/EX4_038.cs
+++ b/Assets/Scripts/CardEffect/EX4/Black/EX4_038.cs
@@ -96,7 +96,8 @@ namespace DCGO.CardEffects.EX4
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckTop,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX4/Black/EX4_039.cs
+++ b/Assets/Scripts/CardEffect/EX4/Black/EX4_039.cs
@@ -96,7 +96,8 @@ namespace DCGO.CardEffects.EX4
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckTop,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX4/Blue/EX4_016.cs
+++ b/Assets/Scripts/CardEffect/EX4/Blue/EX4_016.cs
@@ -93,7 +93,8 @@ namespace DCGO.CardEffects.EX4
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.Trash,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX4/Green/EX4_032.cs
+++ b/Assets/Scripts/CardEffect/EX4/Green/EX4_032.cs
@@ -87,7 +87,8 @@ namespace DCGO.CardEffects.EX4
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX4/Green/EX4_034.cs
+++ b/Assets/Scripts/CardEffect/EX4/Green/EX4_034.cs
@@ -87,7 +87,8 @@ namespace DCGO.CardEffects.EX4
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/EX4/Purple/EX4_053.cs
+++ b/Assets/Scripts/CardEffect/EX4/Purple/EX4_053.cs
@@ -97,7 +97,8 @@ namespace DCGO.CardEffects.EX4
                             selectCardCoroutine: null),
                         },
                         remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                        activateClass: activateClass
+                        activateClass: activateClass,
+                        mutualConditions: true
                     ));
                 }
             }

--- a/Assets/Scripts/CardEffect/ST10/Purple/ST10_12.cs
+++ b/Assets/Scripts/CardEffect/ST10/Purple/ST10_12.cs
@@ -155,7 +155,8 @@ public class ST10_12 : CEntity_Effect
                                     selectCardCoroutine: null),
                             },
                             remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                            activateClass: activateClass
+                            activateClass: activateClass,
+                            mutualConditions: true
                             ));
                     }
                 }

--- a/Assets/Scripts/CardEffect/ST10/Yellow/ST10_04.cs
+++ b/Assets/Scripts/CardEffect/ST10/Yellow/ST10_04.cs
@@ -88,7 +88,8 @@ public class ST10_04 : CEntity_Effect
                             selectCardCoroutine: null),
                     },
                     remainingCardsPlace: RemainingCardsPlace.DeckBottom,
-                    activateClass: activateClass
+                    activateClass: activateClass,
+                    mutualConditions: true
                 ));
             }
         }

--- a/Assets/Scripts/Script/CardEffectCommons/RevealLibrary.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/RevealLibrary.cs
@@ -187,7 +187,8 @@ public partial class CardEffectCommons
         bool canEndNotMax = false,
         bool isSendAllCardsToSamePlace = false,
         bool isOpponentDeck = false,
-        Func<List<CardSource>, IEnumerator> revealedCardsCoroutine = null)
+        Func<List<CardSource>, IEnumerator> revealedCardsCoroutine = null,
+        bool mutualConditions = false)
     {
         if (revealCount <= 0) yield break;
         if (activateClass == null) yield break;
@@ -220,7 +221,8 @@ public partial class CardEffectCommons
             activateClass: activateClass,
             isSendAllCardsToSamePlace: isSendAllCardsToSamePlace,
             isOpponentDeck: isOpponentDeck,
-            revealedCardsCoroutine: revealedCardsCoroutine
+            revealedCardsCoroutine: revealedCardsCoroutine,
+            mutualConditions: mutualConditions
         ));
     }
 
@@ -232,7 +234,8 @@ public partial class CardEffectCommons
         bool canNoAction = false,
         bool isSendAllCardsToSamePlace = false,
         bool isOpponentDeck = false,
-        Func<List<CardSource>, IEnumerator> revealedCardsCoroutine = null)
+        Func<List<CardSource>, IEnumerator> revealedCardsCoroutine = null,
+        bool mutualConditions = false)
     {
         if (revealCount <= 0) yield break;
         if (activateClass == null) yield break;
@@ -253,10 +256,12 @@ public partial class CardEffectCommons
 
         List<CardSource> remainingCards = revealedCards.Clone();
 
+        List<CardSource> chosenCards = new List<CardSource>();
+
         bool doAction = true;
 
-        // ƒo[ƒjƒ“ƒOƒXƒ^[ƒNƒ‰ƒbƒVƒƒ[(BT10-096)
-        // ƒuƒŒƒCƒWƒ“ƒOEƒƒ‚ƒŠ[ƒu[ƒXƒg
+        // ï¿½oï¿½[ï¿½jï¿½ï¿½ï¿½Oï¿½Xï¿½^ï¿½[ï¿½Nï¿½ï¿½ï¿½bï¿½Vï¿½ï¿½ï¿½[(BT10-096)
+        // ï¿½uï¿½ï¿½ï¿½Cï¿½Wï¿½ï¿½ï¿½Oï¿½Eï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½uï¿½[ï¿½Xï¿½g
         if (selectCardConditions.Length >= 2)
         {
             if (canNoAction)
@@ -282,17 +287,32 @@ public partial class CardEffectCommons
         {
             SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
 
+            bool firstSelection = true;
+
             foreach(SelectCardConditionClass selectCondition in selectCardConditions)
             {
                 int maxCount = Math.Min(selectCondition.MaxCount, revealedCards.Count(selectCondition.CanTargetCondition));
 
                 if (maxCount >= 1)
                 {
+                    bool canNoSelect = selectCondition.CanNoSelect;
+                    if (firstSelection)
+                    {
+                        firstSelection = false;
+                    }
+                    else if (mutualConditions //If both conditions are chosen at once (per card game rules)
+                          && chosenCards.Count == 1 //And first condition lets you select 1
+                          && selectCondition.CanTargetCondition(chosenCards[0]) //If that one also fulfills the second condition
+                          && !revealedCards.Any(selectCardConditions[0].CanTargetCondition)) //And was the only card that could fulfill the first condition
+                    {
+                        canNoSelect = true; // Can no select on the basis of choosing it as the second condition, leaving no valid targets for the first
+                    }
+
                     selectCardEffect.SetUp(
                         canTargetCondition: selectCondition.CanTargetCondition,
                         canTargetCondition_ByPreSelecetedList: selectCondition.CanTargetCondition_ByPreSelecetedList,
                         canEndSelectCondition: selectCondition.CanEndSelectCondition,
-                        canNoSelect: () => selectCondition.CanNoSelect,
+                        canNoSelect: () => canNoSelect,
                         selectCardCoroutine: selectCondition.SelectCardCoroutine,
                         afterSelectCardCoroutine: AfterSelectCardCoroutine,
                         message: selectCondition.Message,
@@ -313,6 +333,7 @@ public partial class CardEffectCommons
                 {
                     foreach (CardSource cardSource in cardSources)
                     {
+                        chosenCards.Add(cardSource);
                         revealedCards.Remove(cardSource);
                     }
 
@@ -743,7 +764,7 @@ public class RevealLibraryClass
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(RevealedCards, "Revealed Cards", true, true));
         }
 
-        #region ƒƒO’Ç‰Á
+        #region ï¿½ï¿½ï¿½Oï¿½Ç‰ï¿½
         if (RevealedCards.Count >= 1)
         {
             string log = "";


### PR DESCRIPTION
When an effect says to "select 1 X and 1 Y" from revealed cards, it is allowed to select a card that fulfills both as either condition when it would be the only card that could fulfill the other condition, thus taking only 1 digimon. For example on Davis Motomiya, if you have a green card, a blue green card and some other card that doesn't meet the conditions, it should be legal to select the blue green card "as the green card" and then not take another card. Previously you were forced to select the blue green card as your blue card, and then since you still have a valid green card must select that.
Now in this circumstance, the player is given the option to not select a card, thus taking the previously chosen card as their green card.

I have tested this with Davis specifically locally, all scenarios worked correctly.

Every (current) card which uses the relevant wording has been updated, although not all of them currently have a card that can fulfill both of their conditions.