### PR TITLE
Fix On Deletion to always care about whether the top card is in trash

### DIFF
--- a/Assets/Scripts/CardEffect/BT1/Blue/BT1_030.cs
+++ b/Assets/Scripts/CardEffect/BT1/Blue/BT1_030.cs
@@ -32,7 +32,7 @@ public class BT1_030 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.CanAddMemory(activateClass))
                     {

--- a/Assets/Scripts/CardEffect/BT1/Blue/BT1_035.cs
+++ b/Assets/Scripts/CardEffect/BT1/Blue/BT1_035.cs
@@ -31,7 +31,7 @@ public class BT1_035 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.CanAddMemory(activateClass))
                     {

--- a/Assets/Scripts/CardEffect/BT10/Black/BT10_069.cs
+++ b/Assets/Scripts/CardEffect/BT10/Black/BT10_069.cs
@@ -175,7 +175,7 @@ namespace DCGO.CardEffects.BT10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT10/Black/BT10_092.cs
+++ b/Assets/Scripts/CardEffect/BT10/Black/BT10_092.cs
@@ -139,7 +139,7 @@ namespace DCGO.CardEffects.BT10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/BT10/Blue/BT10_018.cs
+++ b/Assets/Scripts/CardEffect/BT10/Blue/BT10_018.cs
@@ -61,7 +61,7 @@ namespace DCGO.CardEffects.BT10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT10/Green/BT10_056.cs
+++ b/Assets/Scripts/CardEffect/BT10/Green/BT10_056.cs
@@ -181,7 +181,7 @@ namespace DCGO.CardEffects.BT10
 
                         bool CanActivateCondition1(Hashtable hashtable)
                         {
-                            if (CardEffectCommons.CanActivateOnDeletion(cardSource))
+                            if (CardEffectCommons.CanActivateOnDeletion(hashtable, cardSource))
                             {
                                 return true;
                             }

--- a/Assets/Scripts/CardEffect/BT10/Purple/BT10_078.cs
+++ b/Assets/Scripts/CardEffect/BT10/Purple/BT10_078.cs
@@ -80,7 +80,7 @@ namespace DCGO.CardEffects.BT10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT10/Purple/BT10_080.cs
+++ b/Assets/Scripts/CardEffect/BT10/Purple/BT10_080.cs
@@ -229,7 +229,7 @@ namespace DCGO.CardEffects.BT10
 
                             bool CanActivateCondition1(Hashtable hashtable1)
                             {
-                                if (CardEffectCommons.CanActivateOnDeletion(card))
+                                if (CardEffectCommons.CanActivateOnDeletion(hashtable1, card))
                                 {
                                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                                     {

--- a/Assets/Scripts/CardEffect/BT10/Purple/BT10_081.cs
+++ b/Assets/Scripts/CardEffect/BT10/Purple/BT10_081.cs
@@ -103,7 +103,7 @@ namespace DCGO.CardEffects.BT10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT10/Purple/BT10_083.cs
+++ b/Assets/Scripts/CardEffect/BT10/Purple/BT10_083.cs
@@ -175,7 +175,7 @@ namespace DCGO.CardEffects.BT10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT11/Black/BT11_071.cs
+++ b/Assets/Scripts/CardEffect/BT11/Black/BT11_071.cs
@@ -506,7 +506,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT11/Black/BT11_072.cs
+++ b/Assets/Scripts/CardEffect/BT11/Black/BT11_072.cs
@@ -259,7 +259,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.GetBattleAreaPermanents().Count(CanSelectPermanentCondition) >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT11/Blue/BT11_031.cs
+++ b/Assets/Scripts/CardEffect/BT11/Blue/BT11_031.cs
@@ -186,7 +186,7 @@ namespace DCGO.CardEffects.BT11
                         return true;
                     }
 
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.GetBattleAreaPermanents().Count(CanSelectPermanentCondition1) >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT11/Purple/BT11_079.cs
+++ b/Assets/Scripts/CardEffect/BT11/Purple/BT11_079.cs
@@ -33,7 +33,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT11/Purple/BT11_082.cs
+++ b/Assets/Scripts/CardEffect/BT11/Purple/BT11_082.cs
@@ -118,7 +118,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT11/Red/BT11_001.cs
+++ b/Assets/Scripts/CardEffect/BT11/Red/BT11_001.cs
@@ -29,7 +29,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT11/Red/BT11_007.cs
+++ b/Assets/Scripts/CardEffect/BT11/Red/BT11_007.cs
@@ -115,7 +115,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/BT11/Red/BT11_011.cs
+++ b/Assets/Scripts/CardEffect/BT11/Red/BT11_011.cs
@@ -54,7 +54,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT11/Red/BT11_016.cs
+++ b/Assets/Scripts/CardEffect/BT11/Red/BT11_016.cs
@@ -200,7 +200,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT11/Yellow/BT11_036.cs
+++ b/Assets/Scripts/CardEffect/BT11/Yellow/BT11_036.cs
@@ -83,7 +83,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT11/Yellow/BT11_038.cs
+++ b/Assets/Scripts/CardEffect/BT11/Yellow/BT11_038.cs
@@ -49,7 +49,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT11/Yellow/BT11_040.cs
+++ b/Assets/Scripts/CardEffect/BT11/Yellow/BT11_040.cs
@@ -48,7 +48,7 @@ namespace DCGO.CardEffects.BT11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT12/Purple/BT12_006.cs
+++ b/Assets/Scripts/CardEffect/BT12/Purple/BT12_006.cs
@@ -29,7 +29,7 @@ namespace DCGO.CardEffects.BT12
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT12/Red/BT12_012.cs
+++ b/Assets/Scripts/CardEffect/BT12/Red/BT12_012.cs
@@ -67,7 +67,7 @@ namespace DCGO.CardEffects.BT12
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {
@@ -157,7 +157,7 @@ namespace DCGO.CardEffects.BT12
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT13/Black/BT13_061.cs
+++ b/Assets/Scripts/CardEffect/BT13/Black/BT13_061.cs
@@ -38,7 +38,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT13/Black/BT13_062.cs
+++ b/Assets/Scripts/CardEffect/BT13/Black/BT13_062.cs
@@ -192,7 +192,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_006.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_006.cs
@@ -46,7 +46,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_079.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_079.cs
@@ -112,7 +112,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (!CardEffectCommons.IsByBattle(hashtable))
                         {

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_082.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_082.cs
@@ -35,7 +35,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (!CardEffectCommons.IsByBattle(hashtable))
                         {

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_083.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_083.cs
@@ -418,7 +418,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.TrashCards.Count(CanSelectCardCondition) >= 2)
                         {

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_085.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_085.cs
@@ -106,7 +106,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (!CardEffectCommons.IsByBattle(hashtable))
                         {

--- a/Assets/Scripts/CardEffect/BT13/Red/BT13_001.cs
+++ b/Assets/Scripts/CardEffect/BT13/Red/BT13_001.cs
@@ -43,7 +43,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT13/Red/BT13_010.cs
+++ b/Assets/Scripts/CardEffect/BT13/Red/BT13_010.cs
@@ -152,7 +152,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT13/Red/BT13_011.cs
+++ b/Assets/Scripts/CardEffect/BT13/Red/BT13_011.cs
@@ -168,7 +168,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT13/Red/BT13_014.cs
+++ b/Assets/Scripts/CardEffect/BT13/Red/BT13_014.cs
@@ -223,7 +223,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT13/White/BT13_093.cs
+++ b/Assets/Scripts/CardEffect/BT13/White/BT13_093.cs
@@ -99,7 +99,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count(CanSelectCardCondition) >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT13/Yellow/BT13_041.cs
+++ b/Assets/Scripts/CardEffect/BT13/Yellow/BT13_041.cs
@@ -57,7 +57,7 @@ namespace DCGO.CardEffects.BT13
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT14/Black/BT14_063.cs
+++ b/Assets/Scripts/CardEffect/BT14/Black/BT14_063.cs
@@ -59,7 +59,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT14/Black/BT14_066.cs
+++ b/Assets/Scripts/CardEffect/BT14/Black/BT14_066.cs
@@ -225,7 +225,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT14/Purple/BT14_075.cs
+++ b/Assets/Scripts/CardEffect/BT14/Purple/BT14_075.cs
@@ -127,7 +127,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.Enemy.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT14/Purple/BT14_078.cs
+++ b/Assets/Scripts/CardEffect/BT14/Purple/BT14_078.cs
@@ -122,7 +122,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT14/Yellow/BT14_032.cs
+++ b/Assets/Scripts/CardEffect/BT14/Yellow/BT14_032.cs
@@ -140,7 +140,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT14/Yellow/BT14_034.cs
+++ b/Assets/Scripts/CardEffect/BT14/Yellow/BT14_034.cs
@@ -40,7 +40,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT14/Yellow/BT14_038.cs
+++ b/Assets/Scripts/CardEffect/BT14/Yellow/BT14_038.cs
@@ -153,7 +153,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.CanAddSecurity(activateClass))
                         {
@@ -198,7 +198,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.TrashCards.Some(CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT14/Yellow/BT14_102.cs
+++ b/Assets/Scripts/CardEffect/BT14/Yellow/BT14_102.cs
@@ -212,7 +212,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.CanAddSecurity(activateClass))
                         {
@@ -270,7 +270,7 @@ namespace DCGO.CardEffects.BT14
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT15/Black/BT15_057.cs
+++ b/Assets/Scripts/CardEffect/BT15/Black/BT15_057.cs
@@ -73,7 +73,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {
@@ -173,7 +173,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/BT15/Blue/BT15_030.cs
+++ b/Assets/Scripts/CardEffect/BT15/Blue/BT15_030.cs
@@ -153,7 +153,7 @@ namespace DCGO.CardEffects.BT15
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {
-                        if (CardEffectCommons.CanActivateOnDeletion(card))
+                        if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                         {
                             return true;
                         }

--- a/Assets/Scripts/CardEffect/BT15/Green/BT15_044.cs
+++ b/Assets/Scripts/CardEffect/BT15/Green/BT15_044.cs
@@ -34,7 +34,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT15/Purple/BT15_006.cs
+++ b/Assets/Scripts/CardEffect/BT15/Purple/BT15_006.cs
@@ -46,7 +46,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT15/Purple/BT15_069.cs
+++ b/Assets/Scripts/CardEffect/BT15/Purple/BT15_069.cs
@@ -28,7 +28,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.Enemy.MemoryForPlayer <= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT15/Purple/BT15_073.cs
+++ b/Assets/Scripts/CardEffect/BT15/Purple/BT15_073.cs
@@ -90,7 +90,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         return true;
                     }

--- a/Assets/Scripts/CardEffect/BT15/Purple/BT15_078.cs
+++ b/Assets/Scripts/CardEffect/BT15/Purple/BT15_078.cs
@@ -148,7 +148,7 @@ namespace DCGO.CardEffects.BT15
 
                             bool CanActivateCondition1(Hashtable hashtable)
                             {
-                                if (CardEffectCommons.CanActivateOnDeletion(cardSource))
+                                if (CardEffectCommons.CanActivateOnDeletion(hashtable, cardSource))
                                 {
                                     return true;
                                 }

--- a/Assets/Scripts/CardEffect/BT15/Purple/BT15_080.cs
+++ b/Assets/Scripts/CardEffect/BT15/Purple/BT15_080.cs
@@ -175,7 +175,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT15/Red/BT15_001.cs
+++ b/Assets/Scripts/CardEffect/BT15/Red/BT15_001.cs
@@ -44,7 +44,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT15/Red/BT15_016.cs
+++ b/Assets/Scripts/CardEffect/BT15/Red/BT15_016.cs
@@ -309,7 +309,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT15/Red/BT15_017.cs
+++ b/Assets/Scripts/CardEffect/BT15/Red/BT15_017.cs
@@ -116,7 +116,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.Enemy.SecurityCards.Count <= 3)
                         {

--- a/Assets/Scripts/CardEffect/BT15/Yellow/BT15_035.cs
+++ b/Assets/Scripts/CardEffect/BT15/Yellow/BT15_035.cs
@@ -210,7 +210,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT15/Yellow/BT15_036.cs
+++ b/Assets/Scripts/CardEffect/BT15/Yellow/BT15_036.cs
@@ -31,7 +31,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.SecurityCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT15/Yellow/BT15_041.cs
+++ b/Assets/Scripts/CardEffect/BT15/Yellow/BT15_041.cs
@@ -105,7 +105,7 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanUseCondition(Hashtable hashtable)
@@ -173,7 +173,7 @@ namespace DCGO.CardEffects.BT15
 
                 string EffectDiscription()
                 {
-                    return "[End of OpponentÅ's Turn] By deleting this Digimon, you may play 1 [Rosemon] or [Jijimon] from your hand without paying the cost. Then activate the [When Digivolving] effect of the Digimon played by this effect.";
+                    return "[End of OpponentÔøΩ's Turn] By deleting this Digimon, you may play 1 [Rosemon] or [Jijimon] from your hand without paying the cost. Then activate the [When Digivolving] effect of the Digimon played by this effect.";
                 }
 
                 bool CanUseCondition(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT16/Purple/BT16_006.cs
+++ b/Assets/Scripts/CardEffect/BT16/Purple/BT16_006.cs
@@ -31,7 +31,7 @@ namespace DCGO.CardEffects.BT16
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT16/Purple/BT16_072.cs
+++ b/Assets/Scripts/CardEffect/BT16/Purple/BT16_072.cs
@@ -125,7 +125,7 @@ namespace DCGO.CardEffects.BT16
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT16/Purple/BT16_073.cs
+++ b/Assets/Scripts/CardEffect/BT16/Purple/BT16_073.cs
@@ -139,7 +139,7 @@ namespace DCGO.CardEffects.BT16
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT16/Purple/BT16_089.cs
+++ b/Assets/Scripts/CardEffect/BT16/Purple/BT16_089.cs
@@ -244,7 +244,7 @@ namespace DCGO.CardEffects.BT16
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.TrashCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT16/Red/BT16_010.cs
+++ b/Assets/Scripts/CardEffect/BT16/Red/BT16_010.cs
@@ -166,7 +166,7 @@ namespace DCGO.CardEffects.BT16
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT16/Red/BT16_011.cs
+++ b/Assets/Scripts/CardEffect/BT16/Red/BT16_011.cs
@@ -320,7 +320,7 @@ namespace DCGO.CardEffects.BT16
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.Enemy.SecurityCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT16/Red/BT16_015.cs
+++ b/Assets/Scripts/CardEffect/BT16/Red/BT16_015.cs
@@ -161,7 +161,7 @@ namespace DCGO.CardEffects.BT16
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT17/Black/BT17_005.cs
+++ b/Assets/Scripts/CardEffect/BT17/Black/BT17_005.cs
@@ -30,7 +30,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if(CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if(CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if(CardEffectCommons.CanActivateSelfOnDeletionWithContainingTrait(hashtable, "Unidentified", card))
                             return true;

--- a/Assets/Scripts/CardEffect/BT17/Black/BT17_053.cs
+++ b/Assets/Scripts/CardEffect/BT17/Black/BT17_053.cs
@@ -103,7 +103,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.CanActivateSelfOnDeletionWithContainingTrait(hashtable, "Unidentified", card))
                         {

--- a/Assets/Scripts/CardEffect/BT17/Green/BT17_042.cs
+++ b/Assets/Scripts/CardEffect/BT17/Green/BT17_042.cs
@@ -119,7 +119,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT17/Green/BT17_045.cs
+++ b/Assets/Scripts/CardEffect/BT17/Green/BT17_045.cs
@@ -147,7 +147,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT17/Green/BT17_046.cs
+++ b/Assets/Scripts/CardEffect/BT17/Green/BT17_046.cs
@@ -41,7 +41,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if(CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsTerriermon))
                         {

--- a/Assets/Scripts/CardEffect/BT17/Green/BT17_048.cs
+++ b/Assets/Scripts/CardEffect/BT17/Green/BT17_048.cs
@@ -104,7 +104,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if(CardEffectCommons.HasMatchConditionOwnersHand(card, IsLevel6Argomon))
                         {

--- a/Assets/Scripts/CardEffect/BT17/Purple/BT17_068.cs
+++ b/Assets/Scripts/CardEffect/BT17/Purple/BT17_068.cs
@@ -215,7 +215,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            (card.Owner.HandCards.Some(CanSelectCardCondition) ||
                             card.Owner.TrashCards.Some(CanSelectCardCondition));
                 }

--- a/Assets/Scripts/CardEffect/BT17/Red/BT17_009.cs
+++ b/Assets/Scripts/CardEffect/BT17/Red/BT17_009.cs
@@ -132,7 +132,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count(CanSelectCardCondition) >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT17/White/BT17_102.cs
+++ b/Assets/Scripts/CardEffect/BT17/White/BT17_102.cs
@@ -177,7 +177,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
@@ -289,7 +289,7 @@ namespace DCGO.CardEffects.BT17
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT18/Black/BT18_073.cs
+++ b/Assets/Scripts/CardEffect/BT18/Black/BT18_073.cs
@@ -402,7 +402,7 @@ namespace DCGO.CardEffects.BT18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(HasKimeramon) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasMachinedramon) &&
                            CardEffectCommons.HasMatchConditionOwnersHand(card, HasMillenniummon);

--- a/Assets/Scripts/CardEffect/BT18/Purple/BT18_006.cs
+++ b/Assets/Scripts/CardEffect/BT18/Purple/BT18_006.cs
@@ -47,7 +47,7 @@ namespace DCGO.CardEffects.BT18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT18/Purple/BT18_078.cs
+++ b/Assets/Scripts/CardEffect/BT18/Purple/BT18_078.cs
@@ -415,7 +415,7 @@ namespace DCGO.CardEffects.BT18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT18/Red/BT18_015.cs
+++ b/Assets/Scripts/CardEffect/BT18/Red/BT18_015.cs
@@ -271,7 +271,7 @@ namespace DCGO.CardEffects.BT18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(HasMachinedramon) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasKimeramon) &&
                            CardEffectCommons.HasMatchConditionOwnersHand(card, HasMillenniummon);

--- a/Assets/Scripts/CardEffect/BT18/Red/BT18_019.cs
+++ b/Assets/Scripts/CardEffect/BT18/Red/BT18_019.cs
@@ -378,7 +378,7 @@ namespace DCGO.CardEffects.BT18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardConditionKimeramon) || CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardConditionMachinedramon))
                         {

--- a/Assets/Scripts/CardEffect/BT18/Yellow/BT18_038.cs
+++ b/Assets/Scripts/CardEffect/BT18/Yellow/BT18_038.cs
@@ -146,7 +146,7 @@ namespace DCGO.CardEffects.BT18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count(CanSelectCardCondition) >= 1)
                         {
@@ -220,7 +220,7 @@ namespace DCGO.CardEffects.BT18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.CanAddSecurity(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/BT18/Yellow/BT18_041.cs
+++ b/Assets/Scripts/CardEffect/BT18/Yellow/BT18_041.cs
@@ -356,7 +356,7 @@ namespace DCGO.CardEffects.BT18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT19/Black/BT19_055.cs
+++ b/Assets/Scripts/CardEffect/BT19/Black/BT19_055.cs
@@ -41,7 +41,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT19/Black/BT19_061.cs
+++ b/Assets/Scripts/CardEffect/BT19/Black/BT19_061.cs
@@ -189,7 +189,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersPermanent(card, IsOwnTamerCondition) &&
                            (CardEffectCommons.HasMatchConditionOwnersHand(card, HasTraitCondition) ||
                             CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasTraitCondition));

--- a/Assets/Scripts/CardEffect/BT19/Black/BT19_063.cs
+++ b/Assets/Scripts/CardEffect/BT19/Black/BT19_063.cs
@@ -354,7 +354,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(TamerHasDigimon);
                 }
 
@@ -474,7 +474,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasKnightmonInText);
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/Black/BT19_065.cs
+++ b/Assets/Scripts/CardEffect/BT19/Black/BT19_065.cs
@@ -233,7 +233,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsTargetableDigimon);
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/Blue/BT19_016.cs
+++ b/Assets/Scripts/CardEffect/BT19/Blue/BT19_016.cs
@@ -151,7 +151,7 @@ namespace DCGO.CardEffects.BT19
                 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersHand(card, HasBlueFlareTraitCondition) &&
                            CardEffectCommons.HasMatchConditionOwnersPermanent(card, IsOwnTamerCondition);
                 }

--- a/Assets/Scripts/CardEffect/BT19/Blue/BT19_020.cs
+++ b/Assets/Scripts/CardEffect/BT19/Blue/BT19_020.cs
@@ -57,7 +57,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            ((CardEffectCommons.HasMatchConditionOwnersHand(card, IsTamerCardCondition) &&
                              card.Owner.GetBattleAreaPermanents().Count(permanent => permanent.IsTamer) <= 1) ||
                             CardEffectCommons.CanActivateSave(hashtable, CanSelectSaveTamerPermanentCondition));

--- a/Assets/Scripts/CardEffect/BT19/Blue/BT19_022.cs
+++ b/Assets/Scripts/CardEffect/BT19/Blue/BT19_022.cs
@@ -54,7 +54,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasBlueFlareTraitCondition) ||
                             CardEffectCommons.CanActivateSave(hashtable, CanSelectSaveTamerPermanentCondition));
                 }

--- a/Assets/Scripts/CardEffect/BT19/Blue/BT19_026.cs
+++ b/Assets/Scripts/CardEffect/BT19/Blue/BT19_026.cs
@@ -228,7 +228,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            (CardEffectCommons.HasMatchConditionPermanent(TamerHasDigimonCondition) ||
                             CardEffectCommons.CanActivateSave(hashtable, CanSelectSaveTamerPermanentCondition));
                 }

--- a/Assets/Scripts/CardEffect/BT19/Green/BT19_051.cs
+++ b/Assets/Scripts/CardEffect/BT19/Green/BT19_051.cs
@@ -273,7 +273,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersPermanent(card, IsOwnTamerCondition) &&
                            (CardEffectCommons.HasMatchConditionOwnersHand(card, HasTraitCondition) ||
                             CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasTraitCondition));

--- a/Assets/Scripts/CardEffect/BT19/Green/BT19_095.cs
+++ b/Assets/Scripts/CardEffect/BT19/Green/BT19_095.cs
@@ -59,7 +59,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT19/Purple/BT19_006.cs
+++ b/Assets/Scripts/CardEffect/BT19/Purple/BT19_006.cs
@@ -38,7 +38,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                         return CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, PurpleLevelThree);
                     return false;
                 }

