### PR TITLE
Collision Overhaul

### DIFF
--- a/Assets/Scripts/CardEffect/AD1/Blue/AD1_011.cs
+++ b/Assets/Scripts/CardEffect/AD1/Blue/AD1_011.cs
@@ -109,7 +109,7 @@ namespace DCGO.CardEffects.AD1
 
                     if (CardEffectCommons.IsJogress(hashtable))
                     {
-                        card.PermanentOfThisCard().UntilEachTurnEndEffects.Add(_timing => PermanentEffectFactory.CanNotSwitchAttackTargetEffect(card.PermanentOfThisCard()));
+                        card.PermanentOfThisCard().UntilEachTurnEndEffects.Add(_timing => PermanentEffectFactory.CanNotSwitchAttackTargetEffect(card.PermanentOfThisCard(), activateClass));
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT18/Purple/BT18_083.cs
+++ b/Assets/Scripts/CardEffect/BT18/Purple/BT18_083.cs
@@ -157,12 +157,9 @@ namespace DCGO.CardEffects.BT18
 
             if (timing == EffectTiming.None)
             {
-                AddSkillClass addSkillClass = new AddSkillClass();
-                addSkillClass.SetUpICardEffect("Your Digimon gain Collision", CanUseCondition, card);
-                addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
-                cardEffects.Add(addSkillClass);
+                cardEffects.Add(CardEffectFactory.CollisionStaticEffect(PermanentCondition, false, card, CanUseCondition));
 
-                bool CanUseCondition(Hashtable hashtable)
+                bool CanUseCondition()
                 {
                     return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
                 }
@@ -171,37 +168,6 @@ namespace DCGO.CardEffects.BT18
                 {
                     return CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(permanent) &&
                            permanent.DP <= card.PermanentOfThisCard().DP;
-                }
-
-                bool CardSourceCondition(CardSource cardSource)
-                {
-                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(cardSource))
-                    {
-                        if (cardSource == cardSource.PermanentOfThisCard().TopCard)
-                        {
-                            if (PermanentCondition(cardSource.PermanentOfThisCard()))
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    return false;
-                }
-
-                List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
-                {
-                    if (_timing == EffectTiming.OnCounterTiming)
-                    {
-                        bool Condition()
-                        {
-                            return CardSourceCondition(cardSource);
-                        }
-
-                        cardEffects.Add(CardEffectFactory.CollisionSelfStaticEffect(false, cardSource, Condition));
-                    }
-
-                    return cardEffects;
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_077.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_077.cs
@@ -132,65 +132,8 @@ namespace DCGO.CardEffects.BT21
 
                                 if (selectedPermanent != null)
                                 {
-                                    AddSkillClass addSkillClass = new AddSkillClass();
-                                    addSkillClass.SetUpICardEffect("Gain Collision", CanUseCondition1, card);
-                                    addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
-                                    selectedPermanent.TopCard.Owner.UntilOwnerTurnEndEffects.Add((_timing) => addSkillClass);
-
-                                    bool CanUseCondition1(Hashtable hashtable)
-                                    {
-                                        return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
-                                    }
-
-                                    bool CardSourceCondition(CardSource cardSource)
-                                    {
-                                        return PermanentCondition(selectedPermanent);
-                                    }
-
-                                    bool PermanentCondition(Permanent permanent)
-                                    {
-                                        if (CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
-                                        {
-                                            if (!permanent.TopCard.CanNotBeAffected(activateClass))
-                                            {
-                                                if (permanent == selectedPermanent)
-                                                    return true;
-                                            }
-                                        }
-
-                                        return false;
-                                    }
-
-                                    List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
-                                    {
-                                        if (_timing == EffectTiming.OnCounterTiming)
-                                        {
-                                            bool CardSourceCondition(CardSource cardSource)
-                                            {
-                                                if (CardEffectCommons.IsExistOnBattleAreaDigimon(cardSource))
-                                                {
-                                                    if (cardSource == selectedPermanent.TopCard)
-                                                    {
-                                                        if (PermanentCondition(selectedPermanent))
-                                                        {
-                                                            return true;
-                                                        }
-                                                    }
-                                                }
-
-                                                return false;
-                                            }
-
-                                            bool Condition()
-                                            {
-                                                return CardSourceCondition(cardSource);
-                                            }
-
-                                            cardEffects.Add(CardEffectFactory.CollisionSelfStaticEffect(false, cardSource, Condition));
-                                        }
-
-                                        return cardEffects;
-                                    }
+                                    CollisionClass collisionClass = PermanentEffectFactory.CollisionEffect(selectedPermanent, activateClass);
+                                    CardEffectCommons.AddEffectToPermanent(targetPermanent: selectedPermanent, effectDuration: EffectDuration.UntilOwnerTurnEnd, card: card, cardEffect: collisionClass, timing: EffectTiming.OnCounterTiming);
 
                                     ActivateClass activateClassDebuff = new ActivateClass();
                                     activateClassDebuff.SetUpICardEffect("Attack with this Digimon", CanUseConditionDebuff,
@@ -346,65 +289,8 @@ namespace DCGO.CardEffects.BT21
 
                                 if (selectedPermanent != null)
                                 {
-                                    AddSkillClass addSkillClass = new AddSkillClass();
-                                    addSkillClass.SetUpICardEffect("Gain Collision", CanUseCondition1, card);
-                                    addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
-                                    selectedPermanent.TopCard.Owner.UntilOwnerTurnEndEffects.Add((_timing) => addSkillClass);
-
-                                    bool CanUseCondition1(Hashtable hashtable)
-                                    {
-                                        return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
-                                    }
-
-                                    bool CardSourceCondition(CardSource cardSource)
-                                    {
-                                        return PermanentCondition(selectedPermanent);
-                                    }
-
-                                    bool PermanentCondition(Permanent permanent)
-                                    {
-                                        if (CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card))
-                                        {
-                                            if (!permanent.TopCard.CanNotBeAffected(activateClass))
-                                            {
-                                                if (permanent == selectedPermanent)
-                                                    return true;
-                                            }
-                                        }
-
-                                        return false;
-                                    }
-
-                                    List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
-                                    {
-                                        if (_timing == EffectTiming.OnCounterTiming)
-                                        {
-                                            bool CardSourceCondition(CardSource cardSource)
-                                            {
-                                                if (CardEffectCommons.IsExistOnBattleAreaDigimon(cardSource))
-                                                {
-                                                    if (cardSource == selectedPermanent.TopCard)
-                                                    {
-                                                        if (PermanentCondition(selectedPermanent))
-                                                        {
-                                                            return true;
-                                                        }
-                                                    }
-                                                }
-
-                                                return false;
-                                            }
-
-                                            bool Condition()
-                                            {
-                                                return CardSourceCondition(cardSource);
-                                            }
-
-                                            cardEffects.Add(CardEffectFactory.CollisionSelfStaticEffect(false, cardSource, Condition));
-                                        }
-
-                                        return cardEffects;
-                                    }
+                                    CollisionClass collisionClass = PermanentEffectFactory.CollisionEffect(selectedPermanent, activateClass);
+                                    CardEffectCommons.AddEffectToPermanent(targetPermanent: selectedPermanent, effectDuration: EffectDuration.UntilOwnerTurnEnd, card: card, cardEffect: collisionClass, timing: EffectTiming.OnCounterTiming);
 
                                     ActivateClass activateClassDebuff = new ActivateClass();
                                     activateClassDebuff.SetUpICardEffect("Attack with this Digimon", CanUseConditionDebuff, selectedPermanent.TopCard);

--- a/Assets/Scripts/CardEffect/BT23/Blue/BT23_017.cs
+++ b/Assets/Scripts/CardEffect/BT23/Blue/BT23_017.cs
@@ -236,7 +236,7 @@ namespace DCGO.CardEffects.BT23
                                 #region Delete Digimon Played
 
                                 yield return ContinuousController.instance.StartCoroutine(
-                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd));
+                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd, activateClass));
 
                                 #endregion
                             }

--- a/Assets/Scripts/CardEffect/BT23/Green/BT23_037.cs
+++ b/Assets/Scripts/CardEffect/BT23/Green/BT23_037.cs
@@ -176,7 +176,7 @@ namespace DCGO.CardEffects.BT23
                                 #region Delete Digimon Played
 
                                 yield return ContinuousController.instance.StartCoroutine(
-                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd));
+                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd, activateClass));
                                 
                                 #endregion
                             }

