### PR TITLE
AddDetailClass to show messages in Permanent Details and display granted effects

### DIFF
--- a/Assets/Scripts/CardEffect/BT11/Purple/BT11_087.cs
+++ b/Assets/Scripts/CardEffect/BT11/Purple/BT11_087.cs
@@ -361,6 +361,7 @@ namespace DCGO.CardEffects.BT11
                             activateClass1.SetUpActivateClass(CanActivateCondition1, ActivateCoroutine1, -1, false, EffectDiscription1());
                             activateClass1.SetEffectSourcePermanent(selectedPermanent);
                             selectedPermanent.UntilEachTurnEndEffects.Add(GetCardEffect);
+                            selectedPermanent.UntilEachTurnEndEffects.Add(GetDetailEffect);
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(selectedPermanent));
 
@@ -419,6 +420,15 @@ namespace DCGO.CardEffects.BT11
                                     return activateClass1;
                                 }
 
+                                return null;
+                            }
+
+                            ICardEffect GetDetailEffect(EffectTiming timing)
+                            {
+                                if (timing == EffectTiming.None)
+                                {
+                                    return PermanentEffectFactory.AddDetailClass(selectedPermanent, "[When Attacking] Lose 3 Memory", true, activateClass);
+                                }
                                 return null;
                             }
                         }

--- a/Assets/Scripts/CardEffect/BT14/Green/BT14_044.cs
+++ b/Assets/Scripts/CardEffect/BT14/Green/BT14_044.cs
@@ -102,6 +102,13 @@ namespace DCGO.CardEffects.BT14
                                     cardEffect: activateClass1,
                                     timing: EffectTiming.OnTappedAnyone);
 
+                                CardEffectCommons.AddEffectToPermanent(
+                                    targetPermanent: selectedPermanent,
+                                    effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                                    card: card,
+                                    cardEffect: PermanentEffectFactory.AddDetailClass(selectedPermanent, "[All Turns] When this Digimon becomes suspended, lose 2 memory.", true, activateClass),
+                                    timing: EffectTiming.None);
+
                                 string EffectDiscription1()
                                 {
                                     return "[All Turns] When this Digimon becomes suspended, lose 2 memory.";

--- a/Assets/Scripts/CardEffect/BT20/Black/BT20_059.cs
+++ b/Assets/Scripts/CardEffect/BT20/Black/BT20_059.cs
@@ -96,6 +96,7 @@ namespace DCGO.CardEffects.BT20
                         canNotAffectedClass.SetUpICardEffect("Isn't affected by opponent's Digimon's effects", CanUseConditionImmunity, card);
                         canNotAffectedClass.SetUpCanNotAffectedClass(CardCondition: CardCondition, SkillCondition: SkillCondition);
                         card.Owner.UntilOpponentTurnEndEffects.Add(GetCardEffect);
+                        card.Owner.UntilOpponentTurnEndEffects.Add(GetDetailEffect);
 
                         bool CanUseConditionImmunity(Hashtable hashtable)
                         {
@@ -135,6 +136,20 @@ namespace DCGO.CardEffects.BT20
                                 return canNotAffectedClass;
                             }
 
+                            return null;
+                        }
+
+                        bool PermanentCondition(Permanent permanent)
+                        {
+                            return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card);
+                        }
+
+                        ICardEffect GetDetailEffect(EffectTiming timing)
+                        {
+                            if (timing == EffectTiming.None)
+                            {
+                                return CardEffectFactory.AddDetailClass(CanUseConditionImmunity, PermanentCondition, "Isn't affected by opponent's Digimon's effects", false, activateClass.EffectSourceCard);
+                            }
                             return null;
                         }
                     }

--- a/Assets/Scripts/CardEffect/EX6/Purple/EX6_057.cs
+++ b/Assets/Scripts/CardEffect/EX6/Purple/EX6_057.cs
@@ -152,6 +152,15 @@ namespace DCGO.CardEffects.EX6
 
                                     return null;
                                 }