--- a/Assets/Scripts/CardEffect/BT19/Purple/BT19_068.cs
+++ b/Assets/Scripts/CardEffect/BT19/Purple/BT19_068.cs
@@ -180,7 +180,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT19/Purple/BT19_069.cs
+++ b/Assets/Scripts/CardEffect/BT19/Purple/BT19_069.cs
@@ -226,7 +226,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            card.Owner.HandCards.Count >= 1;
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/Purple/BT19_070.cs
+++ b/Assets/Scripts/CardEffect/BT19/Purple/BT19_070.cs
@@ -416,7 +416,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(CanSelectOwnerPermanentCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/Purple/BT19_098.cs
+++ b/Assets/Scripts/CardEffect/BT19/Purple/BT19_098.cs
@@ -61,7 +61,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsPlayableDevice);
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/Red/BT19_008.cs
+++ b/Assets/Scripts/CardEffect/BT19/Red/BT19_008.cs
@@ -180,7 +180,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT19/Red/BT19_012.cs
+++ b/Assets/Scripts/CardEffect/BT19/Red/BT19_012.cs
@@ -277,7 +277,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersPermanent(card, IsOwnTamerCondition) &&
                            (CardEffectCommons.HasMatchConditionOwnersHand(card, HasTraitCondition) ||
                             CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasTraitCondition));