--- a/Assets/Scripts/CardEffect/BT23/Red/BT23_048.cs
+++ b/Assets/Scripts/CardEffect/BT23/Red/BT23_048.cs
@@ -205,7 +205,7 @@ namespace DCGO.CardEffects.BT23
                                 #region Delete Digimon Played
 
                                 yield return ContinuousController.instance.StartCoroutine(
-                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd));
+                                    CardEffectCommons.AddSelfDeleteEffect(playedDigimon, CardEffectCommons.DeleteTiming.AtOpponentTurnEnd, activateClass));
                                 
                                 #endregion
                             }

--- a/Assets/Scripts/CardEffect/EX11/Yellow/EX11_022.cs
+++ b/Assets/Scripts/CardEffect/EX11/Yellow/EX11_022.cs
@@ -162,7 +162,7 @@ namespace DCGO.CardEffects.EX11
                     if (selectedCard != null)
                     {
                         yield return ContinuousController.instance.StartCoroutine(
-                            CardEffectCommons.AddSelfDeleteEffect(selectedCard.PermanentOfThisCard(), CardEffectCommons.DeleteTiming.AtTurnEnd));
+                            CardEffectCommons.AddSelfDeleteEffect(selectedCard.PermanentOfThisCard(), CardEffectCommons.DeleteTiming.AtTurnEnd, activateClass));
                     }
 
                     #endregion

