### PR TITLE
Improve CCU efficiency & various networking quality of life updates & fixes

### DIFF
--- a/Assets/Scripts/Script/ContinuousController.cs
+++ b/Assets/Scripts/Script/ContinuousController.cs
@@ -1225,6 +1225,10 @@ public class ContinuousController : MonoBehaviour
             Application.Quit();
         }
 #endif
+        if (Input.GetKeyDown(KeyCode.F1))
+        {
+            _showPhotonDebug = !_showPhotonDebug;
+        }
     }
     int _frameCount = 0;
     int _updateFrame = 40;
@@ -1298,7 +1302,120 @@ public class ContinuousController : MonoBehaviour
         Debug.Log($"random number sequence initialization,InitState:{random}");
     }
 
+    #region Photon Debug HUD
+    bool _showPhotonDebug = false;
+    Photon.Realtime.IConnectionCallbacks _connectionCallbacks;
+    Photon.Realtime.IMatchmakingCallbacks _matchmakingCallbacks;
+    Photon.Realtime.ILobbyCallbacks _lobbyCallbacks;
 
+    void OnEnable()
+    {
+        var listener = new PhotonDebugListener();
+        _connectionCallbacks = listener;
+        _matchmakingCallbacks = listener;
+        _lobbyCallbacks = listener;
+        PhotonNetwork.AddCallbackTarget(listener);
+    }
+
+    void OnDisable()
+    {
+        if (_connectionCallbacks != null)
+            PhotonNetwork.RemoveCallbackTarget(_connectionCallbacks);
+    }
+
+    class PhotonDebugListener :
+        Photon.Realtime.IConnectionCallbacks,
+        Photon.Realtime.IMatchmakingCallbacks,
+        Photon.Realtime.ILobbyCallbacks
+    {
+        public void OnDisconnected(Photon.Realtime.DisconnectCause cause)
+        {
+            Debug.LogWarning($"[Photon Debug] Disconnected: {cause}");
+        }
+
+        public void OnConnected() { }
+        public void OnConnectedToMaster()
+        {
+            Debug.Log("[Photon Debug] Connected to Master");
+        }
+        public void OnRegionListReceived(Photon.Realtime.RegionHandler handler) { }
+        public void OnCustomAuthenticationResponse(Dictionary<string, object> data) { }
+        public void OnCustomAuthenticationFailed(string debugMessage)
+        {
+            Debug.LogError($"[Photon Debug] Auth failed: {debugMessage}");
+        }
+
+        public void OnJoinedLobby()
+        {
+            Debug.Log("[Photon Debug] Joined Lobby");
+        }
+        public void OnLeftLobby()
+        {
+            Debug.Log("[Photon Debug] Left Lobby");
+        }
+        public void OnLobbyStatisticsUpdate(List<Photon.Realtime.TypedLobbyInfo> lobbyStatistics) { }
+        public void OnRoomListUpdate(List<Photon.Realtime.RoomInfo> roomList) { }
+
+        public void OnJoinedRoom()
+        {
+            Debug.Log($"[Photon Debug] Joined Room: {PhotonNetwork.CurrentRoom?.Name}");
+        }
+        public void OnJoinRoomFailed(short returnCode, string message)
+        {
+            Debug.LogError($"[Photon Debug] Join Room FAILED: [{returnCode}] {message}");
+        }
+        public void OnJoinRandomFailed(short returnCode, string message)
+        {
+            Debug.LogError($"[Photon Debug] Join Random FAILED: [{returnCode}] {message}");
+        }
+        public void OnCreateRoomFailed(short returnCode, string message)
+        {
+            Debug.LogError($"[Photon Debug] Create Room FAILED: [{returnCode}] {message}");
+        }
+        public void OnCreatedRoom()
+        {
+            Debug.Log("[Photon Debug] Created Room");
+        }
+        public void OnLeftRoom()
+        {
+            Debug.Log("[Photon Debug] Left Room");
+        }
+        public void OnFriendListUpdate(List<Photon.Realtime.FriendInfo> friendList) { }
+    }
+
+    void OnGUI()
+    {
+        if (!_showPhotonDebug) return;
+
+        string status;
+
+        if (!PhotonNetwork.IsConnected)
+        {
+            status = "<color=#FF4444>[Photon] Disconnected</color>";
+        }
+        else if (PhotonNetwork.InRoom)
+        {
+            string roomName = PhotonNetwork.CurrentRoom != null ? PhotonNetwork.CurrentRoom.Name : "?";
+            int players = PhotonNetwork.CurrentRoom != null ? PhotonNetwork.CurrentRoom.PlayerCount : 0;
+            status = $"<color=#44FF44>[Photon] Connected | Region: {PhotonNetwork.CloudRegion} | Room: {roomName} ({players} players)</color>";
+        }
+        else if (PhotonNetwork.InLobby)
+        {
+            status = $"<color=#44FF44>[Photon] Connected | Region: {PhotonNetwork.CloudRegion} | In Lobby</color>";
+        }
+        else
+        {
+            status = $"<color=#FFAA00>[Photon] Connected | Region: {PhotonNetwork.CloudRegion} | Not in Lobby/Room</color>";
+        }
+
+        GUIStyle style = new GUIStyle(GUI.skin.label);
+        style.fontSize = 16;
+        style.richText = true;
+        style.fontStyle = FontStyle.Bold;
+
+        GUI.Label(new Rect(10, 10, 800, 30), status, style);
+    }
+    #endregion
 }
 
 #region Manage random numbers