--- a/Assets/Scripts/CardEffect/BT19/Red/BT19_013.cs
+++ b/Assets/Scripts/CardEffect/BT19/Red/BT19_013.cs
@@ -166,7 +166,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(TamerHasDigimonCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/White/BT19_077.cs
+++ b/Assets/Scripts/CardEffect/BT19/White/BT19_077.cs
@@ -154,7 +154,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            card.Owner.CanAddSecurity(activateClass);
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/White/BT19_102.cs
+++ b/Assets/Scripts/CardEffect/BT19/White/BT19_102.cs
@@ -395,7 +395,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(CanSelectTamerCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_031.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_031.cs
@@ -110,7 +110,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(TamerHasDigimonCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_032.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_032.cs
@@ -35,7 +35,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_035.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_035.cs
@@ -174,7 +174,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersPermanent(card, IsOwnTamerCondition) &&
                            (CardEffectCommons.HasMatchConditionOwnersHand(card, HasTraitCondition) ||
                             CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasTraitCondition));

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_038.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_038.cs
@@ -345,7 +345,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersPermanent(card, IsOwnTamerCondition) &&
                            (CardEffectCommons.HasMatchConditionOwnersHand(card, HasTraitCondition) ||
                             CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasTraitCondition));

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_039.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_039.cs
@@ -179,7 +179,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_093.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_093.cs
@@ -56,7 +56,7 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT2/Purple/BT2_068.cs
+++ b/Assets/Scripts/CardEffect/BT2/Purple/BT2_068.cs
@@ -30,7 +30,7 @@ public class BT2_068 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT2/Purple/BT2_069.cs
+++ b/Assets/Scripts/CardEffect/BT2/Purple/BT2_069.cs
@@ -32,7 +32,7 @@ public class BT2_069 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_006.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_006.cs
@@ -31,7 +31,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_062.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_062.cs
@@ -51,7 +51,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) &&
                            card.Owner.HandCards.Count >= 1;
                 }
 

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_063.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_063.cs
@@ -97,7 +97,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_067.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_067.cs
@@ -197,7 +197,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) &&
                            card.Owner.HandCards.Count >= 1;
                 }
 

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_068.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_068.cs
@@ -109,7 +109,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_072.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_072.cs
@@ -48,7 +48,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
                 }
 