--- a/Assets/Scripts/CardEffect/EX8/Black/EX8_070.cs
+++ b/Assets/Scripts/CardEffect/EX8/Black/EX8_070.cs
@@ -71,37 +71,7 @@ namespace DCGO.CardEffects.EX8
 
                     if (cardsTrashed)
                     {
-                        AddSkillClass addSkillClass = new AddSkillClass();
-                        addSkillClass.SetUpICardEffect("Gain Collision", CanUseCondition1, card);
-                        addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
-
-                        selectedPermanent.TopCard.Owner.UntilOpponentTurnEndEffects.Add((_timing) => addSkillClass);
-
-                        bool CanUseCondition1(Hashtable hashtable)
-                        {
-                            return true;
-                        }
-
-                        bool CardSourceCondition(CardSource cardSource)
-                        {
-                            return PermanentCondition(selectedPermanent);
-                        }
-
-                        bool PermanentCondition(Permanent permanent)
-                        {
-                            if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
-                            {
-                                if (!permanent.TopCard.CanNotBeAffected(activateClass))
-                                {
-                                    if(permanent == selectedPermanent)
-                                        return true;
-                                }
-                            }
-
-                            return false;
-                        }
-
-                        //yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCollision(selectedPermanent, EffectDuration.UntilOpponentTurnEnd, activateClass));
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCollision(selectedPermanent, EffectDuration.UntilOpponentTurnEnd, activateClass));
                         yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainPierce(selectedPermanent, EffectDuration.UntilOpponentTurnEnd, activateClass));
                         yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainReboot(selectedPermanent, EffectDuration.UntilOpponentTurnEnd, activateClass));
                         yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(selectedPermanent, 3000, EffectDuration.UntilOpponentTurnEnd, activateClass));
@@ -125,36 +95,6 @@ namespace DCGO.CardEffects.EX8
                             activateClass: activateClass,
                             effectName: "Can't return to deck by opponent's effects"));
 
