### PR TITLE
BT18_095 & BT18_097 fix 

### DIFF
--- a/Assets/Scripts/CardEffect/BT18/Red/BT18_095.cs
+++ b/Assets/Scripts/CardEffect/BT18/Red/BT18_095.cs
@@ -43,6 +43,8 @@ namespace DCGO.CardEffects.BT18
 
                 List<string> GetNamesList(List<CardSource> cardSources)
                 {
+	                selectedNames.Clear();
+
                     foreach (CardSource cardName in cardSources)
                     {
                         foreach (string name in cardName.CardNames)

--- a/Assets/Scripts/CardEffect/BT18/Yellow/BT18_097.cs
+++ b/Assets/Scripts/CardEffect/BT18/Yellow/BT18_097.cs
@@ -43,6 +43,8 @@ namespace DCGO.CardEffects.BT18
 
                 List<string> GetNamesList(List<CardSource> cardSources)
                 {
+	                selectedNames.Clear();
+
                     foreach (CardSource cardName in cardSources)
                     {
                         foreach (string name in cardName.CardNames)


### PR DESCRIPTION
Fixing the bug on BT18_097 and BT18_095 where unselecting a card in the card selection screen didn't allow you to reselect the card.  Now the list will properly refresh.

Bug report: https://discord.com/channels/1095717982522585098/1487183101070151892