### PR TITLE
CRM: Dual Cards in play are treated only as Digimon

### DIFF
--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -3380,7 +3380,7 @@ public class Permanent
         {
             if (TopCard != null)
             {
-                if (TopCard.IsOption)
+                if (TopCard.IsOption && !TopCard.IsDigimon) //DualCard is never an option while it is a permanent
                 {
                     return true;
                 }


### PR DESCRIPTION
Will also preemptively ensure Justimon cannot trash dual cards in play