### PR TITLE
Fix Dual Cards can be used while under can't use options

### DIFF
--- a/Assets/Scripts/Script/TurnStateMachine.cs
+++ b/Assets/Scripts/Script/TurnStateMachine.cs
@@ -2141,7 +2141,7 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
                             #endregion
 
                             #region オプション
-                            if (handCard1.cardSource.IsOption)
+                            if (handCard1.cardSource.IsOption && !handCard1.cardSource.CanNotPlayThisOption)
                             {
                                 GManager.instance.You.playMatCardFrame.Frame.transform.parent.gameObject.SetActive(true);
                                 GManager.instance.You.playMatCardFrame.OnFrame_Select(DataBase.SelectColor_Blue);
@@ -2622,7 +2622,7 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
                                 #endregion
 
                                 #region option
-                                if (handCard.cardSource.IsOption)
+                                if (handCard.cardSource.IsOption && !handCard.cardSource.CanNotPlayThisOption)
                                 {
                                     #region Check for drops on the playmat
                                     if (dropAreas.Count((dropArea) => dropArea.IsChildThisDropArea(GManager.instance.You.playMatCardFrame.Frame)) > 0)


### PR DESCRIPTION
Importantly: they can still digivolve if there is a valid target

Tested locally through using normally, couldn't use while under the effect and no valid digivolution target
While highlighted in hand, could not use, could only digivolve when valid target