### PR TITLE
Revert "BT18_095 & BT18_097 fix "

### DIFF
--- a/Assets/Scripts/CardEffect/BT18/Red/BT18_095.cs
+++ b/Assets/Scripts/CardEffect/BT18/Red/BT18_095.cs
@@ -43,8 +43,6 @@ namespace DCGO.CardEffects.BT18
 
                 List<string> GetNamesList(List<CardSource> cardSources)
                 {
-	                selectedNames.Clear();
-
                     foreach (CardSource cardName in cardSources)
                     {
                         foreach (string name in cardName.CardNames)

--- a/Assets/Scripts/CardEffect/BT18/Yellow/BT18_097.cs
+++ b/Assets/Scripts/CardEffect/BT18/Yellow/BT18_097.cs
@@ -43,8 +43,6 @@ namespace DCGO.CardEffects.BT18
 
                 List<string> GetNamesList(List<CardSource> cardSources)
                 {
-	                selectedNames.Clear();
-
                     foreach (CardSource cardName in cardSources)
                     {
                         foreach (string name in cardName.CardNames)


### PR DESCRIPTION
Reverts DCGO2/DCGO#962

allowed selecting same names.
<img width="1283" height="472" alt="image" src="https://github.com/user-attachments/assets/859bfca1-e786-4fea-850b-abc907b1421e" />