-                        List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
-                        {
-                            if (_timing == EffectTiming.OnCounterTiming)
-                            {
-                                bool CardSourceCondition(CardSource cardSource)
-                                {
-                                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(cardSource))
-                                    {
-                                        if (cardSource == selectedPermanent.TopCard)
-                                        {
-                                            if (PermanentCondition(selectedPermanent))
-                                            {
-                                                return true;
-                                            }
-                                        }
-                                    }
-
-                                    return false;
-                                }
-
-                                bool Condition()
-                                {
-                                    return CardSourceCondition(cardSource);
-                                }
-
-                                cardEffects.Add(CardEffectFactory.CollisionSelfStaticEffect(false, cardSource, Condition));
-                            }
-
-                            return cardEffects;
-                        }
                     }
                 }
             }

--- a/Assets/Scripts/Script/AttackProcess.cs
+++ b/Assets/Scripts/Script/AttackProcess.cs
@@ -352,7 +352,7 @@ public class AttackProcess : MonoBehaviourPunCallbacks
                 canTargetCondition_ByPreSelecetedList: null,
                 canEndSelectCondition: null,
                 maxCount: maxCount,
-                canNoSelect: (!IsBlocking),
+                canNoSelect: !AttackingPermanent.HasCollision,
                 canEndNotMax: false,
                 selectPermanentCoroutine: SelectPermanentCoroutine,
                 afterSelectPermanentCoroutine: null,

--- a/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/DeleteSelf.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/DeleteSelf.cs
@@ -11,7 +11,7 @@ public partial class CardEffectCommons
         AtOpponentTurnEnd
     }
 
-    public static IEnumerator AddSelfDeleteEffect(Permanent permanent, DeleteTiming deleteTiming)
+    public static IEnumerator AddSelfDeleteEffect(Permanent permanent, DeleteTiming deleteTiming, ICardEffect activateClass)
     {
         bool deleteOnOwnturn = deleteTiming != DeleteTiming.AtOpponentTurnEnd;
         bool deleteOnOpponentsTurn = deleteTiming != DeleteTiming.AtOwnTurnEnd;
@@ -21,7 +21,7 @@ public partial class CardEffectCommons
         {
             if (timing == EffectTiming.OnEndTurn)
             {
-                return PermanentEffectFactory.DeleteSelfEffect(permanent, deleteOnOwnturn, deleteOnOpponentsTurn);
+                return PermanentEffectFactory.DeleteSelfEffect(permanent, activateClass, deleteOnOwnturn, deleteOnOpponentsTurn);
             }
             return null;
         }

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Collision.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Collision.cs
@@ -34,47 +34,13 @@ public partial class CardEffectCommons
             return false;
         }
 
-        ActivateClass collision = CardEffectFactory.CollisionSelfStaticEffect(false, targetPermanent.TopCard, CanUseCondition);
+        CollisionClass collision = CardEffectFactory.CollisionSelfStaticEffect(false, targetPermanent.TopCard, CanUseCondition);
 
         AddEffectToPermanent(targetPermanent: targetPermanent, effectDuration: effectDuration, card: card, cardEffect: collision, timing: EffectTiming.OnCounterTiming);
 
         if (!targetPermanent.TopCard.CanNotBeAffected(activateClass))
         {
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateBuffEffect(targetPermanent));
-        }
-    }
-    #endregion
-
-    #region Can activate [Collision]
-    public static bool CanActivateCollision(CardSource cardSource)
-    {
-        return IsExistOnBattleArea(cardSource) &&
-               cardSource.Owner.Enemy.GetBattleAreaDigimons().Count >= 1 &&
-               GManager.instance.attackProcess.IsAttacking &&
-               GManager.instance.attackProcess.AttackingPermanent == cardSource.PermanentOfThisCard();
-    }
-    #endregion
-
-    #region Effect process of [Collision]
-    public static IEnumerator CollisionProcess(CardSource cardSource, ICardEffect activateClass, Func<IEnumerator> beforeOnAttackCoroutine = null)
-    {
-        List<Permanent> enemyDigimons = cardSource.Owner.Enemy.GetBattleAreaDigimons();
-
-        if (CanActivateCollision(cardSource))
-        {
-            foreach (Permanent enemyDigimon in enemyDigimons)
-            {
-                if (enemyDigimon.TopCard.CanNotBeAffected(activateClass))
-                    continue;
-
-                yield return ContinuousController.instance.StartCoroutine(GainBlocker(
-                        targetPermanent: enemyDigimon,
-                        effectDuration: EffectDuration.UntilEndAttack,
-                        activateClass: activateClass));
-            }
-
-            if (HasMatchConditionOpponentsPermanent(cardSource, permanent => permanent.HasBlocker))
-                GManager.instance.attackProcess.IsBlocking = true;
         }
     }
     #endregion

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Collision.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Collision.cs
@@ -19,22 +19,7 @@ public partial class CardEffectCommons
 
         CardSource card = targetPermanent.TopCard;
 
