### PR TITLE
Implement BT25-085 and skippable on card effects

### DIFF
--- a/Assets/Scripts/CardEffect/BT25/Purple/BT25_085.cs
+++ b/Assets/Scripts/CardEffect/BT25/Purple/BT25_085.cs
@@ -234,7 +234,7 @@ namespace DCGO.CardEffects.BT25
                         canNoSelect: () => true,
                         selectCardCoroutine: null,
                         afterSelectCardCoroutine: AfterSelectCardCoroutine,
-                        message: "Select 1 card to place.",
+                        message: "Select 1 card to trash.",
                         maxCount: 1,
                         canEndNotMax: false,
                         isShowOpponent: true,

--- a/Assets/Scripts/CardEffect/BT25/Purple/BT25_085.cs
+++ b/Assets/Scripts/CardEffect/BT25/Purple/BT25_085.cs
@@ -1,0 +1,459 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// BeelStarMon // Fly Bullet
+namespace DCGO.CardEffects.BT25
+{
+    public class BT25_085 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Digimon Effects
+
+            #region Alt Digivolution
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return permanent.TopCard.HasText("Three Musketeers")
+                            || permanent.TopCard.EqualsTraits("TS");
+                }
+            
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 3, true, card, null, level: 5));
+            }
+            #endregion
+
+            #region Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared WD / WA
+
+            string UseOptionHashString = "BT25_085_WD_WA";
+
+            string UseOptionEffectName = "Use a [Three Musketeers] or [TS] Option from hand or under this digimon for free";
+
+            string UseOptionEffectDescription(string tag)
+                => $"[{tag}] [Once Per Turn] You may use 1 [Three Musketeers] or [TS] trait Option card from your hand or this Digimon's digivolution cards without paying the cost.";
+
+            CardEffectFactory.ActivateClassesForSharedEffects
+                (ref cardEffects, timing, card,
+                    UseOptionEffectName,
+                    UseOptionActivateCoroutine,
+                    UseOptionEffectDescription,
+                    optional: false,
+                    isSkippable: true,
+                    additionalActivateCondition: CanActivateUseOption,
+                    maxCountPerTurn: 1,
+                    hashValue: UseOptionHashString,
+                    whenDigivolving: true,
+                    whenAttacking: true);
+
+            bool IsTraitedOption(CardSource cardSource)
+            {
+                return cardSource.IsOption
+                    && (cardSource.EqualsTraits("Three Musketeers")
+                        || cardSource.EqualsTraits("TS"))
+                    && !cardSource.CanNotPlayThisOption;
+            }
+
+            bool CanActivateUseOption(Hashtable hashtable)
+            {
+                return CardEffectCommons.HasMatchConditionOwnersHand(card, IsTraitedOption)
+                    || card.PermanentOfThisCard().DigivolutionCards.Any(IsTraitedOption);
+            }
+
+            IEnumerator UseOptionActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                bool executed = false;
+                bool validHandCards = CardEffectCommons.HasMatchConditionOwnersHand(card, IsTraitedOption);
+                bool validDigivolutionCards = card.PermanentOfThisCard().DigivolutionCards.Any(IsTraitedOption);
+
+                List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>();
+                if (validHandCards)
+                {
+                    selectionElements.Add(new (message: $"Use from Hand", value : 1, spriteIndex: 0));
+                }
+                if (validDigivolutionCards)
+                {
+                    selectionElements.Add(new (message: $"Use from Digivolution Cards", value : 2, spriteIndex: 0));
+                }
+                selectionElements.Add( new (message: "Don't use an Option", value: 3, spriteIndex: 1));
+
+                string selectPlayerMessage = "From which area will you use an Option?";
+                string notSelectPlayerMessage = "The opponent is choosing from which area to select a card.";
+
+                GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage, notSelectPlayerMessage: notSelectPlayerMessage);
+
+                yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+
+                bool doUse = GManager.instance.userSelectionManager.SelectedIntValue != 3;
+                bool fromHand = GManager.instance.userSelectionManager.SelectedIntValue == 1;
+
+                if (!doUse)
+                {
+                    if (fromHand)
+                    {
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsTraitedOption,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: cardSource => SelectCardCoroutine(cardSource, SelectCardEffect.Root.Hand),
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectHandEffect.SetUpCustomMessage("Select a [Three Musketeers] Option to place use.", "Opponent is selecting a card to use.");
+
+                        yield return StartCoroutine(selectHandEffect.Activate());
+                    }
+                    else
+                    {
+                        SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                        selectCardEffect.SetUp(
+                            canTargetCondition: IsTraitedOption,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            canNoSelect: () => true,
+                            selectCardCoroutine: cardSource => SelectCardCoroutine(cardSource, SelectCardEffect.Root.DigivolutionCards),
+                            afterSelectCardCoroutine: null,
+                            message: "Select 1 card to place.",
+                            maxCount: 1,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            mode: SelectCardEffect.Mode.Custom,
+                            root: SelectCardEffect.Root.DigivolutionCards,
+                            customRootCardList: card.PermanentOfThisCard().DigivolutionCards,
+                            canLookReverseCard: true,
+                            selectPlayer: card.Owner,
+                            cardEffect: activateClass);
+
+                        selectCardEffect.SetUpCustomMessage("Select a [Three Musketeers] Option to place use.", "Opponent is selecting a card to use.");
+
+                        yield return StartCoroutine(selectCardEffect.Activate());
+                    }
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource, SelectCardEffect.Root root)
+                    {
+                        executed = true;
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
+                                cardSources: new List<CardSource> { cardSource },
+                                activateClass: activateClass,
+                                payCost: false,
+                                root: root));
+                    }
+                }
+
+                if (!executed)
+                {
+                    activateClass.RemoveUse();
+                }
+            }
+
+            #endregion
+
+            #region Shared WD / WA / Counter
+
+            string UnsuspendHashString = "BT25_085_WD_WA_Counter";
+
+            string UnsuspendEffectName = "By trashing 1 Option from any of your digivolution cards or link cards, unsuspend";
+
+            string UnsuspendEffectDescription(string tag)
+                => $"[{tag}] [Once Per Turn] By trashing 1 Option card from any of your Digimon's digivolution cards or link cards, this Digimon unsuspends.";
+
+            CardEffectFactory.ActivateClassesForSharedEffects
+                (ref cardEffects, timing, card,
+                    UnsuspendEffectName,
+                    UnsuspendActivateCoroutine,
+                    UnsuspendEffectDescription,
+                    optional: false,
+                    isSkippable: true,
+                    additionalActivateCondition: CanActivateUnsuspend,
+                    maxCountPerTurn: 1,
+                    hashValue: UnsuspendHashString,
+                    whenDigivolving: true,
+                    whenAttacking: true,
+                    counter: true);
+
+            bool CanTrashCardSource(CardSource cardSource) => cardSource.IsOption;
+
+            bool PermanentWithTrashableCard(Permanent permanent)
+            {
+                return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                    && permanent.DigivolutionOrLinkCards.Any(CanTrashCardSource);
+            }
+
+            bool CanActivateUnsuspend(Hashtable hashtable) => CardEffectCommons.HasMatchConditionOwnersPermanent(card, PermanentWithTrashableCard);
+
+            IEnumerator UnsuspendActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                bool executed = false;
+
+                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                selectPermanentEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: PermanentWithTrashableCard,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: 1,
+                    canNoSelect: true,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: null,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Custom,
+                    cardEffect: activateClass);
+
+                selectPermanentEffect.SetUpCustomMessage("Select a Digimon to trash a card from", "Opponent is selecting a card to trash a card from");
+
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                {
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: CanTrashCardSource,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                        message: "Select 1 card to place.",
+                        maxCount: 1,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Discard,
+                        root: SelectCardEffect.Root.DigivolutionCards,//This only sets behaviour, so currently is safe to use for this combined list. Will ensure pending effects show
+                        customRootCardList: permanent.DigivolutionOrLinkCards,
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    selectCardEffect.SetUpCustomMessage("Select a [Three Musketeers] card to place under 1 of your Digimon.", "Opponent is selecting a card to place.");
+
+                    yield return StartCoroutine(selectCardEffect.Activate());
+
+                    IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                    {
+                        executed = cardSources.Count > 0;
+
+                        yield return ContinuousController.instance.StartCoroutine(new IUnsuspendPermanents(
+                            new List<Permanent>() { card.PermanentOfThisCard() },
+                            activateClass).Unsuspend());
+                    }
+                }
+
+                if (!executed)
+                {
+                    activateClass.RemoveUse();
+                }
+            }
+
+            #endregion
+
+            #endregion 
+
+            #region Option Effects
+
+            #region Ignore Colour Requirement
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.UseRequirements(card, CardCondition));
+
+                bool CardCondition(CardSource cardSource)
+                {
+                    return cardSource.HasText("Three Musketeers");
+                }
+            }
+            #endregion
+
+            #region Main
+            if (timing == EffectTiming.OptionSkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Delete 1 highest level enemy Digimon. Place 1 [Three Musketeers] card from hand or trash under any of your Digimon.", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Main] Delete 1 of your opponent's highest level Digimon. Then, you may place 1 [Three Musketeer] trait card from your hand or trash as any of your Digimon's bottom digivolution card.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+
+                bool IsStrongestEnemy(Permanent permanent)
+                    => CardEffectCommons.IsMaxLevel(permanent, card.Owner.Enemy);
+
+                bool CanSelectCardCondition(CardSource cardSource) 
+                    => cardSource.EqualsTraits("Three Musketeers");
+
+                bool CanSelectPermamentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, IsStrongestEnemy))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsStrongestEnemy,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+
+                    if(CardEffectCommons.HasMatchConditionOwnersPermanent(card, CanSelectPermamentCondition))
+                    {
+                        bool canSelectHand = CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+                        bool canSelectTrash = CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
+
+                        if (canSelectHand || canSelectTrash)
+                        {
+                            #region Setup Location Selection
+                            List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>();
+                            if (canSelectHand)
+                            {
+                                selectionElements.Add(new(message: $"From hand", value: 1, spriteIndex: 0));
+                            }
+                            if (canSelectTrash)
+                            {
+                                selectionElements.Add(new(message: $"From trash", value: 2, spriteIndex: 0));
+                            }
+                            selectionElements.Add(new(message: $"Do not place a card", value: 3, spriteIndex: 1));
+
+                            string selectPlayerMessage = "From which area will you place a card to digivolution cards?";
+                            string notSelectPlayerMessage = "The opponent is choosing from which area to select a card.";
+
+                            GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage, notSelectPlayerMessage: notSelectPlayerMessage);
+
+                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+                            #endregion
+
+                            bool doPlace = GManager.instance.userSelectionManager.SelectedIntValue != 3;
+                            bool fromHand = GManager.instance.userSelectionManager.SelectedIntValue == 1;
+
+                            if (doPlace)
+                            {
+                                if (fromHand)
+                                {
+                                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                                    selectHandEffect.SetUp(
+                                        selectPlayer: card.Owner,
+                                        canTargetCondition: CanSelectCardCondition,
+                                        canTargetCondition_ByPreSelecetedList: null,
+                                        canEndSelectCondition: null,
+                                        maxCount: 1,
+                                        canNoSelect: true,
+                                        canEndNotMax: false,
+                                        isShowOpponent: true,
+                                        selectCardCoroutine: SelectCardCoroutine,
+                                        afterSelectCardCoroutine: null,
+                                        mode: SelectHandEffect.Mode.Custom,
+                                        cardEffect: activateClass);
+
+                                    selectHandEffect.SetUpCustomMessage("Select a [Three Musketeers] card to place under 1 of your Digimon.", "Opponent is selecting a card to place.");
+
+                                    yield return StartCoroutine(selectHandEffect.Activate());
+                                }
+                                else
+                                {
+                                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                                    selectCardEffect.SetUp(
+                                        canTargetCondition: CanSelectCardCondition,
+                                        canTargetCondition_ByPreSelecetedList: null,
+                                        canEndSelectCondition: null,
+                                        canNoSelect: () => true,
+                                        selectCardCoroutine: SelectCardCoroutine,
+                                        afterSelectCardCoroutine: null,
+                                        message: "Select 1 card to place.",
+                                        maxCount: 1,
+                                        canEndNotMax: false,
+                                        isShowOpponent: true,
+                                        mode: SelectCardEffect.Mode.Custom,
+                                        root: SelectCardEffect.Root.Trash,
+                                        customRootCardList: null,
+                                        canLookReverseCard: true,
+                                        selectPlayer: card.Owner,
+                                        cardEffect: activateClass);
+
+                                    selectCardEffect.SetUpCustomMessage("Select a [Three Musketeers] card to place under 1 of your Digimon.", "Opponent is selecting a card to place.");
+
+                                    yield return StartCoroutine(selectCardEffect.Activate());
+                                }
+
+                                IEnumerator SelectCardCoroutine(CardSource cardSource)
+                                {
+                                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                                    selectPermanentEffect.SetUp(
+                                        selectPlayer: card.Owner,
+                                        canTargetCondition: CanSelectPermamentCondition,
+                                        canTargetCondition_ByPreSelecetedList: null,
+                                        canEndSelectCondition: null,
+                                        maxCount: 1,
+                                        canNoSelect: true,
+                                        canEndNotMax: false,
+                                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                                        afterSelectPermanentCoroutine: null,
+                                        mode: SelectPermanentEffect.Mode.Custom,
+                                        cardEffect: activateClass);
+
+                                    selectPermanentEffect.SetUpCustomMessage("Select 1 digimon to place card underneath", "The opponent is selecting 1 digimon to place card underneath");
+                                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                                    {
+                                        if (permanent != null)
+                                        {
+                                            yield return ContinuousController.instance.StartCoroutine(permanent.AddDigivolutionCardsBottom(new List<CardSource>() { cardSource }, activateClass));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Arts Digivolution
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.ArtsDigivolveEffect(card));
+            }
+            #endregion
+
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT25/Purple/BT25_085.cs
+++ b/Assets/Scripts/CardEffect/BT25/Purple/BT25_085.cs
@@ -97,7 +97,7 @@ namespace DCGO.CardEffects.BT25
                 bool doUse = GManager.instance.userSelectionManager.SelectedIntValue != 3;
                 bool fromHand = GManager.instance.userSelectionManager.SelectedIntValue == 1;
 
-                if (!doUse)
+                if (doUse)
                 {
                     if (fromHand)
                     {

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -835,6 +835,7 @@ public partial class CardEffectFactory
                                                                     Func<Hashtable, bool> additionalUseCondition = null,
                                                                     Func<Hashtable, bool> additionalActivateCondition = null, 
                                                                     Func<Hashtable, bool> isOptionalFunction = null,
+                                                                    bool isSkippable = false,
                                                                     int maxCountPerTurn = -1,
                                                                     string hashValue = null,
                                                                     bool whenMoving = false,
@@ -852,51 +853,51 @@ public partial class CardEffectFactory
     {
         if (whenMoving && timing == EffectTiming.OnMove)
         {
-            cardEffects.Add(WhenMovingClass(card, effectName, activateCoroutine, effectDescription("When Moving"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(WhenMovingClass(card, effectName, activateCoroutine, effectDescription("When Moving"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (onPlay && timing == EffectTiming.OnEnterFieldAnyone)
         {
-            cardEffects.Add(OnPlayClass(card, effectName, activateCoroutine, effectDescription("On Play"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(OnPlayClass(card, effectName, activateCoroutine, effectDescription("On Play"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (whenDigivolving && timing == EffectTiming.OnEnterFieldAnyone)
         {
-            cardEffects.Add(WhenDigivolvingClass(card, effectName, activateCoroutine, effectDescription("When Digivolving"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(WhenDigivolvingClass(card, effectName, activateCoroutine, effectDescription("When Digivolving"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (whenAttacking && timing == EffectTiming.OnAllyAttack)
         {
-            cardEffects.Add(WhenAttackingClass(card, effectName, activateCoroutine, effectDescription("When Attacking"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(WhenAttackingClass(card, effectName, activateCoroutine, effectDescription("When Attacking"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (onDeletion && timing == EffectTiming.OnDestroyedAnyone)
         {
-            cardEffects.Add(OnDeletionClass(card, effectName, activateCoroutine, effectDescription("On Deletion"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(OnDeletionClass(card, effectName, activateCoroutine, effectDescription("On Deletion"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (whenLinking && timing == EffectTiming.WhenLinked)
         {
-            cardEffects.Add(WhenLinkingClass(card, effectName, activateCoroutine, effectDescription("When Linking"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(WhenLinkingClass(card, effectName, activateCoroutine, effectDescription("When Linking"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (endOfAttack && timing == EffectTiming.OnEndAttack)
         {
-            cardEffects.Add(EndOfAttackClass(card, effectName, activateCoroutine, effectDescription("End of Attack"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(EndOfAttackClass(card, effectName, activateCoroutine, effectDescription("End of Attack"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (endOfYourTurn && timing == EffectTiming.OnEndTurn)
         {
-            cardEffects.Add(EndOfYourTurnClass(card, effectName, activateCoroutine, effectDescription("End of Your Turn"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(EndOfYourTurnClass(card, effectName, activateCoroutine, effectDescription("End of Your Turn"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (endOfOpponentTurn && timing == EffectTiming.OnEndTurn)
         {
-            cardEffects.Add(EndOfYourOpponentsTurnClass(card, effectName, activateCoroutine, effectDescription("End of Opponent's Turn"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(EndOfYourOpponentsTurnClass(card, effectName, activateCoroutine, effectDescription("End of Opponent's Turn"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (endOfAllTurns && timing == EffectTiming.OnEndTurn)
         {
-            cardEffects.Add(EndOfAllTurnsClass(card, effectName, activateCoroutine, effectDescription("End of All Turns"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(EndOfAllTurnsClass(card, effectName, activateCoroutine, effectDescription("End of All Turns"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if(startOfYourMainPhase && timing == EffectTiming.OnStartMainPhase)
         {
-            cardEffects.Add(StartOfYourMainPhaseClass(card, effectName, activateCoroutine, effectDescription("Start of Your Main Phase"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(StartOfYourMainPhaseClass(card, effectName, activateCoroutine, effectDescription("Start of Your Main Phase"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (counter && timing == EffectTiming.OnCounterTiming)
         {
-            cardEffects.Add(CounterClass(card, effectName, activateCoroutine, effectDescription("Counter"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue));
+            cardEffects.Add(CounterClass(card, effectName, activateCoroutine, effectDescription("Counter"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
 
         return cardEffects;
@@ -918,7 +919,8 @@ public partial class CardEffectFactory
                                                 string hashValue = null,
                                                 bool isInheritedEffect = false,
                                                 bool isLinkedEffect = false,
-                                                bool isSecurityEffect = false
+                                                bool isSecurityEffect = false,
+                                                bool isSkippable = false
                                                 )
     {
         ActivateClass activateClass = new ActivateClass();
@@ -927,6 +929,7 @@ public partial class CardEffectFactory
         activateClass.SetHashString(hashValue);
         activateClass.SetIsSecurityEffect(isSecurityEffect);
         activateClass.SetIsOptionalOverride(isOptionalFunction);
+        activateClass.SetIsSkippable(isSkippable);
         return activateClass;
     }
 
@@ -944,9 +947,10 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
-                                                bool isInherited = false)
+                                                bool isInherited = false,
+                                                bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, false);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, false, isSkippable: isSkippable);
 
         bool PermanentCondition(Permanent permanent)
         {
@@ -981,9 +985,10 @@ public partial class CardEffectFactory
                                             Func<Hashtable, bool> additionalActivateCondition = null,
                                             int maxCountPerTurn = -1,
                                             string hashValue = null,
-                                            bool isInherited = false)
+                                            bool isInherited = false,
+                                            bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, false);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, false, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable)
         {
@@ -1014,9 +1019,10 @@ public partial class CardEffectFactory
                                                         int maxCountPerTurn = -1,
                                                         string hashValue = null,
                                                         bool isInherited = false,
-                                                        bool isLinked = false)
+                                                        bool isLinked = false,
+                                                        bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable)
         {
@@ -1046,9 +1052,10 @@ public partial class CardEffectFactory
                                                     int maxCountPerTurn = -1,
                                                     string hashValue = null,
                                                     bool isInherited = false,
-                                                    bool isLinked = false)
+                                                    bool isLinked = false,
+                                                    bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable)
         {
@@ -1079,9 +1086,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable)
         {
@@ -1112,10 +1120,11 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false
+                                                bool isLinked = false,
+                                                bool isSkippable = false
                                                 )
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable)
         {
@@ -1142,10 +1151,10 @@ public partial class CardEffectFactory
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
                                                 Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null)
+                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                bool isSkippable = false)
     {
-        ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, additionalActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, -1, null, false, false);
-        activateClass.SetIsSecurityEffect(true);
+        ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, additionalActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, -1, null, false, false, true, isSkippable);
         return activateClass;
 
         bool CanUseCondition(Hashtable hashtable)
@@ -1170,9 +1179,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable)
         {
@@ -1205,9 +1215,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked);
+        ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
         activateClass.SetIsCounterEffect(true);
         return activateClass;
 
@@ -1248,9 +1259,10 @@ public partial class CardEffectFactory
                                                 bool isInherited = false,
                                                 bool isLinked = false,
                                                 bool yourTurn = false,
-                                                bool opponentTurn = false)
+                                                bool opponentTurn = false,
+                                                bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable)
         {
@@ -1283,9 +1295,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
     }
 
     public static ActivateClass StartOfYourMainPhaseClass(CardSource card,
@@ -1299,9 +1312,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
     }
 
     public static ActivateClass EndOfYourTurnClass(CardSource card,
@@ -1315,9 +1329,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
     }
 
     public static ActivateClass YourTurnClass(CardSource card,
@@ -1331,9 +1346,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
     }
 
     #endregion
@@ -1351,9 +1367,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
     }
 
     public static ActivateClass StartOfYourOpponentsMainPhaseClass(CardSource card,
@@ -1367,9 +1384,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
     }
 
     public static ActivateClass EndOfYourOpponentsTurnClass(CardSource card,
@@ -1383,9 +1401,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
     }
 
     public static ActivateClass OpponentsTurnClass(CardSource card,
@@ -1399,9 +1418,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
     }
 
     #endregion
@@ -1419,9 +1439,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, true);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, true, isSkippable);
     }
 
     public static ActivateClass AllTurnsClass(CardSource card,
@@ -1435,9 +1456,10 @@ public partial class CardEffectFactory
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
-                                                bool isLinked = false)
+                                                bool isLinked = false,
+                                                bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, true);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, true, isSkippable);
     }
 
     #endregion

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -286,11 +286,10 @@ public abstract class ICardEffect
     #region Override IsOptional with a function
 
     Func<Hashtable, bool> _isOptionalFunction = null;
-
-    public Func<Hashtable, bool> IsOptionalOverride
+    public bool IsOptionalCondition(Hashtable hashtable)
     {
-        get { return _isOptionalFunction; }
-        private set { _isOptionalFunction = value; }
+        if (_isOptionalFunction != null) return _isOptionalFunction(hashtable);
+        return IsOptional;
     }
 
     public void SetIsOptionalOverride(Func<Hashtable, bool> isOptionalOverride)
@@ -300,11 +299,21 @@ public abstract class ICardEffect
 
     #endregion
 
-    public bool IsOptionalCondition(Hashtable hashtable)
+    #region If effect is skippable for effects that remove the extra click with isOptional false
+
+    bool _isSkippable = false;
+
+    public bool IsSkippable(Hashtable hashtable)
     {
-        if (IsOptionalOverride != null) return IsOptionalOverride(hashtable);
-        return IsOptional;
+        return _isSkippable || IsOptionalCondition(hashtable);
     }
+
+    public void SetIsSkippable(bool isSkippable)
+    {
+        _isSkippable = isSkippable;
+    }
+
+    #endregion
 
     #region Whether this triggering effect triggers
 

--- a/Assets/Scripts/Script/MultipleSkills.cs
+++ b/Assets/Scripts/Script/MultipleSkills.cs
@@ -15,7 +15,7 @@ public class MultipleSkills : MonoBehaviourPunCallbacks
     public bool IsOnlyHandEffectStacked => StackedSkillInfos.Every(skillInfo =>
         skillInfo.CardEffect != null && skillInfo.CardEffect.EffectSourceCard != null && CardEffectCommons.IsExistOnHand(skillInfo.CardEffect.EffectSourceCard) && skillInfo.CardEffect.EffectDiscription.Contains("[Hand]"));
 
-    bool IsOnlyOptionalEffectStacked => StackedSkillInfos.Every(skillInfo => skillInfo.CardEffect != null && skillInfo.CardEffect.IsOptionalCondition(null));
+    bool IsOnlyOptionalEffectStacked => StackedSkillInfos.Every(skillInfo => skillInfo.CardEffect != null && skillInfo.CardEffect.IsSkippable(null));
     bool IsEachStackedEffectHasDistinctSourceCard => StackedSkillInfos.Filter(skillInfo1 => skillInfo1.CardEffect != null && skillInfo1.CardEffect.EffectSourceCard != null)
         .Every(skillInfo => StackedSkillInfos.Filter(skillInfo1 => skillInfo1.CardEffect != null && skillInfo1.CardEffect.EffectSourceCard != null)
             .Count(otherSkillInfo => otherSkillInfo != skillInfo && skillInfo.CardEffect.EffectSourceCard == otherSkillInfo.CardEffect.EffectSourceCard) == 0);
@@ -286,7 +286,7 @@ public class MultipleSkills : MonoBehaviourPunCallbacks
                                 _CanEndSelectCondition: null,
                                 _MaxCount: 1,
                                 _CanEndNotMax: false,
-                                _CanNoSelect: () => skillInfos_active.All(skillInfo => skillInfo.CardEffect.IsOptionalCondition(skillInfo.Hashtable)),
+                                _CanNoSelect: () => skillInfos_active.All(skillInfo => skillInfo.CardEffect.IsSkippable(skillInfo.Hashtable)),
                                 CanLookReverseCard: true,
                                 skillInfos: skillInfos_active,
                                 root: SelectCardEffect.Root.None));

--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -888,6 +888,10 @@ public class Permanent
     public List<CardSource> DigivolutionCards => cardSources.Filter(cardSource => cardSource != TopCard && !LinkedCards.Contains(cardSource));
     #endregion
 
+    #region DigivolutionOrLinkCards
+    public List<CardSource> DigivolutionOrLinkCards => cardSources.Filter(cardSource => cardSource != TopCard);
+    #endregion
+
     #region Linked Cards
     public int LinkedMax
     {

--- a/Assets/Scripts/Script/SelectCardEffect.cs
+++ b/Assets/Scripts/Script/SelectCardEffect.cs
@@ -778,6 +778,15 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
                                 new List<CardSource> { cardSource },
                                 _cardEffect).TrashLinkCards());
                         }
+                        //After IsExistLinked, this would be digivolution cards, or topcard which should have been disbarred by selection condition. 
+                        //ITrashDigiviolutionCards also refuses to do anything with a TopCard
+                        else if (CardEffectCommons.IsExistOnBattleArea(cardSource))
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(new ITrashDigivolutionCards(
+                                cardSource.PermanentOfThisCard(), 
+                                new List<CardSource> { cardSource }, 
+                                _cardEffect).TrashDigivolutionCards());
+                        }
                         else
                             yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddTrashCard(cardSource));
                     }


### PR DESCRIPTION
Other changes:
Permanent now has a collected DigivolutionCardsOrLinkCards
ICardEffect.SetIsSkippable, which allows the user to "skip all" alongside optional effects
SelectCardEffect.Mode.Discard now correctly trashes digivolution cards, same as it would Link Cards

Was able to do some basic testing of some effects, but even enabling the bot to attack in editor it did not feel inclined to