@@ -131,7 +131,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
                 }
 

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_073.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_073.cs
@@ -261,7 +261,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_078.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_078.cs
@@ -137,7 +137,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_079.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_079.cs
@@ -232,7 +232,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
                 }
 

--- a/Assets/Scripts/CardEffect/BT20/White/BT20_083.cs
+++ b/Assets/Scripts/CardEffect/BT20/White/BT20_083.cs
@@ -134,7 +134,7 @@ namespace DCGO.CardEffects.BT20
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(isKingDrasil, true);
                 }
 

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_064.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_064.cs
@@ -120,7 +120,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_065.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_065.cs
@@ -179,7 +179,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable,card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable,card))
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_066.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_066.cs
@@ -208,7 +208,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersPermanent(card, IsOwnTamerCondition) &&
                            (CardEffectCommons.HasMatchConditionOwnersHand(card, SelectableDigimonCondition) ||
                             CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, SelectableDigimonCondition));

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_068.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_068.cs
@@ -206,7 +206,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_075.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_075.cs
@@ -198,7 +198,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanPlay);
                 }
 
@@ -272,7 +272,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanPlay);
                 }
 

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_076.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_076.cs
@@ -167,7 +167,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.Enemy.SecurityCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_077.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_077.cs
@@ -281,7 +281,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanPlay);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanPlay);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
@@ -361,7 +361,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanPlay);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanPlay);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT21/Purple/BT21_079.cs
+++ b/Assets/Scripts/CardEffect/BT21/Purple/BT21_079.cs
@@ -121,7 +121,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT21/Red/BT21_016.cs
+++ b/Assets/Scripts/CardEffect/BT21/Red/BT21_016.cs
@@ -156,7 +156,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectTamerCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/BT21/Red/BT21_020.cs
+++ b/Assets/Scripts/CardEffect/BT21/Red/BT21_020.cs
@@ -203,7 +203,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCard) || CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCard))
                         {
@@ -356,7 +356,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCard) || CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCard))
                         {

--- a/Assets/Scripts/CardEffect/BT21/Red/BT21_021.cs
+++ b/Assets/Scripts/CardEffect/BT21/Red/BT21_021.cs
@@ -153,7 +153,7 @@ namespace DCGO.CardEffects.BT21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectTamerCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/BT22/Purple/BT22_071.cs
+++ b/Assets/Scripts/CardEffect/BT22/Purple/BT22_071.cs
@@ -128,7 +128,7 @@ namespace DCGO.CardEffects.BT22
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card)
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT22/Purple/BT22_074.cs
+++ b/Assets/Scripts/CardEffect/BT22/Purple/BT22_074.cs
@@ -146,7 +146,7 @@ namespace DCGO.CardEffects.BT22
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
@@ -202,7 +202,7 @@ namespace DCGO.CardEffects.BT22
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card)
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT22/Yellow/BT22_029.cs
+++ b/Assets/Scripts/CardEffect/BT22/Yellow/BT22_029.cs
@@ -116,7 +116,7 @@ namespace DCGO.CardEffects.BT22
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersPermanent(card, SharedPuppetDigimon);
                 }
 

--- a/Assets/Scripts/CardEffect/BT22/Yellow/BT22_032.cs
+++ b/Assets/Scripts/CardEffect/BT22/Yellow/BT22_032.cs
@@ -32,7 +32,7 @@ namespace DCGO.CardEffects.BT22
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, IsPuppetLevel3Card);
                 }
 

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_004.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_004.cs
@@ -31,7 +31,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_061.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_061.cs
@@ -116,7 +116,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersPermanent(card, SharedGhostDigimon);
                 }
 
@@ -150,7 +150,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_064.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_064.cs
@@ -170,7 +170,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_065.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_065.cs
@@ -173,7 +173,7 @@ namespace DCGO.CardEffects.BT23
 
             bool SharedCanActivateCondition(Hashtable hashtable)
             {
-                return CardEffectCommons.CanActivateOnDeletion(card);
+                return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
             }
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_068.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_068.cs
@@ -176,7 +176,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent((permanent) => SharedCanSelectPermanentCondition(permanent, activateClass)))
                         {

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_069.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_069.cs
@@ -132,7 +132,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_071.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_071.cs
@@ -179,7 +179,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT23/Red/BT23_011.cs
+++ b/Assets/Scripts/CardEffect/BT23/Red/BT23_011.cs
@@ -147,7 +147,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card)
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT23/Red/BT23_012.cs
+++ b/Assets/Scripts/CardEffect/BT23/Red/BT23_012.cs
@@ -213,7 +213,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, cs => SharedCanSelectCardCondition(cs, activateClass));
                 }
             }
@@ -242,7 +242,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card)
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, cs => SharedCanSelectCardCondition(cs, activateClass));
                 }
             }

--- a/Assets/Scripts/CardEffect/BT23/Red/BT23_015.cs
+++ b/Assets/Scripts/CardEffect/BT23/Red/BT23_015.cs
@@ -411,7 +411,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.CanAddSecurity(activateClass);
                 }
 

--- a/Assets/Scripts/CardEffect/BT23/Yellow/BT23_034.cs
+++ b/Assets/Scripts/CardEffect/BT23/Yellow/BT23_034.cs
@@ -414,7 +414,7 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.CanAddSecurity(activateClass);
                 }
 

--- a/Assets/Scripts/CardEffect/BT24/Black/BT24_057.cs
+++ b/Assets/Scripts/CardEffect/BT24/Black/BT24_057.cs
@@ -186,7 +186,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT24/Black/BT24_059.cs
+++ b/Assets/Scripts/CardEffect/BT24/Black/BT24_059.cs
@@ -142,7 +142,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectCardCondition(CardSource cardSource)

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_071.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_071.cs
@@ -215,7 +215,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 
@@ -233,7 +233,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_072.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_072.cs
@@ -175,7 +175,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanPlayCardCondition(CardSource cardSource)

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_073.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_073.cs
@@ -136,7 +136,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_074.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_074.cs
@@ -164,7 +164,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_076.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_076.cs
@@ -203,7 +203,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card)
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_077.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_077.cs
@@ -255,7 +255,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 
@@ -279,7 +279,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanPlayCardCondition(CardSource cardSource)

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_080.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_080.cs
@@ -195,7 +195,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_081.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_081.cs
@@ -229,7 +229,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
                 }
 
                 bool HasCorrectTrait(CardSource cardSource)

--- a/Assets/Scripts/CardEffect/BT24/Red/BT24_010.cs
+++ b/Assets/Scripts/CardEffect/BT24/Red/BT24_010.cs
@@ -70,7 +70,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) 
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) 
                         && CardEffectCommons.HasMatchConditionPermanent(SelectableOpponentsDigimon);
                 }
 

--- a/Assets/Scripts/CardEffect/BT24/Yellow/BT24_036.cs
+++ b/Assets/Scripts/CardEffect/BT24/Yellow/BT24_036.cs
@@ -132,7 +132,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
             #endregion
@@ -171,7 +171,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT24/Yellow/BT24_039.cs
+++ b/Assets/Scripts/CardEffect/BT24/Yellow/BT24_039.cs
@@ -132,7 +132,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                         card.Owner.LibraryCards.Count >= 1 && 
                         card.Owner.CanAddSecurity(activateClass);
                 }