--- a/Assets/Scripts/Script/ContinuousController.cs
+++ b/Assets/Scripts/Script/ContinuousController.cs
@@ -1385,6 +1385,23 @@ public class ContinuousController : MonoBehaviour
 
     void OnGUI()
     {
+        if (!string.IsNullOrEmpty(PhotonUtility.RetryStatus))
+        {
+            GUIStyle retryStyle = new GUIStyle(GUI.skin.label);
+            retryStyle.fontSize = 20;
+            retryStyle.richText = true;
+            retryStyle.fontStyle = FontStyle.Bold;
+            retryStyle.alignment = TextAnchor.MiddleCenter;
+
+            float boxW = 500;
+            float boxH = 40;
+            float x = (Screen.width - boxW) / 2;
+            float y = (Screen.height - boxH) / 2;
+
+            GUI.Box(new Rect(x - 10, y - 10, boxW + 20, boxH + 20), "");
+            GUI.Label(new Rect(x, y, boxW, boxH), $"<color=#FFAA00>{PhotonUtility.RetryStatus}</color>", retryStyle);
+        }
+
         if (!_showPhotonDebug) return;
 
         string status;
@@ -1525,6 +1542,8 @@ public static class RandomUtility
 #region Manage connections to Photon
 public class PhotonUtility
 {
+    public static string RetryStatus { get; set; } = null;
+
     #region Disconnected from Photon
     public static IEnumerator DisconnectCoroutine()
     {
@@ -1587,6 +1606,7 @@ public class PhotonUtility
 
             if (PhotonNetwork.IsConnectedAndReady)
             {
+                RetryStatus = null;
                 yield break;
             }
 
@@ -1595,12 +1615,20 @@ public class PhotonUtility
 
             if (cause == Photon.Realtime.DisconnectCause.MaxCcuReached && attempt < maxRetries)
             {
+                RetryStatus = LocalizeUtility.GetLocalizedString(
+                    EngMessage: $"Server full. Retrying... ({attempt + 1}/{maxRetries})",
+                    JpnMessage: $"サーバーが満員です。再接続中... ({attempt + 1}/{maxRetries})"
+                );
                 Debug.Log($"[Photon] Server full, retrying in {retryDelay}s...");
                 yield return new WaitForSeconds(retryDelay);
                 retryDelay += 2f;
                 continue;
             }
 
+            RetryStatus = LocalizeUtility.GetLocalizedString(
+                EngMessage: "Connection failed. Please try again later.",
+                JpnMessage: "接続に失敗しました。後でもう一度お試しください。"
+            );
             Debug.LogError($"[Photon] Connection failed permanently: {cause}");
             yield break;
         }

--- a/Assets/Scripts/Script/ContinuousController.cs
+++ b/Assets/Scripts/Script/ContinuousController.cs
@@ -1261,10 +1261,12 @@ public class ContinuousController : MonoBehaviour
             Application.Quit();
         }
 #endif
+#if UNITY_EDITOR
         if (Input.GetKeyDown(KeyCode.F1))
         {
             _showPhotonDebug = !_showPhotonDebug;
         }
+#endif
     }
     int _frameCount = 0;
     int _updateFrame = 40;
