### PR TITLE
Add methods to check card colours of just one half of a dual card

### DIFF
--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_037.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_037.cs
@@ -38,18 +38,9 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanSelectOptionCard(CardSource cardSource)
                 {
-                    if (cardSource.IsOption)
-                    {
-                        if (cardSource.CardColors.Count == 1 && cardSource.GetCostItself <= 5)
-                        {
-                            if (!cardSource.CanNotPlayThisOption)
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    return false;
+                    return cardSource.OptionCardColors.Count == 1
+                        && cardSource.GetCostItself <= 5
+                        && !cardSource.CanNotPlayThisOption;
                 }
 
                 bool PermanentCondition(Permanent permanent)

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_040.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_040.cs
@@ -52,18 +52,9 @@ namespace DCGO.CardEffects.BT19
 
                 bool CanSelectOptionCard(CardSource cardSource)
                 {
-                    if (cardSource.IsOption)
-                    {
-                        if (cardSource.CardColors.Count == 1 && cardSource.GetCostItself <= 5)
-                        {
-                            if (!cardSource.CanNotPlayThisOption)
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    return false;
+                    return cardSource.OptionCardColors.Count == 1
+                        && cardSource.GetCostItself <= 5
+                        && !cardSource.CanNotPlayThisOption;
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT23/Black/BT23_085.cs
+++ b/Assets/Scripts/CardEffect/BT23/Black/BT23_085.cs
@@ -189,10 +189,9 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanSelectOptionCard(CardSource cardSource)
                 {
-                    return cardSource.IsOption &&
-                           cardSource.HasCSTraits &&
-                           (cardSource.CardColors.Count == 1) &&
-                           !cardSource.CanNotPlayThisOption;
+                    return cardSource.HasCSTraits
+                        && cardSource.OptionCardColors.Count == 1
+                        && !cardSource.CanNotPlayThisOption;
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX8/Yellow/EX8_037.cs
+++ b/Assets/Scripts/CardEffect/EX8/Yellow/EX8_037.cs
@@ -101,28 +101,9 @@ namespace DCGO.CardEffects.EX8
 
                 bool CanSelectOptionCard(CardSource cardSource)
                 {
-                    if (cardSource.IsOption)
-                    {
-                        if (cardSource.IsDigimon)//Dual Card
-                        {
-                            if (cardSource.DualCardColors.Count == 1 && cardSource.GetCostItself <= 5)
-                            {
-                                if (!cardSource.CanNotPlayThisOption)
-                                {
-                                    return true;
-                                }
-                            }
-                        }
-                        if (cardSource.CardColors.Count == 1 && cardSource.GetCostItself <= 5)
-                        {
-                            if (!cardSource.CanNotPlayThisOption)
-                            {
-                                return true;
-                            }
-                        }
-                    }
-
-                    return false;
+                    return cardSource.OptionCardColors.Count == 1 
+                        && cardSource.GetCostItself <= 5
+                        && !cardSource.CanNotPlayThisOption;
                 }
 
                 bool CanUseCondition(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/LM/Yellow/LM_023.cs
+++ b/Assets/Scripts/CardEffect/LM/Yellow/LM_023.cs
@@ -38,7 +38,7 @@ namespace DCGO.CardEffects.LM
             bool CanSelectCardConditionShared(CardSource cardSource)
             {
                 return (cardSource.IsTamer && cardSource.HasCardColor(CardColor.Yellow)) ||
-                       (cardSource.IsOption && cardSource.CardColors.Count == 1 && cardSource.GetCostItself <= 5);
+                       (cardSource.OptionCardColors.Count == 1 && cardSource.GetCostItself <= 5);
             }
 
             #endregion

--- a/Assets/Scripts/Script/CardSource.cs
+++ b/Assets/Scripts/Script/CardSource.cs
@@ -1481,22 +1481,75 @@ public class CardSource : MonoBehaviour
 
     #endregion
 
-    #region whether this card has the mentioned color
-
-    public bool HasCardColor(CardColor cardColor, bool isOptionOnly = false)
+    #region All colors of a Digimon Card
+    public List<CardColor> DigimonCardColors
     {
-        if (isOptionOnly)
+        get
+        {
+            if (!IsDigimon)
+            {
+                return new List<CardColor>();
+            }
+            return CardColors;
+        }
+    }
+    #endregion
+
+    #region All Colors of an Option Card
+    public List<CardColor> OptionCardColors
+    {
+        get
         {
             if (!IsOption)
-                return false;
-            if (IsDigimon)
+                return new List<CardColor>();
+            if (IsDigimon) //Dual Card
             {
-                return DualCardColors.Contains(cardColor);
+                return DualCardColors;
             }
+            return CardColors;
         }
-        return CardColors.Contains(cardColor) || DualCardColors.Contains(cardColor);
+    }
+    #endregion
+
+    #region All colors of a card
+    public List<CardColor> AllCardColors
+    {
+        get
+        {
+            return CardColors.Concat(DualCardColors).ToList();
+        }
+    }
+    #endregion
+
+    #region whether this card has the mentioned color
+    public bool HasCardColor(CardColor cardColor, bool isOptionOnly = false, bool isDigimonOnly = false)
+    {
+        if (isOptionOnly && isDigimonOnly)
+            return false; //Shouldn't be done, just here to cover all bases with consistency
+        if (isOptionOnly)
+        {
+            return OptionCardColors.Contains(cardColor);
+        } 
+        else if (isDigimonOnly)
+        {
+            return DigimonCardColors.Contains(cardColor);
+        }
+        return AllCardColors.Contains(cardColor); //check entire card
     }
 
+    public bool HasDigimonColor(CardColor cardColor)
+    {
+        if (!IsDigimon)
+            return false;
+        return HasCardColor(cardColor, isDigimonOnly: true);
+    }
+
+    public bool HasOptionColor(CardColor cardColor)
+    {
+        if (!IsOption)
+            return false;
+        return HasCardColor(cardColor, isOptionOnly: true);
+    }
     #endregion
 
     #region whether this card has at least 1 card name that contains "Greymon"


### PR DESCRIPTION
After the official rules came out, this was the only thing I believe we missed.
Need a way to check the colors of just one side, as for example there  are dual cards with a 2 color digimon which do still fulfill "Single colored option card"