### PR TITLE
Show place to security or arts digivolve as options to choose

### DIFF
--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -186,11 +186,6 @@ public class PlayCardClass
         _reducedCost = ReducedCost;
     }
 
-    public void SetAddSecurityEndOption()
-    {
-        _addSecurityEndOption = true;
-    }
-
     public void SetIsBreedingArea()
     {
         _isBreedingArea = true;
@@ -211,7 +206,6 @@ public class PlayCardClass
     int[] _jogressEvoRootsFrameIDs = null;
     int _burstTamerFrameID = -1;
     int[] _appFusionFrameIDs = null;
-    bool _addSecurityEndOption = false;
     bool _isBreedingArea = false;
 
     public bool isJogress => _jogressEvoRootsFrameIDs != null && _jogressEvoRootsFrameIDs.Length == 2;
@@ -1030,8 +1024,7 @@ public class PlayCardClass
 
         UseOptionClass useOption = new UseOptionClass(optionCards, _hashtable, Root)
         {
-            _showEffect = _showEffect,
-            _addSecurityEndOption = _addSecurityEndOption
+            _showEffect = _showEffect
         };
 
         yield return ContinuousController.instance.StartCoroutine(useOption.UseOption());
@@ -1682,7 +1675,6 @@ public class UseOptionClass
     SelectCardEffect.Root _root = SelectCardEffect.Root.None;
     Hashtable _hashtable = null;
     public bool _showEffect = false;
-    public bool _addSecurityEndOption = false;
 
     public IEnumerator UseOption()
     {
@@ -1764,7 +1756,7 @@ public class UseOptionClass
                         {
                             if (cardEffect is OptionResolutionClass)
                             {
-                                if (cardEffect.CanTrigger(null))
+                                if (cardEffect.CanUse(null))
                                 {
                                     optionResolutionEffects.Add((OptionResolutionClass)cardEffect);
                                 }
@@ -1778,7 +1770,7 @@ public class UseOptionClass
                     {
                         if (cardEffect is OptionResolutionClass)
                         {
-                            if (cardEffect.CanTrigger(null))
+                            if (cardEffect.CanUse(null))
                             {
                                 optionResolutionEffects.Add((OptionResolutionClass)cardEffect);
                             }
@@ -1787,24 +1779,30 @@ public class UseOptionClass
                     #endregion
                 }
 
+                #region effects of the card itself
                 foreach (ICardEffect cardEffect in card.EffectList(EffectTiming.None))
                 {
                     if (cardEffect is OptionResolutionClass)
                     {
-                        if (cardEffect.CanTrigger(null))
+                        if (cardEffect.CanUse(null))
                         {
                             optionResolutionEffects.Add((OptionResolutionClass)cardEffect);
                         }
                     }
                 }
+                #endregion
 
-                while (card.Owner.ExecutingCards.Contains(card) && optionResolutionEffects.Count(effect => effect.CanResolve()) > 0)
+                while (card.Owner.ExecutingCards.Contains(card))
                 {
-                    List<OptionResolutionClass> possibleEffects = optionResolutionEffects.Filter(effect => effect.CanResolve());
-                    if (possibleEffects.Count() == 1)
+                    List<OptionResolutionClass> possibleEffects = optionResolutionEffects.Filter(effect => effect.CanResolve(card));
+                    if (possibleEffects.Count() == 0)
+                    {
+                        break;
+                    }
+                    else if (possibleEffects.Count() == 1)
                     {
                         OptionResolutionClass currentEffect = possibleEffects[0];
-                        if (currentEffect != null) yield return ContinuousController.instance.StartCoroutine(currentEffect.Resolve());
+                        if (currentEffect != null) yield return ContinuousController.instance.StartCoroutine(currentEffect.Resolve(card));
                         optionResolutionEffects.Remove(currentEffect);
                     }
                     else
@@ -1835,7 +1833,7 @@ public class UseOptionClass
                         if (skillIndex >= 0)
                         {
                             OptionResolutionClass currentEffect = possibleEffects[skillIndex];
-                            if (currentEffect != null) yield return ContinuousController.instance.StartCoroutine(currentEffect.Resolve());
+                            if (currentEffect != null) yield return ContinuousController.instance.StartCoroutine(currentEffect.Resolve(card));
                             optionResolutionEffects.Remove(currentEffect);
                         }
                         else
@@ -1848,14 +1846,7 @@ public class UseOptionClass
 
             if (card.Owner.ExecutingCards.Contains(card))
             {
-                if (_addSecurityEndOption && card.Owner.CanAddSecurity(CardEffect))
-                {
-                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddSecurityCard(card));
-                }
-                else
-                {
-                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddTrashCard(card));
-                }
+                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddTrashCard(card));
             }
 
             yield return ContinuousController.instance.StartCoroutine(card.Owner.brainStormObject.CloseBrainstrorm(card));

--- a/Assets/Scripts/Script/CardEffectCommons.cs
+++ b/Assets/Scripts/Script/CardEffectCommons.cs
@@ -61,6 +61,8 @@ public partial class CardEffectCommons
     {
         if (cardSources == null) yield break;
 
+        Func<EffectTiming, ICardEffect> getEffect = null;
+
         cardSources = cardSources
         .Filter(cardSource => cardSource != null)
         .Filter(cardSource => !cardSource.CanNotPlayThisOption);
@@ -79,14 +81,29 @@ public partial class CardEffectCommons
         if (activateClass != null)
         {
             playCard.SetShowEffect();
-        }
 
-        if (setAddSecurityEndOption)
-        {
-            playCard.SetAddSecurityEndOption();
+            if (setAddSecurityEndOption)
+            {
+                getEffect = GetCardEffect;
+                activateClass.EffectSourceCard.Owner.UntilEachTurnEndEffects.Add(getEffect);
+            }
         }
 
         yield return ContinuousController.instance.StartCoroutine(playCard.PlayCard());
+
+        if (getEffect != null)
+        {
+            activateClass.EffectSourceCard.Owner.UntilEachTurnEndEffects.Remove(getEffect);
+        }
+
+        ICardEffect GetCardEffect(EffectTiming timing)
+        {
+            if (timing == EffectTiming.None)
+            {
+                return CardEffectFactory.PlaceToSecurityEffect(activateClass.EffectSourceCard, toTop: true);
+            }
+            return null;
+        }
     }
 
     #endregion

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -1471,4 +1471,30 @@ public partial class CardEffectFactory
         }
     }
     #endregion
+
+    #region Place used Options in Security instead of trash effect
+    public static OptionResolutionClass PlaceToSecurityEffect(CardSource card, bool toTop, bool isFaceUp = false, Func<bool> Condition = null)
+    {
+        if (card == null) return null;
+        string location = toTop ? "top" : "bottom";
+        string facing = isFaceUp ? "face up" : "face down";
+        string effectName = $"Place the used Option card on {location} of security {facing}.";
+        OptionResolutionClass placeToSecurityEffect = new();
+        placeToSecurityEffect.SetUpICardEffect(effectName, CanUseCondition, card);
+        placeToSecurityEffect.SetUpOptionResolutionClass(ResolutionCoroutine, CanResolveCondition);
+        return placeToSecurityEffect;
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            return Condition == null || Condition();
+        }
+
+        bool CanResolveCondition(CardSource optionCard) => optionCard.Owner.CanAddSecurity(placeToSecurityEffect);
+        
+        IEnumerator ResolutionCoroutine(CardSource optionCard)
+        {
+            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddSecurityCard(optionCard, toTop, isFaceUp));
+        }
+    }
+    #endregion
 }

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/ArtsDigivolve.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/ArtsDigivolve.cs
@@ -12,12 +12,12 @@ public partial class CardEffectFactory
         if (card == null) return null;
         OptionResolutionClass artsDigivolutionClass = new();
         artsDigivolutionClass.SetUpICardEffect("Arts Digivolve", CanUseCondition, card);