@@ -1338,6 +1340,7 @@ public class ContinuousController : MonoBehaviour
         Debug.Log($"random number sequence initialization,InitState:{random}");
     }
 
+#if UNITY_EDITOR
     #region Photon Debug HUD
     bool _showPhotonDebug = false;
     Photon.Realtime.IConnectionCallbacks _connectionCallbacks;
@@ -1469,6 +1472,7 @@ public class ContinuousController : MonoBehaviour
         GUI.Label(new Rect(10, 10, 800, 30), status, style);
     }
     #endregion
+#endif
 }
 
 #region Manage random numbers

--- a/Assets/Scripts/Script/ContinuousController.cs
+++ b/Assets/Scripts/Script/ContinuousController.cs
@@ -1560,23 +1560,50 @@ public class PhotonUtility
     #region Connect to Photon server
     public static IEnumerator ConnectToMasterServerCoroutine()
     {
-        if (!PhotonNetwork.IsConnected || ContinuousController.instance.LastConnectServerRegion != ContinuousController.instance.serverRegion)
-        {
-            if (PhotonNetwork.IsConnected)
-            {
-                yield return ContinuousController.instance.StartCoroutine(DisconnectCoroutine());
+        int maxRetries = 5;
+        float retryDelay = 3f;
 
-                yield return new WaitWhile(() => PhotonNetwork.IsConnected);
+        for (int attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            if (!PhotonNetwork.IsConnected || ContinuousController.instance.LastConnectServerRegion != ContinuousController.instance.serverRegion)
+            {
+                if (PhotonNetwork.IsConnected)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(DisconnectCoroutine());
+
+                    yield return new WaitWhile(() => PhotonNetwork.IsConnected);
+                }
+
+                PhotonNetwork.NetworkingClient.AppId = PhotonNetwork.PhotonServerSettings.AppSettings.AppIdRealtime;
+                PhotonNetwork.ConnectToRegion(ContinuousController.instance.serverRegion);
+                PhotonNetwork.NickName = ContinuousController.instance.PlayerName;
+                PhotonNetwork.GameVersion = ContinuousController.instance.GameVerString;
+                ContinuousController.instance.LastConnectServerRegion = ContinuousController.instance.serverRegion;
             }
 
-            PhotonNetwork.NetworkingClient.AppId = PhotonNetwork.PhotonServerSettings.AppSettings.AppIdRealtime;
-            PhotonNetwork.ConnectToRegion(ContinuousController.instance.serverRegion);
-            PhotonNetwork.NickName = ContinuousController.instance.PlayerName;
-            PhotonNetwork.GameVersion = ContinuousController.instance.GameVerString;
-            ContinuousController.instance.LastConnectServerRegion = ContinuousController.instance.serverRegion;
-        }
+            yield return new WaitUntil(() =>
+                PhotonNetwork.IsConnectedAndReady ||
+                PhotonNetwork.NetworkingClient.State == Photon.Realtime.ClientState.Disconnected);
 
-        yield return new WaitWhile(() => !PhotonNetwork.IsConnectedAndReady);
+            if (PhotonNetwork.IsConnectedAndReady)
+            {
+                yield break;
+            }
+
+            var cause = PhotonNetwork.NetworkingClient.DisconnectedCause;
+            Debug.LogWarning($"[Photon] Connection failed: {cause} (attempt {attempt + 1}/{maxRetries + 1})");
+
+            if (cause == Photon.Realtime.DisconnectCause.MaxCcuReached && attempt < maxRetries)
+            {
+                Debug.Log($"[Photon] Server full, retrying in {retryDelay}s...");
+                yield return new WaitForSeconds(retryDelay);
+                retryDelay += 2f;
+                continue;
+            }
+
+            Debug.LogError($"[Photon] Connection failed permanently: {cause}");
+            yield break;
+        }
     }
     #endregion
     #region Connect to Photon Server and Lobby

--- a/Assets/Scripts/Script/EnterRoom.cs
+++ b/Assets/Scripts/Script/EnterRoom.cs
@@ -68,7 +68,7 @@ public class EnterRoom : MonoBehaviourPunCallbacks
     {
         if (CanClickEnterRoomButton() && canClick)
         {
-            ContinuousController.instance.StartCoroutine(JoinRoomCoroutine());
+            PhotonNetwork.JoinRoom(RoomIDInputField.text);
         }
     }
 

