### PR TITLE
Include dual card option information in base name and with text

### DIFF
--- a/Assets/Scripts/Script/CardSource.cs
+++ b/Assets/Scripts/Script/CardSource.cs
@@ -1345,6 +1345,13 @@ public class CardSource : MonoBehaviour
             bool isPermanent = PermanentOfThisCard() != null;
             bool isDigivolutionCard = isPermanent && thisPermanent.DigivolutionCards.Contains(this);
 
+            #region if dual card and not in play
+            if (!isPermanent && _cEntity_Base.IsDualCard)
+            {
+                baseCardNames.Add(_cEntity_Base.dualEffect);
+            }
+            #endregion
+
             #region card effects that change base card names
 
             if (isDigivolutionCard)
@@ -2088,9 +2095,11 @@ public class CardSource : MonoBehaviour
         List<string> checkStrings = new List<string>()
         {
             DataBase.ReplaceToASCII(_cEntity_Base.CardName_ENG),
+            DataBase.ReplaceToASCII(_cEntity_Base.dualEffect),
             DataBase.ReplaceToASCII(_cEntity_Base.EffectDiscription_ENG),
             DataBase.ReplaceToASCII(_cEntity_Base.InheritedEffectDiscription_ENG),
             DataBase.ReplaceToASCII(_cEntity_Base.SecurityEffectDiscription_ENG),
+            DataBase.ReplaceToASCII(_cEntity_Base.OptionEffect),
         };
 
         foreach (string attribute in _cEntity_Base.Attribute_ENG)


### PR DESCRIPTION
Ok, found how card name is being stored, this should be the last stuff to fully cover dual cards. No current dual cards have any "With Text" or "with different names" interactions for testing unfortunately