+
+                                ICardEffect GetDetailEffect(EffectTiming timing)
+                                {
+                                    if (timing == EffectTiming.None)
+                                    {
+                                        return PermanentEffectFactory.AddDetailClass(permanent, "[End of your turn] Delete this Digimon", true, activateClass);
+                                    }
+                                    return null;
+                                }
                             }
                         }
                     }

--- a/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/DeleteSelf.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/DeleteSelf.cs
@@ -15,13 +15,28 @@ public partial class CardEffectCommons
     {
         bool deleteOnOwnturn = deleteTiming != DeleteTiming.AtOpponentTurnEnd;
         bool deleteOnOpponentsTurn = deleteTiming != DeleteTiming.AtOwnTurnEnd;
+        string message = "Delete this at turn end";
+        if (deleteOnOpponentsTurn && !deleteOnOwnturn)
+            message = "Delete this at opponent's turn end";
+        if (deleteOnOwnturn && ! deleteOnOpponentsTurn)
+            message = "Delete this at your turn end.";
         permanent.PermanentEffects.Add(GetCardEffect);
+        permanent.PermanentEffects.Add(GetDetailEffect);
 
         ICardEffect GetCardEffect(EffectTiming timing)
         {
             if (timing == EffectTiming.OnEndTurn)
             {
                 return PermanentEffectFactory.DeleteSelfEffect(permanent, activateClass, deleteOnOwnturn, deleteOnOpponentsTurn);
+            }
+            return null;
+        }
+
+        ICardEffect GetDetailEffect(EffectTiming timing)
+        {
+            if (timing == EffectTiming.None)
+            {
+                return PermanentEffectFactory.AddDetailClass(permanent, message, true, activateClass);
             }
             return null;
         }

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Execute.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Execute.cs
@@ -72,12 +72,22 @@ public partial class CardEffectCommons
             #region Delete this Digimon
 
             selectedPermanent.UntilEndAttackEffects.Add(GetCardEffect);
+            selectedPermanent.UntilEndAttackEffects.Add(GetDetailEffect);
 
             ICardEffect GetCardEffect(EffectTiming timing)
             {
                 if (timing == EffectTiming.OnEndAttack)
                 {
                     return PermanentEffectFactory.DeleteSelfEffect(selectedPermanent, activateClass);
+                }
+                return null;
+            }
+
+            ICardEffect GetDetailEffect(EffectTiming timing)
+            {
+                if (timing == EffectTiming.None)
+                {
+                    return PermanentEffectFactory.AddDetailClass(selectedPermanent, "At end of attack, delete this Digimon.", true, activateClass);
                 }
                 return null;
             }

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -1519,4 +1519,14 @@ public partial class CardEffectFactory
         }
     }
     #endregion
+
+    #region Add detail for Display
+    public static AddDetailClass AddDetailClass(Func<Hashtable, bool> canUseCondition, Func<Permanent, bool> permanentCondition, string detail, bool triggerEffect, CardSource card)
+    {
+        AddDetailClass addDetailClass = new();
+        addDetailClass.SetUpICardEffect("Added Detail", canUseCondition, card);
+        addDetailClass.SetUpAddDetailClass(permanentCondition, detail, triggerEffect);
+        return addDetailClass;
+    }
+    #endregion
 }

--- a/Assets/Scripts/Script/CardEffectInterfaces.cs
+++ b/Assets/Scripts/Script/CardEffectInterfaces.cs
@@ -87,6 +87,15 @@ public interface IAddSkillEffect
 }
 #endregion
 