--- a/Assets/Scripts/CardEffect/BT24/Yellow/BT24_041.cs
+++ b/Assets/Scripts/CardEffect/BT24/Yellow/BT24_041.cs
@@ -314,7 +314,7 @@ namespace DCGO.CardEffects.BT24
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/BT3/Black/BT3_063.cs
+++ b/Assets/Scripts/CardEffect/BT3/Black/BT3_063.cs
@@ -45,7 +45,7 @@ public class BT3_063 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT3/Green/BT3_047.cs
+++ b/Assets/Scripts/CardEffect/BT3/Green/BT3_047.cs
@@ -51,7 +51,7 @@ public class BT3_047 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT3/Purple/BT3_006.cs
+++ b/Assets/Scripts/CardEffect/BT3/Purple/BT3_006.cs
@@ -31,7 +31,7 @@ public class BT3_006 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT4/Black/BT4_063.cs
+++ b/Assets/Scripts/CardEffect/BT4/Black/BT4_063.cs
@@ -44,7 +44,7 @@ public class BT4_063 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT4/Purple/BT4_088.cs
+++ b/Assets/Scripts/CardEffect/BT4/Purple/BT4_088.cs
@@ -79,7 +79,7 @@ public class BT4_088 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.Enemy.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT4/Red/BT4_113.cs
+++ b/Assets/Scripts/CardEffect/BT4/Red/BT4_113.cs
@@ -102,7 +102,7 @@ public class BT4_113 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT5/Black/BT5_060.cs
+++ b/Assets/Scripts/CardEffect/BT5/Black/BT5_060.cs
@@ -102,7 +102,7 @@ public class BT5_060 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT5/Black/BT5_067.cs
+++ b/Assets/Scripts/CardEffect/BT5/Black/BT5_067.cs
@@ -55,7 +55,7 @@ public class BT5_067 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.fieldCardFrames.Count((frame) => frame.IsEmptyFrame()) >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT5/Purple/BT5_083.cs
+++ b/Assets/Scripts/CardEffect/BT5/Purple/BT5_083.cs
@@ -108,7 +108,7 @@ public class BT5_083 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, (permanent) => permanent.IsTamer))
                     {

--- a/Assets/Scripts/CardEffect/BT5/Yellow/BT5_043.cs
+++ b/Assets/Scripts/CardEffect/BT5/Yellow/BT5_043.cs
@@ -31,7 +31,7 @@ public class BT5_043 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT6/Black/BT6_005.cs
+++ b/Assets/Scripts/CardEffect/BT6/Black/BT6_005.cs
@@ -46,7 +46,7 @@ public class BT6_005 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT6/Green/BT6_047.cs
+++ b/Assets/Scripts/CardEffect/BT6/Green/BT6_047.cs
@@ -49,7 +49,7 @@ public class BT6_047 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT6/Green/BT6_054.cs
+++ b/Assets/Scripts/CardEffect/BT6/Green/BT6_054.cs
@@ -147,7 +147,7 @@ public class BT6_054 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT7/Blue/BT7_019.cs
+++ b/Assets/Scripts/CardEffect/BT7/Blue/BT7_019.cs
@@ -127,7 +127,7 @@ public class BT7_019 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT7/Green/BT7_052.cs
+++ b/Assets/Scripts/CardEffect/BT7/Green/BT7_052.cs
@@ -59,7 +59,7 @@ public class BT7_052 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.CanAddMemory(activateClass))
                     {

--- a/Assets/Scripts/CardEffect/BT7/Purple/BT7_075.cs
+++ b/Assets/Scripts/CardEffect/BT7/Purple/BT7_075.cs
@@ -90,7 +90,7 @@ public class BT7_075 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     List<Hashtable> hashtables = CardEffectCommons.GetHashtablesFromHashtable(hashtable);
 

--- a/Assets/Scripts/CardEffect/BT7/Purple/BT7_078.cs
+++ b/Assets/Scripts/CardEffect/BT7/Purple/BT7_078.cs
@@ -196,7 +196,7 @@ public class BT7_078 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT7/Purple/BT7_091.cs
+++ b/Assets/Scripts/CardEffect/BT7/Purple/BT7_091.cs
@@ -107,7 +107,7 @@ public class BT7_091 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     return true;
                 }

--- a/Assets/Scripts/CardEffect/BT7/Red/BT7_008.cs
+++ b/Assets/Scripts/CardEffect/BT7/Red/BT7_008.cs
@@ -126,7 +126,7 @@ public class BT7_008 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/BT8/Purple/BT8_080.cs
+++ b/Assets/Scripts/CardEffect/BT8/Purple/BT8_080.cs
@@ -149,7 +149,7 @@ public class BT8_080 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (CardEffectCommons.CanActivateSelfOnDeletionWithContainingCardName(hashtable, "Myotismon", card))
                     {

--- a/Assets/Scripts/CardEffect/BT8/Purple/BT8_082.cs
+++ b/Assets/Scripts/CardEffect/BT8/Purple/BT8_082.cs
@@ -168,7 +168,7 @@ public class BT8_082 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                     {

--- a/Assets/Scripts/CardEffect/BT9/Purple/BT9_074.cs
+++ b/Assets/Scripts/CardEffect/BT9/Purple/BT9_074.cs
@@ -37,7 +37,7 @@ public class BT9_074 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.CanAddMemory(activateClass))
                     {

--- a/Assets/Scripts/CardEffect/BT9/Purple/BT9_076.cs
+++ b/Assets/Scripts/CardEffect/BT9/Purple/BT9_076.cs
@@ -331,7 +331,7 @@ public class BT9_076 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.CanAddMemory(activateClass))
                     {

--- a/Assets/Scripts/CardEffect/EX1/Purple/EX1_058.cs
+++ b/Assets/Scripts/CardEffect/EX1/Purple/EX1_058.cs
@@ -56,7 +56,7 @@ namespace DCGO.CardEffects.EX1
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX1/Yellow/EX1_023.cs
+++ b/Assets/Scripts/CardEffect/EX1/Yellow/EX1_023.cs
@@ -35,7 +35,7 @@ namespace DCGO.CardEffects.EX1
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX10/Black/EX10_035.cs
+++ b/Assets/Scripts/CardEffect/EX10/Black/EX10_035.cs
@@ -391,7 +391,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.CanAddSecurity(activateClass);
                 }
 

--- a/Assets/Scripts/CardEffect/EX10/Blue/EX10_012.cs
+++ b/Assets/Scripts/CardEffect/EX10/Blue/EX10_012.cs
@@ -506,7 +506,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.CanAddSecurity(activateClass);
                 }
 

--- a/Assets/Scripts/CardEffect/EX10/Green/EX10_020.cs
+++ b/Assets/Scripts/CardEffect/EX10/Green/EX10_020.cs
@@ -378,7 +378,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.CanAddSecurity(activateClass);
                 }
 

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_044.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_044.cs
@@ -198,7 +198,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectTamerCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_047.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_047.cs
@@ -195,7 +195,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_048.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_048.cs
@@ -330,7 +330,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPurplePermanentCondition))
                         {
@@ -415,7 +415,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_049.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_049.cs
@@ -126,7 +126,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_050.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_050.cs
@@ -127,7 +127,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.TrashCards.Count >= 10
                         && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsBeelzemon);
                 }

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_051.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_051.cs
@@ -164,7 +164,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_054.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_054.cs
@@ -329,7 +329,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_057.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_057.cs
@@ -372,7 +372,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.CanAddSecurity(activateClass);
                 }
 

--- a/Assets/Scripts/CardEffect/EX10/Red/EX10_009.cs
+++ b/Assets/Scripts/CardEffect/EX10/Red/EX10_009.cs
@@ -95,7 +95,7 @@ namespace DCGO.CardEffects.EX10
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/EX11/Purple/EX11_048.cs
+++ b/Assets/Scripts/CardEffect/EX11/Purple/EX11_048.cs
@@ -124,7 +124,7 @@ namespace DCGO.CardEffects.EX11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX11/Purple/EX11_051.cs
+++ b/Assets/Scripts/CardEffect/EX11/Purple/EX11_051.cs
@@ -183,7 +183,7 @@ namespace DCGO.CardEffects.EX11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 
@@ -210,7 +210,7 @@ namespace DCGO.CardEffects.EX11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectPermanentCondition1(Permanent permanent)

--- a/Assets/Scripts/CardEffect/EX11/White/EX11_053.cs
+++ b/Assets/Scripts/CardEffect/EX11/White/EX11_053.cs
@@ -163,7 +163,7 @@ namespace DCGO.CardEffects.EX11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.SecurityCards.Count <= 1
                         && (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition)
                             || CardEffectCommons.HasMatchConditionOwnersPermanent(card, CanSelectPermanentCondition)

