### PR TITLE
P_206 DGO Fix

### DIFF
--- a/Assets/Scripts/CardEffect/P/White/P_206.cs
+++ b/Assets/Scripts/CardEffect/P/White/P_206.cs
@@ -111,7 +111,7 @@ namespace DCGO.CardEffects.P
                 {
                     var digimonColours = card.Owner.GetFieldPermanents()
                         .Filter(x => x.IsDigimon)
-                        .SelectMany(digimon => digimon.TopCard.BaseCardColors).Distinct();
+                        .SelectMany(digimon => digimon.TopCard.CardColors).Distinct();
 
                     return cardSource.IsTamer
                         && cardSource.BaseCardColors.Exists(x => digimonColours.Contains(x))


### PR DESCRIPTION
Fixing an issue where the delay doesn't recognize the additional colors on BT8 Kimera.  Issue is because the check was using BaseCardColors instead of CardColors, so it was missing the card color changes added at runtime.