### PR TITLE
Fix Stack Overflow and treat as digimon

### DIFF
--- a/Assets/Scripts/CardEffect/BT25/Red/BT25_104.cs
+++ b/Assets/Scripts/CardEffect/BT25/Red/BT25_104.cs
@@ -140,48 +140,91 @@ namespace DCGO.CardEffects.BT25
             #endregion
 
             #region Your Turn
-            if (timing == EffectTiming.None)
+
+            //All your Marcus Damon
+            bool IsMarcusDamon(Permanent permanent)
             {
-                //All of your [Marcus Damon]s
-                bool PermanentCondition(Permanent permanent)
-                {
-                    return CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(permanent, card)
-                        && permanent.TopCard.EqualsCardName("Marcus Damon");
-                }
+                return CardEffectCommons.IsPermanentExistsOnOwnerBattleArea(permanent, card)
+                    && permanent.TopCard.EqualsCardName("Marcus Damon");
+            }
 
-                bool Condition()
-                {
-                    return CardEffectCommons.IsExistOnBattleArea(card)
-                        && CardEffectCommons.IsOwnerTurn(card);
-                }
+            bool MakeDigimonCondition()
+            {
+                return CardEffectCommons.IsExistOnBattleArea(card)
+                    && CardEffectCommons.IsOwnerTurn(card);
+            }
 
+            IEnumerator MarcusActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
                 #region are also treated as Digimon
                 TreatAsDigimonClass treatAsDigimonClass = CardEffectFactory.TreatAsDigimonStaticEffect(
-                    permanentCondition: PermanentCondition, 
+                    permanentCondition: IsMarcusDamon, 
                     isInheritedEffect: false, 
                     card: card, 
-                    condition: Condition);
+                    condition: MakeDigimonCondition);//Granted effect continues checking that Burst mode is on field and is idempotent, so does not have to be remove when it leaves play
 
-                cardEffects.Add(treatAsDigimonClass);
+                ICardEffect GetEffect(EffectTiming timing)
+                {
+                    if (timing == EffectTiming.None)
+                    {
+                        return treatAsDigimonClass;
+                    }
+                    return null;
+                }
+
+                card.Owner.UntilEachTurnEndEffects.Add(GetEffect);
                 #endregion
 
+                yield return null;
+            }
+
+            if(timing == EffectTiming.OnStartTurn)
+            {
+                ActivateClass activateClass = CardEffectFactory.StartOfYourTurnClass(
+                    card,
+                    "[Marcus Damon] are treated as Digimon",
+                    MarcusActivateCoroutine,
+                    "[Marcus Damon] are treated as Digimon",
+                    false
+                );
+                activateClass.SetIsBackgroundProcess(true);//Run in background at start of your turn to add effect to player
+                cardEffects.Add(activateClass);
+            }
+
+
+            //To anyone copying this effect: If this were not a dual card it would also need a matching On Play effect
+            if(timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = CardEffectFactory.WhenDigivolvingClass(
+                    card,
+                    "[Marcus Damon] are treated as Digimon",
+                    MarcusActivateCoroutine,
+                    "[Marcus Damon] are treated as Digimon",
+                    false
+                );
+                activateClass.SetIsBackgroundProcess(true);//Run in background when digivolve into this to add effect to player
+                cardEffects.Add(activateClass);
+            }
+
+            if (timing == EffectTiming.None)
+            {
                 #region with 12000 DP
                 ChangeBaseDPClass changeBaseDPClass = CardEffectFactory.ChangeBaseDPGlobalEffect(
-                    permanentCondition: PermanentCondition, 
+                    permanentCondition: IsMarcusDamon, 
                     changeValue: 12000, 
                     isInheritedEffect: false, 
                     card: card, 
-                    condition: Condition);
+                    condition: MakeDigimonCondition);
 
                 cardEffects.Add(changeBaseDPClass);
                 #endregion
 
                 #region and gain Rush
                 RushClass rushClass = CardEffectFactory.RushStaticEffect(
-                    permanentCondition: PermanentCondition, 
+                    permanentCondition: IsMarcusDamon, 
                     isInheritedEffect: false, 
                     card: card, 
-                    condition: Condition);
+                    condition: MakeDigimonCondition);
 
                 cardEffects.Add(rushClass);
                 #endregion

--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -3310,13 +3310,29 @@ public class Permanent
                     return true;
                 }
 
+                #region Effect on TopCard
+                foreach (ICardEffect cardEffect in TopCard.EffectList(EffectTiming.None))
+                {
+                    if (cardEffect is ITreatAsDigimonEffect)
+                    {
+                        if (cardEffect.CanTrigger(null))
+                        {
+                            if (((ITreatAsDigimonEffect)cardEffect).IsDigimon(this))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                #endregion
+
                 #region Effect of treating it as a Digimon
                 foreach (Player player in GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer)
                 {
                     foreach (Permanent permanent in player.GetFieldPermanents())
                     {
                         #region Effects of permanents in play
-                        foreach (ICardEffect cardEffect in permanent.EffectList(EffectTiming.None))
+                        foreach (ICardEffect cardEffect in permanent.EffectList_Added(EffectTiming.None))//This can never be EffectList, as EffectList_forCard checks Isdigimon and this causes a stack overflow 
                         {
                             if (cardEffect is ITreatAsDigimonEffect)
                             {


### PR DESCRIPTION
Fix Stack Overflow where Permanent.IsDigimon was checking EffectList and EffectList was checking IsDigimon.
This creates an issue where TreatAsDigimon effect can never be seen directly on other permanents, so had to rework burst mode to put the effect onto the player at the start of each turn and when it first enters, which will have to be the pattern for this effect when it applies to "All X".

Tested that stack overflow no longer occurs and Burst Mode's effect works as intended.