-        artsDigivolutionClass.SetUpOptionResolutionClass(ResolutionCoroutine(), CanResolveCondition);
+        artsDigivolutionClass.SetUpOptionResolutionClass(ResolutionCoroutine, CanResolveCondition);
         return artsDigivolutionClass;
 
         bool CanUseCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnExecutingArea(card);
 
-        bool CanResolveCondition() => CardEffectCommons.HasMatchConditionOwnersPermanent(card, CanSelectPermanentCondition);
+        bool CanResolveCondition(CardSource optionCard) => CardEffectCommons.HasMatchConditionOwnersPermanent(card, CanSelectPermanentCondition);
 
         bool CanSelectPermanentCondition(Permanent permanent)
         {
@@ -26,7 +26,7 @@ public partial class CardEffectFactory
                 && card.CanPlayCardTargetFrame(permanent.PermanentFrame, false, artsDigivolutionClass, SelectCardEffect.Root.Execution);
         }
         
-        IEnumerator ResolutionCoroutine()
+        IEnumerator ResolutionCoroutine(CardSource optionCard)
         {
             SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
     

--- a/Assets/Scripts/Script/CardEffectInterfaces.cs
+++ b/Assets/Scripts/Script/CardEffectInterfaces.cs
@@ -525,7 +525,7 @@ public interface IVortexCanAttackPlayersEffect
 #region "Instead of trashing after use" effects
 public interface IOptionResolutionEffect
 {
-    bool CanResolve();
-    IEnumerator Resolve();
+    bool CanResolve(CardSource optionCard);
+    IEnumerator Resolve(CardSource optionCard);
 }
 #endregion

--- a/Assets/Scripts/Script/OptionResolutionClass.cs
+++ b/Assets/Scripts/Script/OptionResolutionClass.cs
@@ -7,27 +7,27 @@ using System;
 
 public class OptionResolutionClass : ICardEffect, IOptionResolutionEffect
 {
-    public void SetUpOptionResolutionClass(IEnumerator resolutionCoroutine, Func<bool> resolutionCondition = null)
+    public void SetUpOptionResolutionClass(Func<CardSource, IEnumerator> resolutionCoroutine, Func<CardSource, bool> resolutionCondition = null)
     {
         ResolutionCoroutine = resolutionCoroutine;
         ResolutionCondition = resolutionCondition;
     }
 
-    Func<bool> ResolutionCondition { get; set; }
-    IEnumerator ResolutionCoroutine { get; set; }
+    Func<CardSource, bool> ResolutionCondition { get; set; }
+    Func<CardSource, IEnumerator> ResolutionCoroutine { get; set; }
 
-    public bool CanResolve()
+    public bool CanResolve(CardSource optionCard)
     {
-        return ResolutionCondition == null || ResolutionCondition();
+        return ResolutionCondition == null || ResolutionCondition(optionCard);
     }
 
-    public IEnumerator Resolve()
+    public IEnumerator Resolve(CardSource optionCard)
     {
-        if (CanResolve())
+        if (CanResolve(optionCard))
         {
             if (ResolutionCoroutine != null)
             {
-                yield return ContinuousController.instance.StartCoroutine(ResolutionCoroutine);
+                yield return ContinuousController.instance.StartCoroutine(ResolutionCoroutine(optionCard));
             }
         }
     }


### PR DESCRIPTION
Change BT10-041's effect to place the used option into security so that it works the same way as arts digivolution, and provides an effect picker when there are multiple "instead of placing in trash" effects upon using an option.
Currently if Maid Mode uses a dual card the flow is:
After the option effect, the user is given the option to arts digivolve. If they do, card is never placed in security. If they decline, card is then placed in security.

With this change:
After the option is used, the user is shown all resolution replacements (if there is more than one, otherwise the 1 is immediately activated)
If the user selects Sakuyamon effect, or if they select arts digivolution but then decline to pick a digimon, the card is placed in security.
The picker: unreadable card test is the effect descriptions "Place the used option on top of security face down" & "Arts Digivolve"
<img width="834" height="400" alt="image" src="https://github.com/user-attachments/assets/9f193367-ff72-48f2-b662-e18b92fa67f4" />

Tested scenarios locally, with valid arts digivolution target and second digimon digivolving into Maid Mode, with her effect use Use Shinegreymon // Geogrey Sword, after main effect resolves:
 - Choose to place to security : Placed in security and did not show any further details about arts digivolve ✅
 - Choose to Arts Digivolve, then decline to pick a valid target: Does not digivolve, and then placed in security by Maid Mode effect ✅
 - Choose to Arts Digivolve, then select a valid target Digimon digivolves, no further effects attempt to move the card ✅
 
 Using the effect, use a regular option: Still correctly placed in security ✅