### PR TITLE
Update BT25-103 Ruling confirmation

### DIFF
--- a/Assets/Scripts/CardEffect/BT25/Red/BT25_103.cs
+++ b/Assets/Scripts/CardEffect/BT25/Red/BT25_103.cs
@@ -152,7 +152,7 @@ namespace DCGO.CardEffects.BT25
                         canNoTrash: true,
                         isFromOnly1Permanent: false,
                         activateClass: activateClass,
-                        canEndNotMax: true,
+                        canEndNotMax: false,
                         afterSelectionCoroutine: AfterSelectCoroutine
                     ));
 


### PR DESCRIPTION
Got some confirmation in unofficial Digimon discord, despite where "may" appears in the sentence, it is still all or nothing so you cannot choose less than the max of valid targets