--- a/Assets/Scripts/CardEffect/EX11/Yellow/EX11_019.cs
+++ b/Assets/Scripts/CardEffect/EX11/Yellow/EX11_019.cs
@@ -31,7 +31,7 @@ namespace DCGO.CardEffects.EX11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX11/Yellow/EX11_020.cs
+++ b/Assets/Scripts/CardEffect/EX11/Yellow/EX11_020.cs
@@ -55,7 +55,7 @@ namespace DCGO.CardEffects.EX11
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/EX2/Red/EX2_012.cs
+++ b/Assets/Scripts/CardEffect/EX2/Red/EX2_012.cs
@@ -193,7 +193,7 @@ namespace DCGO.CardEffects.EX2
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count(CanSelectCardCondition) >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX3/Purple/EX3_056.cs
+++ b/Assets/Scripts/CardEffect/EX3/Purple/EX3_056.cs
@@ -53,7 +53,7 @@ namespace DCGO.CardEffects.EX3
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX3/Purple/EX3_059.cs
+++ b/Assets/Scripts/CardEffect/EX3/Purple/EX3_059.cs
@@ -35,7 +35,7 @@ namespace DCGO.CardEffects.EX3
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX4/Black/EX4_040.cs
+++ b/Assets/Scripts/CardEffect/EX4/Black/EX4_040.cs
@@ -137,7 +137,7 @@ namespace DCGO.CardEffects.EX4
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX4/Black/EX4_041.cs
+++ b/Assets/Scripts/CardEffect/EX4/Black/EX4_041.cs
@@ -150,7 +150,7 @@ namespace DCGO.CardEffects.EX4
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX4/Blue/EX4_001.cs
+++ b/Assets/Scripts/CardEffect/EX4/Blue/EX4_001.cs
@@ -29,7 +29,7 @@ namespace DCGO.CardEffects.EX4
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX4/Purple/EX4_004.cs
+++ b/Assets/Scripts/CardEffect/EX4/Purple/EX4_004.cs
@@ -29,7 +29,7 @@ namespace DCGO.CardEffects.EX4
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (!CardEffectCommons.IsByBattle(hashtable))
                         {

--- a/Assets/Scripts/CardEffect/EX4/Purple/EX4_053.cs
+++ b/Assets/Scripts/CardEffect/EX4/Purple/EX4_053.cs
@@ -123,7 +123,7 @@ namespace DCGO.CardEffects.EX4
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (!CardEffectCommons.IsByBattle(hashtable))
                         {

--- a/Assets/Scripts/CardEffect/EX4/Purple/EX4_055.cs
+++ b/Assets/Scripts/CardEffect/EX4/Purple/EX4_055.cs
@@ -124,7 +124,7 @@ namespace DCGO.CardEffects.EX4
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (!CardEffectCommons.IsByBattle(hashtable))
                         {

--- a/Assets/Scripts/CardEffect/EX4/Purple/EX4_056.cs
+++ b/Assets/Scripts/CardEffect/EX4/Purple/EX4_056.cs
@@ -99,7 +99,7 @@ namespace DCGO.CardEffects.EX4
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (!CardEffectCommons.IsByBattle(hashtable))
                         {

--- a/Assets/Scripts/CardEffect/EX4/Purple/EX4_059.cs
+++ b/Assets/Scripts/CardEffect/EX4/Purple/EX4_059.cs
@@ -138,7 +138,7 @@ namespace DCGO.CardEffects.EX4
 
                                     bool CanActivateCondition1(Hashtable hashtable1)
                                     {
-                                        if (CardEffectCommons.CanActivateOnDeletion(selectedPermanent.TopCard))
+                                        if (CardEffectCommons.CanActivateOnDeletion(hashtable1, selectedPermanent.TopCard))
                                         {
                                             if (CardEffectCommons.CanPlayAsNewPermanent(cardSource: selectedPermanent.TopCard, payCost: false, cardEffect: activateClass1))
                                             {

--- a/Assets/Scripts/CardEffect/EX4/Red/EX4_008.cs
+++ b/Assets/Scripts/CardEffect/EX4/Red/EX4_008.cs
@@ -175,7 +175,7 @@ namespace DCGO.CardEffects.EX4
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX5/Black/EX5_005.cs
+++ b/Assets/Scripts/CardEffect/EX5/Black/EX5_005.cs
@@ -29,7 +29,7 @@ namespace DCGO.CardEffects.EX5
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.LibraryCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX5/Black/EX5_044.cs
+++ b/Assets/Scripts/CardEffect/EX5/Black/EX5_044.cs
@@ -100,7 +100,7 @@ namespace DCGO.CardEffects.EX5
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX5/Black/EX5_045.cs
+++ b/Assets/Scripts/CardEffect/EX5/Black/EX5_045.cs
@@ -133,7 +133,7 @@ namespace DCGO.CardEffects.EX5
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                         {

--- a/Assets/Scripts/CardEffect/EX5/Black/EX5_046.cs
+++ b/Assets/Scripts/CardEffect/EX5/Black/EX5_046.cs
@@ -95,7 +95,7 @@ namespace DCGO.CardEffects.EX5
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX5/Black/EX5_047.cs
+++ b/Assets/Scripts/CardEffect/EX5/Black/EX5_047.cs
@@ -95,7 +95,7 @@ namespace DCGO.CardEffects.EX5
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX5/Black/EX5_053.cs
+++ b/Assets/Scripts/CardEffect/EX5/Black/EX5_053.cs
@@ -158,7 +158,7 @@ namespace DCGO.CardEffects.EX5
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX5/Black/EX5_055.cs
+++ b/Assets/Scripts/CardEffect/EX5/Black/EX5_055.cs
@@ -62,7 +62,7 @@ namespace DCGO.CardEffects.EX5
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX5/Blue/EX5_024.cs
+++ b/Assets/Scripts/CardEffect/EX5/Blue/EX5_024.cs
@@ -319,7 +319,7 @@ namespace DCGO.CardEffects.EX5
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX5/Green/EX5_041.cs
+++ b/Assets/Scripts/CardEffect/EX5/Green/EX5_041.cs
@@ -231,7 +231,7 @@ public class EX5_041 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {

--- a/Assets/Scripts/CardEffect/EX5/Red/EX5_009.cs
+++ b/Assets/Scripts/CardEffect/EX5/Red/EX5_009.cs
@@ -140,7 +140,7 @@ public class EX5_009 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/EX5/Red/EX5_010.cs
+++ b/Assets/Scripts/CardEffect/EX5/Red/EX5_010.cs
@@ -154,7 +154,7 @@ public class EX5_010 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {

--- a/Assets/Scripts/CardEffect/EX5/Red/EX5_011.cs
+++ b/Assets/Scripts/CardEffect/EX5/Red/EX5_011.cs
@@ -140,7 +140,7 @@ public class EX5_011 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.CanAddMemory(activateClass))
                     {

--- a/Assets/Scripts/CardEffect/EX5/Red/EX5_013.cs
+++ b/Assets/Scripts/CardEffect/EX5/Red/EX5_013.cs
@@ -255,7 +255,7 @@ public class EX5_013 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {

--- a/Assets/Scripts/CardEffect/EX5/Yellow/EX5_027.cs
+++ b/Assets/Scripts/CardEffect/EX5/Yellow/EX5_027.cs
@@ -139,7 +139,7 @@ public class EX5_027 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {

--- a/Assets/Scripts/CardEffect/EX5/Yellow/EX5_030.cs
+++ b/Assets/Scripts/CardEffect/EX5/Yellow/EX5_030.cs
@@ -120,7 +120,7 @@ public class EX5_030 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {

--- a/Assets/Scripts/CardEffect/EX6/Black/EX6_036.cs
+++ b/Assets/Scripts/CardEffect/EX6/Black/EX6_036.cs
@@ -100,7 +100,7 @@ namespace DCGO.CardEffects.EX6
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.fieldCardFrames.Count((frame) => frame.IsEmptyFrame()) >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX6/Black/EX6_039.cs
+++ b/Assets/Scripts/CardEffect/EX6/Black/EX6_039.cs
@@ -327,7 +327,7 @@ namespace DCGO.CardEffects.EX6
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.fieldCardFrames.Count((frame) => frame.IsEmptyFrame()) >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX7/Purple/EX7_054.cs
+++ b/Assets/Scripts/CardEffect/EX7/Purple/EX7_054.cs
@@ -145,7 +145,7 @@ namespace DCGO.CardEffects.EX7
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/EX7/Purple/EX7_056.cs
+++ b/Assets/Scripts/CardEffect/EX7/Purple/EX7_056.cs
@@ -41,7 +41,7 @@ namespace DCGO.CardEffects.EX7
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/EX7/Purple/EX7_060.cs
+++ b/Assets/Scripts/CardEffect/EX7/Purple/EX7_060.cs
@@ -149,7 +149,7 @@ namespace DCGO.CardEffects.EX7
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX7/Yellow/EX7_028.cs
+++ b/Assets/Scripts/CardEffect/EX7/Yellow/EX7_028.cs
@@ -60,7 +60,7 @@ namespace DCGO.CardEffects.EX7
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/EX8/Black/EX8_046.cs
+++ b/Assets/Scripts/CardEffect/EX8/Black/EX8_046.cs
@@ -34,7 +34,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX8/Black/EX8_049.cs
+++ b/Assets/Scripts/CardEffect/EX8/Black/EX8_049.cs
@@ -88,7 +88,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(SelectableOpponentsDigimon);
                 }
 

--- a/Assets/Scripts/CardEffect/EX8/Black/EX8_050.cs
+++ b/Assets/Scripts/CardEffect/EX8/Black/EX8_050.cs
@@ -47,7 +47,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX8/Black/EX8_053.cs
+++ b/Assets/Scripts/CardEffect/EX8/Black/EX8_053.cs
@@ -79,7 +79,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX8/Purple/EX8_058.cs
+++ b/Assets/Scripts/CardEffect/EX8/Purple/EX8_058.cs
@@ -50,7 +50,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/EX8/Purple/EX8_061.cs
+++ b/Assets/Scripts/CardEffect/EX8/Purple/EX8_061.cs
@@ -172,7 +172,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, HasCorrectTrait);
                 }
 

--- a/Assets/Scripts/CardEffect/EX8/Red/EX8_008.cs
+++ b/Assets/Scripts/CardEffect/EX8/Red/EX8_008.cs
@@ -50,7 +50,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.CanAddMemory(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/EX8/Red/EX8_010.cs
+++ b/Assets/Scripts/CardEffect/EX8/Red/EX8_010.cs
@@ -135,7 +135,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX8/Yellow/EX8_033.cs
+++ b/Assets/Scripts/CardEffect/EX8/Yellow/EX8_033.cs
@@ -273,7 +273,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)
@@ -342,7 +342,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.CanAddSecurity(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/EX8/Yellow/EX8_034.cs
+++ b/Assets/Scripts/CardEffect/EX8/Yellow/EX8_034.cs
@@ -130,7 +130,7 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/EX9/Black/EX9_047.cs
+++ b/Assets/Scripts/CardEffect/EX9/Black/EX9_047.cs
@@ -110,7 +110,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectCardCondition(CardSource cardSource)

--- a/Assets/Scripts/CardEffect/EX9/Black/EX9_052.cs
+++ b/Assets/Scripts/CardEffect/EX9/Black/EX9_052.cs
@@ -185,7 +185,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX9/Black/EX9_054.cs
+++ b/Assets/Scripts/CardEffect/EX9/Black/EX9_054.cs
@@ -190,7 +190,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX9/Green/EX9_039.cs
+++ b/Assets/Scripts/CardEffect/EX9/Green/EX9_039.cs
@@ -393,7 +393,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/EX9/Purple/EX9_060.cs
+++ b/Assets/Scripts/CardEffect/EX9/Purple/EX9_060.cs
@@ -211,7 +211,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX9/Purple/EX9_062.cs
+++ b/Assets/Scripts/CardEffect/EX9/Purple/EX9_062.cs
@@ -215,7 +215,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectCardCondition(CardSource cardSource)
@@ -295,7 +295,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 bool CanSelectCardCondition(CardSource cardSource)

--- a/Assets/Scripts/CardEffect/EX9/Yellow/EX9_026.cs
+++ b/Assets/Scripts/CardEffect/EX9/Yellow/EX9_026.cs
@@ -203,7 +203,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card);
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/EX9/Yellow/EX9_027.cs
+++ b/Assets/Scripts/CardEffect/EX9/Yellow/EX9_027.cs
@@ -150,7 +150,7 @@ namespace DCGO.CardEffects.EX9
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) && 
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) && 
                            card.Owner.HandCards.Count > 0;
                 }
 

--- a/Assets/Scripts/CardEffect/LM/Green/LM_042.cs
+++ b/Assets/Scripts/CardEffect/LM/Green/LM_042.cs
@@ -380,7 +380,7 @@ namespace DCGO.CardEffects.LM
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (card.Owner.CanAddSecurity(activateClass))
                         {

--- a/Assets/Scripts/CardEffect/LM/Purple/LM_016.cs
+++ b/Assets/Scripts/CardEffect/LM/Purple/LM_016.cs
@@ -134,7 +134,7 @@ namespace DCGO.CardEffects.LM
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (card.Owner.HandCards.Count >= 1)
                         {

--- a/Assets/Scripts/CardEffect/LM/Purple/LM_044.cs
+++ b/Assets/Scripts/CardEffect/LM/Purple/LM_044.cs
@@ -62,7 +62,7 @@ namespace DCGO.CardEffects.LM
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/P/Black/P_157.cs
+++ b/Assets/Scripts/CardEffect/P/Black/P_157.cs
@@ -34,7 +34,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card) &&
+                    return CardEffectCommons.CanActivateOnDeletion( hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersPermanent(card, HasTamer); 
                 }
 

--- a/Assets/Scripts/CardEffect/P/Black/P_159.cs
+++ b/Assets/Scripts/CardEffect/P/Black/P_159.cs
@@ -58,7 +58,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/P/Black/P_174.cs
+++ b/Assets/Scripts/CardEffect/P/Black/P_174.cs
@@ -458,7 +458,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(IsOpponentsDigimon);
                 }
 

--- a/Assets/Scripts/CardEffect/P/Black/P_216.cs
+++ b/Assets/Scripts/CardEffect/P/Black/P_216.cs
@@ -186,7 +186,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card)
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                         && card.Owner.SecurityCards.Any(CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/P/Blue/P_161.cs
+++ b/Assets/Scripts/CardEffect/P/Blue/P_161.cs
@@ -72,7 +72,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/P/Green/P_163.cs
+++ b/Assets/Scripts/CardEffect/P/Green/P_163.cs
@@ -112,7 +112,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/P/Green/P_201.cs
+++ b/Assets/Scripts/CardEffect/P/Green/P_201.cs
@@ -133,7 +133,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/P/Green/P_208.cs
+++ b/Assets/Scripts/CardEffect/P/Green/P_208.cs
@@ -143,7 +143,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card);
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card);
                 }
             }
 

--- a/Assets/Scripts/CardEffect/P/Purple/P_020.cs
+++ b/Assets/Scripts/CardEffect/P/Purple/P_020.cs
@@ -54,7 +54,7 @@ public class P_020 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                     {

--- a/Assets/Scripts/CardEffect/P/Purple/P_034.cs
+++ b/Assets/Scripts/CardEffect/P/Purple/P_034.cs
@@ -44,7 +44,7 @@ public class P_034 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                     {

--- a/Assets/Scripts/CardEffect/P/Purple/P_102.cs
+++ b/Assets/Scripts/CardEffect/P/Purple/P_102.cs
@@ -265,7 +265,7 @@ public class P_102 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                     {
@@ -368,7 +368,7 @@ public class P_102 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, (cardSource) => CanSelectCardCondition(cardSource)))
                     {

--- a/Assets/Scripts/CardEffect/P/Purple/P_115.cs
+++ b/Assets/Scripts/CardEffect/P/Purple/P_115.cs
@@ -81,7 +81,7 @@ public class P_115 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/P/Purple/P_142.cs
+++ b/Assets/Scripts/CardEffect/P/Purple/P_142.cs
@@ -182,7 +182,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (!CardEffectCommons.IsByBattle(hashtable))
                         {

--- a/Assets/Scripts/CardEffect/P/Purple/P_145.cs
+++ b/Assets/Scripts/CardEffect/P/Purple/P_145.cs
@@ -206,7 +206,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         return CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, SelectMyotismonToPlay);
                     }

--- a/Assets/Scripts/CardEffect/P/Purple/P_177.cs
+++ b/Assets/Scripts/CardEffect/P/Purple/P_177.cs
@@ -30,7 +30,7 @@ namespace DCGO.CardEffects.P
                  => CardEffectCommons.CanTriggerOnDeletion(hashtable, card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card)
+                    => CardEffectCommons.CanActivateOnDeletion( hashtable, card)
                     && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/P/Red/P_091.cs
+++ b/Assets/Scripts/CardEffect/P/Red/P_091.cs
@@ -66,7 +66,7 @@ public class P_091 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                     {

--- a/Assets/Scripts/CardEffect/P/Red/P_110.cs
+++ b/Assets/Scripts/CardEffect/P/Red/P_110.cs
@@ -161,7 +161,7 @@ public class P_110 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/P/Red/P_170.cs
+++ b/Assets/Scripts/CardEffect/P/Red/P_170.cs
@@ -344,7 +344,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletion(card))
+                    if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition) || CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/P/Red/P_220.cs
+++ b/Assets/Scripts/CardEffect/P/Red/P_220.cs
@@ -334,7 +334,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                         card.Owner.TrashCards.Count(CardSelectCondition) >= 3;
                 }
 

--- a/Assets/Scripts/CardEffect/P/Yellow/P_043.cs
+++ b/Assets/Scripts/CardEffect/P/Yellow/P_043.cs
@@ -126,7 +126,7 @@ public class P_043 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {

--- a/Assets/Scripts/CardEffect/P/Yellow/P_099.cs
+++ b/Assets/Scripts/CardEffect/P/Yellow/P_099.cs
@@ -192,7 +192,7 @@ public class P_099 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.HandCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/P/Yellow/P_172.cs
+++ b/Assets/Scripts/CardEffect/P/Yellow/P_172.cs
@@ -492,7 +492,7 @@ namespace DCGO.CardEffects.P
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/RB1/Yellow/RB1_017.cs
+++ b/Assets/Scripts/CardEffect/RB1/Yellow/RB1_017.cs
@@ -37,7 +37,7 @@ public class RB1_017 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/ST14/Purple/ST14_03.cs
+++ b/Assets/Scripts/CardEffect/ST14/Purple/ST14_03.cs
@@ -63,7 +63,7 @@ public class ST14_03 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/CardEffect/ST16/Purple/ST16_07.cs
+++ b/Assets/Scripts/CardEffect/ST16/Purple/ST16_07.cs
@@ -27,7 +27,7 @@ public class ST16_07 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletion(card))
+                if (CardEffectCommons.CanActivateOnDeletion(hashtable, card))
                 {
                     if (card.Owner.CanAddMemory(activateClass))
                     {

--- a/Assets/Scripts/CardEffect/ST18/Green/ST18_06.cs
+++ b/Assets/Scripts/CardEffect/ST18/Green/ST18_06.cs
@@ -90,7 +90,7 @@ namespace DCGO.CardEffects.ST18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentSharedCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/ST18/Green/ST18_09.cs
+++ b/Assets/Scripts/CardEffect/ST18/Green/ST18_09.cs
@@ -52,7 +52,7 @@ namespace DCGO.CardEffects.ST18
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/ST19/Black/ST19_05.cs
+++ b/Assets/Scripts/CardEffect/ST19/Black/ST19_05.cs
@@ -47,7 +47,7 @@ namespace DCGO.CardEffects.ST19
                 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersHand(card, HasPuppetInTrait);
                 }
 

--- a/Assets/Scripts/CardEffect/ST19/Yellow/ST19_06.cs
+++ b/Assets/Scripts/CardEffect/ST19/Yellow/ST19_06.cs
@@ -102,7 +102,7 @@ namespace DCGO.CardEffects.ST19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/ST19/Yellow/ST19_09.cs
+++ b/Assets/Scripts/CardEffect/ST19/Yellow/ST19_09.cs
@@ -52,7 +52,7 @@ namespace DCGO.CardEffects.ST19
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanActivateOnDeletion(card) &&
+                    return CardEffectCommons.CanActivateOnDeletion(hashtable, card) &&
                            CardEffectCommons.HasMatchConditionOwnersHand(card, IsLevel3PuppetCardCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/ST21/Purple/ST21_01.cs
+++ b/Assets/Scripts/CardEffect/ST21/Purple/ST21_01.cs
@@ -32,7 +32,7 @@ namespace DCGO.CardEffects.ST21
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                    if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                     {
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                         {

--- a/Assets/Scripts/CardEffect/ST6/Purple/ST6_01.cs
+++ b/Assets/Scripts/CardEffect/ST6/Purple/ST6_01.cs
@@ -31,7 +31,7 @@ public class ST6_01 : CEntity_Effect
 
             bool CanActivateCondition(Hashtable hashtable)
             {
-                if (CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card))
+                if (CardEffectCommons.CanActivateOnDeletion( hashtable, card))
                 {
                     if (card.Owner.LibraryCards.Count >= 1)
                     {

--- a/Assets/Scripts/Script/CardEffectCommons/CanUseEffects/OnDeletion.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/CanUseEffects/OnDeletion.cs
@@ -109,21 +109,30 @@ public partial class CardEffectCommons
 
     #region Can activate
 
-    #region Can activate [On Deletion] effect(not inherited)
-    public static bool CanActivateOnDeletion(CardSource card)
+    #region Can activate [On Deletion] effect
+    public static bool CanActivateOnDeletion(Hashtable hashtable, CardSource card)
     {
-        return IsExistOnTrash(card);
-    }
-    #endregion
+        if (card.IsToken)
+            return true;
 
-    #region Can activate [On Deletion] effect(inherited)
-    public static bool CanActivateOnDeletionInherited(Hashtable hashtable, CardSource card)
-    {
-        if (IsTopCardInTrashOnDeletion(hashtable))
+        List<Hashtable> hashtables = GetHashtablesFromHashtable(hashtable);
+
+        if (hashtables != null)
         {
-            if (IsTopCardSamePermanent(hashtable, card))
+            foreach (Hashtable hashtable1 in hashtables)
             {
-                return true;
+                CardSource TopCard = GetTopCardFromOneHashtable(hashtable1);
+
+                if (TopCard != null)
+                {
+                    if (TopCard.PermanentJustBeforeRemoveField != null)
+                    {
+                        if (card.PermanentJustBeforeRemoveField == TopCard.PermanentJustBeforeRemoveField)
+                        {
+                            return IsExistOnTrash(TopCard);
+                        }
+                    }
+                }
             }
         }
 
@@ -131,7 +140,7 @@ public partial class CardEffectCommons
     }
     #endregion
 
-    #region Whether TopCard is in trash when check [On Deletion] effect
+    #region Whether any TopCard is in trash when check [On Deletion] effect
     public static bool IsTopCardInTrashOnDeletion(Hashtable hashtable)
     {
         List<Hashtable> hashtables = GetHashtablesFromHashtable(hashtable);

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Ascension.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Ascension.cs
@@ -21,7 +21,7 @@ public partial class CardEffectCommons
     #region Can activate [Ascension]
     public static bool CanActivateAscension(Hashtable hashtable, CardSource card)
     {
-        return CanActivateOnDeletion(card);
+        return CanActivateOnDeletion(hashtable, card);
     }
     #endregion
 

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Fortitude.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Fortitude.cs
@@ -17,7 +17,7 @@ public partial class CardEffectCommons
     {
         if (IsExistOnTrash(card))
         {
-            if (!isInheritedEffect || CanActivateOnDeletionInherited(hashtable, card))
+            if (!isInheritedEffect || CanActivateOnDeletion( hashtable, card))
             {
                 List<Hashtable> hashtables = CardEffectCommons.GetHashtablesFromHashtable(hashtable);
 

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -1099,8 +1099,7 @@ public partial class CardEffectFactory
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return ((!(isInherited || isLinked) && CardEffectCommons.CanActivateOnDeletion(card)) 
-                    || ((isInherited || isLinked) && CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card)))
+            return CardEffectCommons.CanActivateOnDeletion(hashtable, card)
                 && (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }


### PR DESCRIPTION
There is not actually a difference in how On Deletion behaves when it is inherited or not. Either way the thing it cares about is that the top card of the stack is still in trash, whether that be the card itself or one it was under.
To remove the issues coming from CanActivateOnDeletion vs CanActivateOnDeletionInherited mix up, I have removed the latter entirely, and the former now correctly checks in all circumstances.

Also removed a bug where for inherited effects, it was only caring if the TopCard of any of the deleted Digimon is still in trash, rather than specifically the top card of the permanent that had contained the card with the effect.

Large number of cards changed is due to needing to add a parameter to CanActivateOnDeletion, at which point it made sense to actually remove the Inherited method and not just have that one call the new code.

Basic testing that on deletions still work has been performed, more in depth testing of removing the top card before effect can activate is still needed