### PR TITLE
Fix connecting/matching text not appearing on cancelled search

### DIFF
--- a/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
+++ b/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
@@ -222,8 +222,6 @@ public class LobbyManager_RandomMatch : MonoBehaviourPunCallbacks
 
         yield return ContinuousController.instance.StartCoroutine(loadingObject.EndLoading());
 
-        time = 0;
-
         ReturnButton.SetActive(true);
     }
     #endregion

--- a/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
+++ b/Assets/Scripts/Script/LobbyManager_RandomMatch.cs
@@ -115,6 +115,7 @@ public class LobbyManager_RandomMatch : MonoBehaviourPunCallbacks
         m = false;
         once1 = false;
         endLoadingText = false;
+        isCoroutineRunning = false;
         time = 0;
         RandomRoomName = "";
         startJoin = false;


### PR DESCRIPTION
It includes two changes:
- timer doesn't reset to zero anymore on joining a room
- Matching/Connecting text now appears correctly when cancelling a search and doing it again