--- a/Assets/Scripts/Script/EnterRoom.cs
+++ b/Assets/Scripts/Script/EnterRoom.cs
@@ -90,7 +90,7 @@ public class EnterRoom : MonoBehaviourPunCallbacks
 
         yield return new WaitUntil(() => PhotonNetwork.InLobby && PhotonNetwork.IsConnectedAndReady);
 
-        PhotonNetwork.JoinRoom(RoomIDInputField.text);
+        PhotonNetwork.JoinRoom(RoomIDInputField.text + "-" + ContinuousController.instance.useBanlist);
 
         canClick = true;
     }

--- a/Assets/Scripts/Script/EnterRoom.cs
+++ b/Assets/Scripts/Script/EnterRoom.cs
@@ -68,7 +68,7 @@ public class EnterRoom : MonoBehaviourPunCallbacks
     {
         if (CanClickEnterRoomButton() && canClick)
         {
-            PhotonNetwork.JoinRoom(RoomIDInputField.text);
+            ContinuousController.instance.StartCoroutine(JoinRoomCoroutine());
         }
     }
 

--- a/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
+++ b/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
@@ -316,6 +316,12 @@ public class LobbyManager_RandomMatch : MonoBehaviourPunCallbacks
             startJoin = false;
             m = false;
             n = false;
+
+            if (!PhotonNetwork.InLobby)
+            {
+                PhotonNetwork.JoinLobby();
+            }
+
             StartRandomMatch();
         }
     }

--- a/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
+++ b/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
@@ -98,6 +98,8 @@ public class LobbyManager_RandomMatch : MonoBehaviourPunCallbacks
         yield return new WaitWhile(() => PhotonNetwork.InRoom);
         #endregion
 
+        yield return ContinuousController.instance.StartCoroutine(PhotonUtility.DisconnectCoroutine());
+
         OffLobby();
 
         yield return ContinuousController.instance.StartCoroutine(disconnectLoadingObject.EndLoading());

--- a/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
+++ b/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
@@ -306,6 +306,21 @@ public class LobbyManager_RandomMatch : MonoBehaviourPunCallbacks
     }
     #endregion
 