+#region Label additional text to appear in Permanent Details
+public interface IAddDetailEffect
+{
+    bool PermanentCondition(Permanent permanent);
+    string GetDetail();//Used to avoid any interactions already built in to effect name
+    bool TriggerEffect();//Unused for now, but could be used to display something on the card to indicate it has gained an additional triggered effect, eg. [When Attacking] Lose 3 Memory
+}
+#endregion
+
 #region "Target card cannot be affected by effects" effect
 public interface ICanNotAffectedEffect
 {

--- a/Assets/Scripts/Script/CardEffects/AddDetailClass.cs
+++ b/Assets/Scripts/Script/CardEffects/AddDetailClass.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using System;
+
+public class AddDetailClass : ICardEffect, IAddDetailEffect
+{
+    Func<Permanent, bool> _permanentCondition = null;
+    string _detail = null;
+    bool _triggerEffect = false;
+
+    public void SetUpAddDetailClass(Func<Permanent, bool> permanentCondition, string detail, bool triggerEffect)
+    {
+        _permanentCondition = permanentCondition;
+        _detail = detail;
+        _triggerEffect = triggerEffect;
+    }
+
+    public bool PermanentCondition(Permanent permanent)
+    {
+        return _permanentCondition != null
+            && permanent != null
+            && permanent.TopCard != null
+            && _permanentCondition(permanent);
+    }
+    public string GetDetail()
+    {
+        return _detail;
+    }
+
+    public bool TriggerEffect()
+    {
+        return _triggerEffect;
+    }
+}

--- a/Assets/Scripts/Script/PermanentDetail.cs
+++ b/Assets/Scripts/Script/PermanentDetail.cs
@@ -290,12 +290,57 @@ public class PermanentDetail : MonoBehaviour
                 continue;
             }
 
+            if (cardEffect is IAddDetailEffect)
+            {
+                continue;
+            }
+
             if (cardEffect.IsNotShowUI)
             {
                 continue;
             }
 
             effectString += $"- {cardEffect.EffectName}\n";
+        }
+        #endregion
+
+        #region AddDetails
+        foreach (Player player in GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer)
+        {
+            #region Effects of permanents in play
+            foreach (Permanent otherPermanent in player.GetFieldPermanents())
+            {
+                foreach (ICardEffect cardEffect in otherPermanent.EffectList(EffectTiming.None))
+                {
+                    if (cardEffect is IAddDetailEffect)
+                    {
+                        if (cardEffect.CanTrigger(null))
+                        {
+                            if (((IAddDetailEffect)cardEffect).PermanentCondition(permanent))
+                            {
+                                effectString += $"- {((IAddDetailEffect)cardEffect).GetDetail()}\n";
+                            }
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Effects of Players
+            foreach (ICardEffect cardEffect in player.EffectList(EffectTiming.None))
+            {
+                if (cardEffect is IAddDetailEffect)
+                {
+                    if (cardEffect.CanTrigger(null))
+                    {
+                        if (((IAddDetailEffect)cardEffect).PermanentCondition(permanent))
+                        {
+                            effectString += $"- {((IAddDetailEffect)cardEffect).GetDetail()}\n";
+                        }
+                    }
+                }
+            }
+            #endregion
         }
         #endregion
 

--- a/Assets/Scripts/Script/PermanentEffectFactory.cs
+++ b/Assets/Scripts/Script/PermanentEffectFactory.cs
@@ -115,4 +115,23 @@ public partial class PermanentEffectFactory
         bool PermanentCondition(Permanent permanent) => permanent == targetPermanent;
     }
     #endregion
+
+    #region Add Detail for Display
+    public static AddDetailClass AddDetailClass(Permanent targetPermanent, string detail, bool triggerEffect, ICardEffect activateClass)
+    {
+        return CardEffectFactory.AddDetailClass(CanUseCondition, PermanentCondition, detail, triggerEffect, activateClass.EffectSourceCard);
+
+        bool PermanentCondition(Permanent permanent)
+        {
+            return permanent != null
+                && permanent == targetPermanent;
+        }
+
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            return CardEffectCommons.IsPermanentExistsOnBattleArea(targetPermanent)
+                && !targetPermanent.TopCard.CanNotBeAffected(activateClass);
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
Add a generic way for us to add specific extra messages to the permanent details, and make use of this to display warnings about granted effects from several Digimon, and for effects which should display but don't as they were attached to the player and not the permanent.

Intention with TriggerEffect is to mark a card with a little exclamation mark when it has been given effects the player should know about. However, the actual display of that is something I would need help or some considerable fiddling time for, so right now I am just leaving in the field so it is easy to come back later.

BT15-078 WaruSeadramon is also on my list for this effect, but it could also use a rework in general to grant a permanent effect, and I don't want to force that to be part of this, so I'll try this out first.