-        bool PermanentCondition(Permanent permanent) => permanent == targetPermanent;
-
-        bool CanUseCondition()
-        {
-            if (IsPermanentExistsOnBattleArea(targetPermanent))
-            {
-                if (!targetPermanent.TopCard.CanNotBeAffected(activateClass))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        CollisionClass collision = CardEffectFactory.CollisionSelfStaticEffect(false, targetPermanent.TopCard, CanUseCondition);
+        CollisionClass collision = PermanentEffectFactory.CollisionEffect(targetPermanent, activateClass);
 
         AddEffectToPermanent(targetPermanent: targetPermanent, effectDuration: effectDuration, card: card, cardEffect: collision, timing: EffectTiming.OnCounterTiming);
 

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Execute.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Execute.cs
@@ -77,7 +77,7 @@ public partial class CardEffectCommons
             {
                 if (timing == EffectTiming.OnEndAttack)
                 {
-                    return PermanentEffectFactory.DeleteSelfEffect(selectedPermanent);
+                    return PermanentEffectFactory.DeleteSelfEffect(selectedPermanent, activateClass);
                 }
                 return null;
             }

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Collision.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Collision.cs
@@ -15,18 +15,9 @@ public partial class CardEffectFactory
         {
             if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
             {
-                if (card.Owner.Enemy.GetBattleAreaDigimons().Count() > 0)
+                if (condition == null || condition())
                 {
-                    if (GManager.instance.attackProcess.IsAttacking)
-                    {
-                        if (GManager.instance.attackProcess.AttackingPermanent == card.PermanentOfThisCard())
-                        {
-                            if (condition == null || condition())
-                            {
-                                return true;
-                            }
-                        }
-                    }     
+                    return true;
                 }
             }
 
@@ -64,13 +55,7 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable)
         {
-            if (condition == null || condition())
-            {
-                if(PermanentCondition(card.PermanentOfThisCard()))
-                    return true;
-            }
-
-            return false;
+            return condition == null || condition();
         }
 
         return collisionClass;

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Collision.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Collision.cs
@@ -7,10 +7,8 @@ using UnityEngine;
 public partial class CardEffectFactory
 {
     #region Static effect of [Collision] on oneself
-    public static ActivateClass CollisionSelfStaticEffect(bool isInheritedEffect, CardSource card, Func<bool> condition)
+    public static CollisionClass CollisionSelfStaticEffect(bool isInheritedEffect, CardSource card, Func<bool> condition)
     {
-        Permanent targetPermanent = card.PermanentOfThisCard();
-
         bool PermanentCondition(Permanent permanent) => permanent == card.PermanentOfThisCard();
 
         bool CanUseCondition()
@@ -40,21 +38,16 @@ public partial class CardEffectFactory
     #endregion
 
     #region Static effect of [Collision]
-    public static ActivateClass CollisionStaticEffect(
+    public static CollisionClass CollisionStaticEffect(
         Func<Permanent, bool> permanentCondition,
         bool isInheritedEffect,
         CardSource card,
         Func<bool> condition)
     {
-        ActivateClass activateClass = new ActivateClass();
-        activateClass.SetUpICardEffect("Collision", CanUseCondition, card);
-        activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
-        activateClass.SetIsInheritedEffect(isInheritedEffect);
-
-        string EffectDiscription()
-        {
-            return DataBase.CollisionEffectDiscription();
-        }
+        CollisionClass collisionClass = new ();
+        collisionClass.SetUpICardEffect("Collision", CanUseCondition, card);
+        collisionClass.SetUpCollisionClass(PermanentCondition);
+        collisionClass.SetIsInheritedEffect(isInheritedEffect);
 
         bool PermanentCondition(Permanent permanent)
         {
@@ -80,17 +73,7 @@ public partial class CardEffectFactory
             return false;
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
-        {
-            return true;
-        }
-
-        IEnumerator ActivateCoroutine(Hashtable _hashtable)
-        {
-            return CardEffectCommons.CollisionProcess(card, activateClass);
-        }
-
-        return activateClass;
+        return collisionClass;
     }
     #endregion
 }

--- a/Assets/Scripts/Script/CardEffectInterfaces.cs
+++ b/Assets/Scripts/Script/CardEffectInterfaces.cs
@@ -530,3 +530,10 @@ public interface IOptionResolutionEffect
     IEnumerator Resolve(CardSource optionCard);
 }
 #endregion
+
+#region Collision
+public interface ICollisionEffect
+{
+    bool HasCollision(Permanent permanent);
+}
+#endregion

--- a/Assets/Scripts/Script/CardEffects/CollisionClass.cs
+++ b/Assets/Scripts/Script/CardEffects/CollisionClass.cs
@@ -1,0 +1,30 @@
+using System;
+
+public class CollisionClass : ICardEffect, ICollisionEffect
+{
+    public void SetUpCollisionClass(Func<Permanent, bool> PermanentCondition)
+    {
+        this.PermanentCondition = PermanentCondition;
+    }
+
+    Func<Permanent, bool> PermanentCondition { get; set; }
+
+    public bool HasCollision(Permanent permanent)
+    {
+        if (PermanentCondition != null)
+        {
+            if (permanent != null)
+            {
+                if (permanent.TopCard != null)
+                {
+                    if (PermanentCondition(permanent))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -2373,6 +2373,20 @@ public class Permanent
     {
         get
         {
+            #region if attacking digimon has collision
+            if (GManager.instance.attackProcess.ActiveAttack())
+            {
+                Permanent attackingPermanent = GManager.instance.attackProcess.AttackingPermanent;
+
+                if (attackingPermanent != null
+                    && attackingPermanent.TopCard.Owner != TopCard.Owner
+                    && attackingPermanent.HasCollision)
+                {
+                    return true;
+                }
+            }
+            #endregion
+
             foreach (Player player in GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer)
             {
                 #region Effects of permanents in play
@@ -2954,15 +2968,64 @@ public class Permanent
     {
         get
         {
-            foreach (ICardEffect cardEffect in this.EffectList(EffectTiming.OnAllyAttack))
+            foreach (Player player in GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer)
             {
-                if (cardEffect is ActivateICardEffect)
+                foreach (Permanent permanent in player.GetFieldPermanents())
                 {
-                    if (cardEffect.EffectName == "Collision")
+                    #region Permanent Effects
+                    foreach (ICardEffect cardEffect in permanent.EffectList(EffectTiming.OnCounterTiming))
                     {
-                        return true;
+                        if (cardEffect is ICollisionEffect)
+                        {
+                            if (cardEffect.CanTrigger(null))
+                            {
+                                if (((ICollisionEffect)cardEffect).HasCollision(this))
+                                {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    #endregion
+                }
+
+                #region Effects of faceup security
+                foreach (CardSource source in player.SecurityCards)
+                {
+                    if (source.IsFlipped)
+                        continue;
+
+                    foreach (ICardEffect cardEffect in source.EffectList(EffectTiming.OnCounterTiming))
+                    {
+                        if (cardEffect is ICollisionEffect)
+                        {
+                            if (cardEffect.CanTrigger(null))
+                            {
+                                if (((ICollisionEffect)cardEffect).HasCollision(this))
+                                {
+                                    return true;
+                                }
+                            }
+                        }
                     }
                 }
+                #endregion
+
+                #region Player Effects
+                foreach (ICardEffect cardEffect in player.EffectList(EffectTiming.OnCounterTiming))
+                {
+                    if (cardEffect is ICollisionEffect)
+                    {
+                        if (cardEffect.CanTrigger(null))
+                        {
+                            if (((ICollisionEffect)cardEffect).HasCollision(this))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                #endregion
             }
 
             return false;

--- a/Assets/Scripts/Script/PermanentEffectFactory.cs
+++ b/Assets/Scripts/Script/PermanentEffectFactory.cs
@@ -11,7 +11,7 @@ public partial class PermanentEffectFactory
 {
 
     #region Effect of a Permanent to Delete Itself
-    public static ActivateClass DeleteSelfEffect(Permanent permanent, bool deleteOnOwnturn = true, bool deleteOnOpponentsTurn = true)
+    public static ActivateClass DeleteSelfEffect(Permanent permanent, ICardEffect cardEffect, bool deleteOnOwnturn = true, bool deleteOnOpponentsTurn = true)
     {
         ActivateClass activateClass = new ActivateClass();
         activateClass.SetUpICardEffect("Delete this Digimon", CanUseCondition, permanent.TopCard);
@@ -21,7 +21,9 @@ public partial class PermanentEffectFactory
 
         bool CanUseCondition(Hashtable hashtable)
         {
-            if (permanent.TopCard != null && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard))
+            if (permanent.TopCard != null
+                && CardEffectCommons.IsExistOnBattleArea(permanent.TopCard)
+                && !permanent.TopCard.CanNotBeAffected(cardEffect))
             {
                 if (CardEffectCommons.IsOwnerTurn(permanent.TopCard))
                 {
@@ -78,7 +80,7 @@ public partial class PermanentEffectFactory
     #endregion
 
     #region Cannot change Attack Target Effect
-    public static CanNotSwitchAttackTargetClass CanNotSwitchAttackTargetEffect(Permanent targetPermanent)
+    public static CanNotSwitchAttackTargetClass CanNotSwitchAttackTargetEffect(Permanent targetPermanent, ICardEffect activateClass)
     {
         CanNotSwitchAttackTargetClass canNotSwitchAttackTargetClass = new CanNotSwitchAttackTargetClass();
         canNotSwitchAttackTargetClass.SetUpICardEffect("This Digimon's attack target can't be switched.", CanUseCondition, targetPermanent.TopCard);
@@ -87,14 +89,30 @@ public partial class PermanentEffectFactory
 
         bool CanUseCondition(Hashtable hashtable)
         {
-            return CardEffectCommons.IsPermanentExistsOnBattleArea(targetPermanent) &&
-                    CardEffectCommons.IsOwnerTurn(targetPermanent.TopCard);
+            return CardEffectCommons.IsPermanentExistsOnBattleArea(targetPermanent)
+                && CardEffectCommons.IsOwnerTurn(targetPermanent.TopCard)
+                && !targetPermanent.TopCard.CanNotBeAffected(activateClass);
         }
 
         bool PermanentCondition(Permanent permanent)
         {
             return permanent != null && permanent.TopCard && permanent == targetPermanent;
         }
+    }
+    #endregion
+
+    #region Gain Collision Effect
+    public static CollisionClass CollisionEffect(Permanent targetPermanent, ICardEffect activateClass)
+    {
+        return CardEffectFactory.CollisionStaticEffect(PermanentCondition, false, targetPermanent.TopCard, CanUseCondition);
+
+        bool CanUseCondition()
+        {
+            return CardEffectCommons.IsPermanentExistsOnBattleArea(targetPermanent)
+                && !targetPermanent.TopCard.CanNotBeAffected(activateClass);
+        }
+
+        bool PermanentCondition(Permanent permanent) => permanent == targetPermanent;
     }
     #endregion
 }


### PR DESCRIPTION
Rework Collision to be a static effect, such that it works correctly when gained at counter timing.
Should fix issue with LordKnightmon Ace
Collision static effect and permanent effect through GainEffect
Should fix Proganomon

Also spotted a bug in current PermanentEffectFactory methods, they should only apply when the owner is not immune to gaining them, fixed while I was making changes on the class.