+    #region Callback when joining a room fails
+    public override void OnJoinRoomFailed(short returnCode, string message)
+    {
+        if (this.gameObject.activeSelf && !DoneCompleteMatching)
+        {
+            Debug.Log($"[RandomMatch] Join room failed: [{returnCode}] {message}, retrying...");
+            RandomRoomName = null;
+            startJoin = false;
+            m = false;
+            n = false;
+            StartRandomMatch();
+        }
+    }
+    #endregion
+
     #region Process to create a room
     public IEnumerator CreateRoomCoroutine(bool isRandomMatch)
     {

--- a/Assets/Scripts/Script/RoomManager.cs
+++ b/Assets/Scripts/Script/RoomManager.cs
@@ -108,11 +108,6 @@ public class RoomManager : MonoBehaviourPunCallbacks
     {
         CreateRoomFailed = false;
 
-        if (!PhotonNetwork.IsConnected)
-        {
-            yield return ContinuousController.instance.StartCoroutine(PhotonUtility.ConnectToMasterServerCoroutine());
-        }
-
         yield return new WaitWhile(() => !PhotonNetwork.IsConnectedAndReady);
 
         if (!PhotonNetwork.InLobby)

--- a/Assets/Scripts/Script/RoomManager.cs
+++ b/Assets/Scripts/Script/RoomManager.cs
@@ -108,6 +108,11 @@ public class RoomManager : MonoBehaviourPunCallbacks
     {
         CreateRoomFailed = false;
 
+        if (!PhotonNetwork.IsConnected)
+        {
+            yield return ContinuousController.instance.StartCoroutine(PhotonUtility.ConnectToMasterServerCoroutine());
+        }
+
         yield return new WaitWhile(() => !PhotonNetwork.IsConnectedAndReady);
 
         if (!PhotonNetwork.InLobby)

--- a/Assets/Scripts/Script/SelectBattleMode.cs
+++ b/Assets/Scripts/Script/SelectBattleMode.cs
@@ -61,18 +61,10 @@ public class SelectBattleMode : MonoBehaviour
 
         Opening.instance.battle.selectBattleDeck.Off();
 
-        yield return ContinuousController.instance.StartCoroutine(loadingObject.StartLoading("Connecting"));
-
-        connecting = true;
-
-        yield return ContinuousController.instance.StartCoroutine(PhotonUtility.ConnectToLobbyCoroutine());
-
-        // ContinuousController.instance.BattleDeckData = null;
-        yield return ContinuousController.instance.StartCoroutine(PhotonUtility.DeleteBattleDeckData());
-
-        connecting = false;
-
-        yield return ContinuousController.instance.StartCoroutine(loadingObject.EndLoading());
+        if (PhotonNetwork.IsConnected)
+        {
+            yield return ContinuousController.instance.StartCoroutine(PhotonUtility.DisconnectCoroutine());
+        }
 
         this.gameObject.SetActive(true);
 

--- a/Assets/Scripts/Script/SelectBattleMode.cs
+++ b/Assets/Scripts/Script/SelectBattleMode.cs
@@ -61,16 +61,18 @@ public class SelectBattleMode : MonoBehaviour
 
         Opening.instance.battle.selectBattleDeck.Off();
 
+        yield return ContinuousController.instance.StartCoroutine(loadingObject.StartLoading("Connecting"));
+
         connecting = true;
 
-        if (PhotonNetwork.IsConnected)
-        {
-            yield return ContinuousController.instance.StartCoroutine(loadingObject.StartLoading("Disconnecting"));
-            yield return ContinuousController.instance.StartCoroutine(PhotonUtility.DisconnectCoroutine());
-            yield return ContinuousController.instance.StartCoroutine(loadingObject.EndLoading());
-        }
+        yield return ContinuousController.instance.StartCoroutine(PhotonUtility.ConnectToLobbyCoroutine());
+
+        // ContinuousController.instance.BattleDeckData = null;
+        yield return ContinuousController.instance.StartCoroutine(PhotonUtility.DeleteBattleDeckData());
 
         connecting = false;
+
+        yield return ContinuousController.instance.StartCoroutine(loadingObject.EndLoading());
 
         this.gameObject.SetActive(true);
 

--- a/Assets/Scripts/Script/SelectBattleMode.cs
+++ b/Assets/Scripts/Script/SelectBattleMode.cs
@@ -61,18 +61,16 @@ public class SelectBattleMode : MonoBehaviour
 
         Opening.instance.battle.selectBattleDeck.Off();
 
-        yield return ContinuousController.instance.StartCoroutine(loadingObject.StartLoading("Connecting"));
-
         connecting = true;
 
-        yield return ContinuousController.instance.StartCoroutine(PhotonUtility.ConnectToLobbyCoroutine());
-
-        // ContinuousController.instance.BattleDeckData = null;
-        yield return ContinuousController.instance.StartCoroutine(PhotonUtility.DeleteBattleDeckData());
+        if (PhotonNetwork.IsConnected)
+        {
+            yield return ContinuousController.instance.StartCoroutine(loadingObject.StartLoading("Disconnecting"));
+            yield return ContinuousController.instance.StartCoroutine(PhotonUtility.DisconnectCoroutine());
+            yield return ContinuousController.instance.StartCoroutine(loadingObject.EndLoading());
+        }
 
         connecting = false;
-
-        yield return ContinuousController.instance.StartCoroutine(loadingObject.EndLoading());
 
         this.gameObject.SetActive(true);
 
@@ -293,7 +291,7 @@ public class SelectBattleMode : MonoBehaviour
     {
         yield return new WaitForSeconds(0.3f);
         Opening.instance.battle.OffBattle();
-        Opening.instance.home.SetUpHome();
+        Opening.instance.home.SetUpHomeMode_Disconnect();
         this.gameObject.SetActive(false);
     }
 }


### PR DESCRIPTION
The goal of this PR was to improve the efficiency of networking usage to allow more players but I ended up adding more improvements and fixing more issues for a better experience.

- Connection to proton are only made when actually searching for a game, otherwise the user gets disconnected everywhere else saving slots for more users. (now if you played a game and left the app in the menu, you would be consuming 1 CCU)
- Fixed an issue where the player would attempt to join a full room and be stuck forever, now it rejoins the lobby and creates a new room
- Fixed an issue where when max CCU was reached, the player would be stuck searching forever. Now it retries with a 3 second falloff for 5 times. A message is shown when retrying
- In details disconnection now happens when:
  - User navigates to home page
  - User cancels matchmaking
  - User ended a game
- F1 mapping to debug information on the top left of the screen for troubleshooting networking issues
- Debug listener for proton to log events