### PR TITLE
Small fix on use req cards.

### DIFF
--- a/Assets/Scripts/CardEffect/P/Purple/P_238.cs
+++ b/Assets/Scripts/CardEffect/P/Purple/P_238.cs
@@ -11,16 +11,15 @@ namespace DCGO.CardEffects.P
         {
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            #region Ignore Color Requirment
+            #region Ignore Color Requirement
             if (timing == EffectTiming.None)
             {
                 cardEffects.Add(CardEffectFactory.UseRequirements(card, PermanentCondition));
 
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return CardEffectCommons.IsOwnerPermanent(permanent, card)
-                        && permanent.TopCard.HasCSTraits
-                        && (permanent.IsDigimon || permanent.IsTamer);
+                    return (permanent.IsDigimon || permanent.IsTamer)
+                        && permanent.TopCard.HasCSTraits;
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/P/Yellow/P_235.cs
+++ b/Assets/Scripts/CardEffect/P/Yellow/P_235.cs
@@ -10,20 +10,17 @@ namespace DCGO.CardEffects.P
         {
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            #region ignoring colours
-
+            #region Ignore Color Requirement
             if (timing == EffectTiming.None)
             {
                 cardEffects.Add(CardEffectFactory.UseRequirements(card, PermanentCondition));
 
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return permanent.TopCard.Owner == card.Owner
-                        && (permanent.IsTamer || permanent.IsDigimon) 
+                    return (permanent.IsTamer || permanent.IsDigimon) 
                         && permanent.TopCard.EqualsTraits("DATA SQUAD");
                 }
             }
-
             #endregion
 
             #region Main

--- a/Assets/Scripts/CardEffect/ST24/White/ST24_15.cs
+++ b/Assets/Scripts/CardEffect/ST24/White/ST24_15.cs
@@ -18,9 +18,8 @@ namespace DCGO.CardEffects.ST24
 
                 bool PermanentCondition(Permanent permanent)
                 {
-                    return CardEffectCommons.IsOwnerPermanent(permanent, card)
-                        && permanent.TopCard.EqualsTraits("DATA SQUAD")
-                        && (permanent.IsDigimon || permanent.IsTamer);
+                    return (permanent.IsDigimon || permanent.IsTamer)
+                        && permanent.TopCard.EqualsTraits("DATA SQUAD");
                 }
             }
             #endregion     
@@ -218,7 +217,7 @@ namespace DCGO.CardEffects.ST24
                         {
                             yield return ContinuousController.instance.StartCoroutine(card.Owner.brainStormObject.CloseBrainstrorm(card));
 
-                            yield return ContinuousController.instance.StartCoroutine(selectedPermanent.AddDigivolutionCardsBottom(new List<CardSource>() { card }, activateClass));
+                            yield return ContinuousController.instance.StartCoroutine(selectedPermanent.AddDigivolutionCardsBottom(new List<CardSource>() { card }, activateClass, false, true));
 
                             yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 1, activateClass).Draw());
 


### PR DESCRIPTION
I'm seeing the definition already has a check that it's your own stuff so I'm removing them here, plus I suspect the cardeffectcommons might be an issue.

also fix soymp going face up instead of face down on ST24-15

cardeffectcommons was not the final issue, it was a card entity data error that has since been fixed