### PR TITLE
Implement BT25-077 and improvements to sharedeffectfactory

### DIFF
--- a/Assets/Editor/Missing AAs/BT25/Black/BT25_073.cs
+++ b/Assets/Editor/Missing AAs/BT25/Black/BT25_073.cs
@@ -46,7 +46,7 @@ namespace DCGO.CardEffects.BT25
 
             string SharedEffectDescription(string tag) => $"[{tag}] By trashing 1 of your Digimon's link cards, you may play or use 1 [TS] trait card with a play or use cost of 5 or less from your hand without paying the cost.";
 
-            bool HasMatchingPermanent(Hashtable hashtable)
+            bool HasMatchingPermanent(Hashtable hashtable, ActivateClass activateClass)
             {
                 return CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
             }

--- a/Assets/Scripts/CardEffect/AD1/Yellow/AD1_015.cs
+++ b/Assets/Scripts/CardEffect/AD1/Yellow/AD1_015.cs
@@ -140,7 +140,7 @@ namespace DCGO.CardEffects.AD1
                     && permanent.IsTamer;
             }
 
-            bool PlayTamerCanActivateCondition(Hashtable hashtable)
+            bool PlayTamerCanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
             {
                 return CardEffectCommons.HasMatchConditionOwnersHand(card, CanPlayTamerCondition)
                         || CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanPlayTamerCondition)

--- a/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
+++ b/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
@@ -91,7 +91,7 @@ namespace DCGO.CardEffects.BT25
 
             #region Shared OP / WD
 
-            string SharedEffectName = "You may play 1 [TS] Dgiimon with 6k or less DP";
+            string SharedEffectName = "You may play 1 [TS] Digimon with 6k or less DP";
 
             string SharedEffectDescription(string tag)
                 => $"[{tag}] You may play 1 [TS] trait Digimon card with 6000 DP or less from your hand without paying the cost.";

--- a/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
+++ b/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
@@ -150,7 +150,7 @@ namespace DCGO.CardEffects.BT25
                 activateClass.SetUpICardEffect("May suspend 1 Digimon. By Effect: Delete lowest DP enemy digimon", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
                 activateClass.SetIsSkippable(true);
-                activateClass.SetHashString("AD1_024_AT");
+                activateClass.SetHashString("BT25_077_AT");
                 cardEffects.Add(activateClass);
 
                 string EffectDescription() 

--- a/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
+++ b/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
@@ -1,0 +1,234 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+// Bacchusmon
+namespace DCGO.CardEffects.BT25
+{
+    public class BT25_077 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alt Digivolution
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent permanent)
+                {
+                    return permanent.TopCard.HasTSTraits;
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(PermanentCondition, 3, true, card, null, level: 5));
+            }
+            #endregion
+
+            #region Reduce Play Cost
+            if (timing == EffectTiming.None)
+            {
+                ChangeCostClass changeCostClass = new ChangeCostClass();
+                changeCostClass.SetUpICardEffect("Play Cost -5", CanUseCondition, card);
+                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                changeCostClass.SetNotShowUI(true);
+                cardEffects.Add(changeCostClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    int totalLevels = GManager.instance.turnStateMachine.gameContext.Players_ForTurnPlayer
+                        .Map(player => player.GetBattleAreaPermanents())
+                        .Flat()
+                        .Map(LevelFromPermanent)
+                        .Sum();
+                    return totalLevels >= 12;
+                }
+
+                int LevelFromPermanent(Permanent permanent)
+                {
+                    if (CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(permanent)
+                        && permanent.TopCard.HasLevel)
+                    {
+                        return permanent.Level;
+                    }
+
+                    return 0;
+                }
+
+                int ChangeCost(CardSource cardSource, int cost, SelectCardEffect.Root root,
+                        List<Permanent> targetPermanents)
+                {
+                    if (CardSourceCondition(cardSource) &&
+                        RootCondition(root) &&
+                        PermanentsCondition(targetPermanents))
+                    {
+                        cost -= 5;
+                    }
+
+                    return cost;
+                }
+
+                bool PermanentsCondition(List<Permanent> targetPermanents)
+                {
+                    return targetPermanents == null || targetPermanents.Count(targetPermanent => targetPermanent != null) == 0;
+                }
+
+                bool CardSourceCondition(CardSource cardSource)
+                {
+                    return cardSource == card;
+                }
+
+                bool RootCondition(SelectCardEffect.Root root)
+                {
+                    return true;
+                }
+
+                bool isUpDown()
+                {
+                    return true;
+                }
+            }
+            #endregion
+
+            #region Shared OP / WD
+
+            string SharedEffectName = "You may play 1 [TS] Dgiimon with 6k or less DP";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] You may play 1 [TS] trait Digimon card with 6000 DP or less from your hand without paying the cost.";
+
+            bool CanPlayTSDigimonCondition(CardSource cardSource, ActivateClass activateClass)
+            {
+                return cardSource.IsDigimon
+                    && cardSource.HasPlayCost
+                    && cardSource.HasTSTraits
+                    && cardSource.HasDP
+                    && cardSource.CardDP <= 6000
+                    && CardEffectCommons.CanPlayAsNewPermanent(card, false, activateClass);
+            }
+
+            bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+            {
+                return CardEffectCommons.HasMatchConditionOwnersHand(card, cardSource => CanPlayTSDigimonCondition(cardSource, activateClass));
+            }
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                selectHandEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: cardSource => CanPlayTSDigimonCondition(cardSource, activateClass),
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: 1,
+                    canNoSelect: true,
+                    canEndNotMax: false,
+                    isShowOpponent: true,
+                    selectCardCoroutine: null,
+                    afterSelectCardCoroutine: null,
+                    mode: SelectHandEffect.Mode.PlayForFree,
+                    cardEffect: activateClass);
+
+                yield return StartCoroutine(selectHandEffect.Activate());
+            }
+
+            CardEffectFactory.ActivateClassesForSharedEffects
+                (ref cardEffects, timing, card,
+                    SharedEffectName,
+                    SharedActivateCoroutine,
+                    SharedEffectDescription,
+                    additionalActivateCondition: AdditionalActivateCondition,
+                    optional: false,
+                    onPlay: true,
+                    whenDigivolving: true);
+            #endregion
+
+            #region All Turns
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("May suspend 1 Digimon. By Effect: Delete lowest DP enemy digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
+                activateClass.SetHashString("AD1_024_AT");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription() 
+                    => "[All Turns] [Once Per Turn] When any Digimon are played or digivolve, you may suspend 1 Digimon. Then, if played or digivolved by an effect, delete 1 of your opponent's lowest DP Digimon.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleArea(card)
+                        && (CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, IsDigimonCondition)
+                            || CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, IsDigimonCondition));
+                }
+
+                bool IsDigimonCondition(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(permanent);
+
+                bool IsOpponentsWeakestDigimon(Permanent permanent) => CardEffectCommons.IsMinDP(permanent, card.Owner.Enemy);
+
+                bool CanActivateCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleArea(card);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool isByEffect = CardEffectCommons.IsByEffect(hashtable, null);
+                    bool executed = false;
+                    
+                    if (CardEffectCommons.HasMatchConditionPermanent(IsDigimonCondition))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsDigimonCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: AfterSelectPermanentCoroutine,
+                            mode: SelectPermanentEffect.Mode.Tap,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        IEnumerator AfterSelectPermanentCoroutine(List<Permanent> permanents)
+                        {
+                            if (permanents.Count > 0)
+                                executed = true;
+                            yield return null;
+                        }
+                    }
+
+                    if (isByEffect && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, IsOpponentsWeakestDigimon))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsOpponentsWeakestDigimon,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        executed = true;
+                    }
+                    
+                    if (!executed) activateClass.RemoveUse();
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
+++ b/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
@@ -150,7 +150,7 @@ namespace DCGO.CardEffects.BT25
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("May suspend 1 Digimon. By Effect: Delete lowest DP enemy digimon", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
-                activateClass.SetIsOptionalOverride(IsOptional);
+                activateClass.SetIsSkippableFunction(IsOptional);
                 activateClass.SetHashString("BT25_077_AT");
                 cardEffects.Add(activateClass);
 

--- a/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
+++ b/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
@@ -139,6 +139,7 @@ namespace DCGO.CardEffects.BT25
                     SharedEffectDescription,
                     additionalActivateCondition: AdditionalActivateCondition,
                     optional: false,
+                    isSkippable: true,
                     onPlay: true,
                     whenDigivolving: true);
             #endregion
@@ -151,6 +152,7 @@ namespace DCGO.CardEffects.BT25
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
                 activateClass.SetIsSkippable(true);
                 activateClass.SetHashString("AD1_024_AT");
+                activateClass.SetIsOptionalOverride(IsOptional);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription() 
@@ -161,6 +163,11 @@ namespace DCGO.CardEffects.BT25
                     return CardEffectCommons.IsExistOnBattleArea(card)
                         && (CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, IsDigimonCondition)
                             || CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, IsDigimonCondition));
+                }
+
+                bool IsOptional(Hashtable hashtable)
+                {
+                    return !CardEffectCommons.IsByEffect(hashtable, null);
                 }
 
                 bool IsDigimonCondition(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(permanent);
@@ -201,28 +208,31 @@ namespace DCGO.CardEffects.BT25
                         }
                     }
 
-                    if (isByEffect && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, IsOpponentsWeakestDigimon))
+                    if (isByEffect)
                     {
-                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                        selectPermanentEffect.SetUp(
-                            selectPlayer: card.Owner,
-                            canTargetCondition: IsOpponentsWeakestDigimon,
-                            canTargetCondition_ByPreSelecetedList: null,
-                            canEndSelectCondition: null,
-                            maxCount: 1,
-                            canNoSelect: false,
-                            canEndNotMax: false,
-                            selectPermanentCoroutine: null,
-                            afterSelectPermanentCoroutine: null,
-                            mode: SelectPermanentEffect.Mode.Destroy,
-                            cardEffect: activateClass);
-
-                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
                         executed = true;
+
+                        if (CardEffectCommons.HasMatchConditionOpponentsPermanent(card, IsOpponentsWeakestDigimon))
+                        {
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: IsOpponentsWeakestDigimon,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: false,
+                                canEndNotMax: false,
+                                selectPermanentCoroutine: null,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Destroy,
+                                cardEffect: activateClass);
+
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                        }
                     }
-                    
+
                     if (!executed) activateClass.RemoveUse();
                 }
             }

--- a/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
+++ b/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs
@@ -150,7 +150,7 @@ namespace DCGO.CardEffects.BT25
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("May suspend 1 Digimon. By Effect: Delete lowest DP enemy digimon", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
-                activateClass.SetIsSkippable(true);
+                activateClass.SetIsOptionalOverride(IsOptional);
                 activateClass.SetHashString("BT25_077_AT");
                 cardEffects.Add(activateClass);
 

--- a/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs.meta
+++ b/Assets/Scripts/CardEffect/BT25/Black/BT25_077.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97ff299a6f535c0419f9fb7a2a44a954
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CardEffect/BT25/Blue/BT25_023.cs
+++ b/Assets/Scripts/CardEffect/BT25/Blue/BT25_023.cs
@@ -38,7 +38,7 @@ namespace DCGO.CardEffects.BT25
 
             string SharedEffectDescription(string tag) => $"[{tag}] If you have 1 or fewer Tamers, you may play 1 [Thomas H. Norstein] from your hand without paying the cost.";
 
-            bool AdditionalActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
             {
                 return CardEffectCommons.MatchConditionOwnersPermanentCount(card, HasTamersInBattleArea) <= 1;
             }

--- a/Assets/Scripts/CardEffect/BT25/Purple/BT25_084.cs
+++ b/Assets/Scripts/CardEffect/BT25/Purple/BT25_084.cs
@@ -60,7 +60,7 @@ namespace DCGO.CardEffects.BT25
                     whenDigivolving: true,
                     whenAttacking: true);
 
-            bool AdditionalActivateCondition(Hashtable hashtable) => card.Owner.HandCards.Count() > 0;
+            bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass) => card.Owner.HandCards.Count() > 0;
 
             bool EnteredByEffect(Hashtable hashtable)
             {

--- a/Assets/Scripts/CardEffect/BT25/Purple/BT25_085.cs
+++ b/Assets/Scripts/CardEffect/BT25/Purple/BT25_085.cs
@@ -63,7 +63,7 @@ namespace DCGO.CardEffects.BT25
                     && !cardSource.CanNotPlayThisOption;
             }
 
-            bool CanActivateUseOption(Hashtable hashtable)
+            bool CanActivateUseOption(Hashtable hashtable, ActivateClass activateClass)
             {
                 return CardEffectCommons.HasMatchConditionOwnersHand(card, IsTraitedOption)
                     || card.PermanentOfThisCard().DigivolutionCards.Any(IsTraitedOption);
@@ -197,7 +197,7 @@ namespace DCGO.CardEffects.BT25
                     && permanent.DigivolutionOrLinkCards.Any(CanTrashCardSource);
             }
 
-            bool CanActivateUnsuspend(Hashtable hashtable) => CardEffectCommons.HasMatchConditionOwnersPermanent(card, PermanentWithTrashableCard);
+            bool CanActivateUnsuspend(Hashtable hashtable, ActivateClass activateClass) => CardEffectCommons.HasMatchConditionOwnersPermanent(card, PermanentWithTrashableCard);
 
             IEnumerator UnsuspendActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {

--- a/Assets/Scripts/CardEffect/BT25/Purple/BT25_092.cs
+++ b/Assets/Scripts/CardEffect/BT25/Purple/BT25_092.cs
@@ -35,7 +35,7 @@ namespace DCGO.CardEffects.BT25
 
                 string EffectDescription() => "[Start of Your Main Phase] By trashing 1 card with [Three Musketeers] in its text or [TS] trait from your hand, <Draw 1> and gain 1 memory.";
 
-                bool AdditionalActivateCondition(Hashtable hashtable) => CardEffectCommons.HasMatchConditionOwnersHand(card, Valid3MOrTSCard);
+                bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass) => CardEffectCommons.HasMatchConditionOwnersHand(card, Valid3MOrTSCard);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
                 {

--- a/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
+++ b/Assets/Scripts/CardEffect/EX11/Black/EX11_066.cs
@@ -54,7 +54,7 @@ namespace DCGO.CardEffects.EX11
 
             string SharedEffectDescription(string tag) => $"[{tag}] By trashing 1 card with [Vemmon] in its text from your hand, <Draw 1> and gain 1 memory.";
 
-            bool AdditionalActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
             {
                 return card.Owner.HandCards.Count(HasVemmonArchetype) >= 1;
             }

--- a/Assets/Scripts/CardEffect/ST23/Green/ST23_07.cs
+++ b/Assets/Scripts/CardEffect/ST23/Green/ST23_07.cs
@@ -38,7 +38,7 @@ namespace DCGO.CardEffects.ST23
 
             string SharedEffectDescription(string tag) => $"[{tag}] If you have 1 or fewer Tamers, you may play 1 Tamer card with the [Glowing Dawn] trait from your hand without paying the cost.";
 
-            bool AdditionalActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
             {
                 return CardEffectCommons.MatchConditionOwnersPermanentCount(card, HasTamersInBattleArea) <= 1;
             }

--- a/Assets/Scripts/CardEffect/ST23/Yellow/ST23_05.cs
+++ b/Assets/Scripts/CardEffect/ST23/Yellow/ST23_05.cs
@@ -37,14 +37,11 @@ namespace DCGO.CardEffects.ST23
                                                               SharedActivateCoroutine,
                                                               SharedEffectDescription,
                                                               false,
-                                                              isOptionalFunction: IsOptional,
                                                               maxCountPerTurn: 1,
                                                               hashValue: SharedHashString,
                                                               whenDigivolving: true,
                                                               whenAttacking: true
                                                               );
-
-            bool IsOptional(Hashtable hashtable) => !CardEffectCommons.HasMatchConditionPermanent(IsWeakestEnemyDigimon);
 
             bool IsWeakestEnemyDigimon(Permanent permanent) => CardEffectCommons.IsMinDP(permanent, card.Owner.Enemy);
 

--- a/Assets/Scripts/CardEffect/ST24/Yellow/ST24_05.cs
+++ b/Assets/Scripts/CardEffect/ST24/Yellow/ST24_05.cs
@@ -40,7 +40,7 @@ namespace DCGO.CardEffects.ST24
 
             string SharedEffectDescription(string tag) => $"[{tag}] If you have 1 or fewer Tamers, you may play 1 Tamer card with the [DATA SQUAD] trait from your hand without paying the cost.";
 
-            bool AdditionalActivateCondition(Hashtable hashtable)
+            bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
             {
                 return CardEffectCommons.MatchConditionOwnersPermanentCount(card, HasTamersInBattleArea) <= 1;
             }

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -834,7 +834,7 @@ public partial class CardEffectFactory
                                                                     bool optional,
                                                                     Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                                     Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null, 
-                                                                    Func<Hashtable, bool> isOptionalFunction = null,
+                                                                    Func<Hashtable, bool> isSkippableFunction = null,
                                                                     bool isSkippable = false,
                                                                     int maxCountPerTurn = -1,
                                                                     string hashValue = null,
@@ -853,51 +853,51 @@ public partial class CardEffectFactory
     {
         if (whenMoving && timing == EffectTiming.OnMove)
         {
-            cardEffects.Add(WhenMovingClass(card, effectName, activateCoroutine, effectDescription("When Moving"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(WhenMovingClass(card, effectName, activateCoroutine, effectDescription("When Moving"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (onPlay && timing == EffectTiming.OnEnterFieldAnyone)
         {
-            cardEffects.Add(OnPlayClass(card, effectName, activateCoroutine, effectDescription("On Play"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(OnPlayClass(card, effectName, activateCoroutine, effectDescription("On Play"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (whenDigivolving && timing == EffectTiming.OnEnterFieldAnyone)
         {
-            cardEffects.Add(WhenDigivolvingClass(card, effectName, activateCoroutine, effectDescription("When Digivolving"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(WhenDigivolvingClass(card, effectName, activateCoroutine, effectDescription("When Digivolving"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (whenAttacking && timing == EffectTiming.OnAllyAttack)
         {
-            cardEffects.Add(WhenAttackingClass(card, effectName, activateCoroutine, effectDescription("When Attacking"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(WhenAttackingClass(card, effectName, activateCoroutine, effectDescription("When Attacking"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (onDeletion && timing == EffectTiming.OnDestroyedAnyone)
         {
-            cardEffects.Add(OnDeletionClass(card, effectName, activateCoroutine, effectDescription("On Deletion"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(OnDeletionClass(card, effectName, activateCoroutine, effectDescription("On Deletion"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (whenLinking && timing == EffectTiming.WhenLinked)
         {
-            cardEffects.Add(WhenLinkingClass(card, effectName, activateCoroutine, effectDescription("When Linking"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(WhenLinkingClass(card, effectName, activateCoroutine, effectDescription("When Linking"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (endOfAttack && timing == EffectTiming.OnEndAttack)
         {
-            cardEffects.Add(EndOfAttackClass(card, effectName, activateCoroutine, effectDescription("End of Attack"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(EndOfAttackClass(card, effectName, activateCoroutine, effectDescription("End of Attack"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (endOfYourTurn && timing == EffectTiming.OnEndTurn)
         {
-            cardEffects.Add(EndOfYourTurnClass(card, effectName, activateCoroutine, effectDescription("End of Your Turn"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(EndOfYourTurnClass(card, effectName, activateCoroutine, effectDescription("End of Your Turn"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (endOfOpponentTurn && timing == EffectTiming.OnEndTurn)
         {
-            cardEffects.Add(EndOfYourOpponentsTurnClass(card, effectName, activateCoroutine, effectDescription("End of Opponent's Turn"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(EndOfYourOpponentsTurnClass(card, effectName, activateCoroutine, effectDescription("End of Opponent's Turn"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (endOfAllTurns && timing == EffectTiming.OnEndTurn)
         {
-            cardEffects.Add(EndOfAllTurnsClass(card, effectName, activateCoroutine, effectDescription("End of All Turns"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(EndOfAllTurnsClass(card, effectName, activateCoroutine, effectDescription("End of All Turns"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if(startOfYourMainPhase && timing == EffectTiming.OnStartMainPhase)
         {
-            cardEffects.Add(StartOfYourMainPhaseClass(card, effectName, activateCoroutine, effectDescription("Start of Your Main Phase"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(StartOfYourMainPhaseClass(card, effectName, activateCoroutine, effectDescription("Start of Your Main Phase"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
         if (counter && timing == EffectTiming.OnCounterTiming)
         {
-            cardEffects.Add(CounterClass(card, effectName, activateCoroutine, effectDescription("Counter"), optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
+            cardEffects.Add(CounterClass(card, effectName, activateCoroutine, effectDescription("Counter"), optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isSkippable: isSkippable));
         }
 
         return cardEffects;
@@ -914,7 +914,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInheritedEffect = false,
@@ -928,7 +928,7 @@ public partial class CardEffectFactory
         activateClass.SetUpActivateClass(hashtable => canActivateCondition(hashtable, activateClass), hashtable => activateCoroutine(hashtable, activateClass), maxCountPerTurn, optional, effectDescription);
         activateClass.SetHashString(hashValue);
         activateClass.SetIsSecurityEffect(isSecurityEffect);
-        activateClass.SetIsOptionalOverride(isOptionalFunction);
+        activateClass.SetIsSkippableFunction(isSkippableFunction);
         activateClass.SetIsSkippable(isSkippable);
         return activateClass;
     }
@@ -942,7 +942,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -950,7 +950,7 @@ public partial class CardEffectFactory
                                                 bool isInherited = false,
                                                 bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, false, isSkippable: isSkippable);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, false, isSkippable: isSkippable);
 
         bool PermanentCondition(Permanent permanent)
         {
@@ -980,7 +980,7 @@ public partial class CardEffectFactory
                                             Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                             string effectDescription,
                                             bool optional,
-                                            Func<Hashtable, bool> isOptionalFunction = null,
+                                            Func<Hashtable, bool> isSkippableFunction = null,
                                             Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                             Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                             int maxCountPerTurn = -1,
@@ -988,7 +988,7 @@ public partial class CardEffectFactory
                                             bool isInherited = false,
                                             bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, false, isSkippable: isSkippable);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, false, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
@@ -1013,7 +1013,7 @@ public partial class CardEffectFactory
                                                         Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                         string effectDescription,
                                                         bool optional,
-                                                        Func<Hashtable, bool> isOptionalFunction = null,
+                                                        Func<Hashtable, bool> isSkippableFunction = null,
                                                         Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                         Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                         int maxCountPerTurn = -1,
@@ -1022,7 +1022,7 @@ public partial class CardEffectFactory
                                                         bool isLinked = false,
                                                         bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
@@ -1046,7 +1046,7 @@ public partial class CardEffectFactory
                                                     Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                     string effectDescription,
                                                     bool optional,
-                                                    Func<Hashtable, bool> isOptionalFunction = null,
+                                                    Func<Hashtable, bool> isSkippableFunction = null,
                                                     Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                     Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                     int maxCountPerTurn = -1,
@@ -1055,7 +1055,7 @@ public partial class CardEffectFactory
                                                     bool isLinked = false,
                                                     bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
@@ -1080,7 +1080,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1089,7 +1089,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
@@ -1114,7 +1114,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1124,7 +1124,7 @@ public partial class CardEffectFactory
                                                 bool isSkippable = false
                                                 )
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
@@ -1149,12 +1149,12 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 bool isSkippable = false)
     {
-        ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, additionalActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, -1, null, false, false, true, isSkippable);
+        ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, additionalActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, -1, null, false, false, true, isSkippable);
         return activateClass;
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
@@ -1173,7 +1173,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1182,7 +1182,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
@@ -1209,7 +1209,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1218,7 +1218,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
+        ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
         activateClass.SetIsCounterEffect(true);
         return activateClass;
 
@@ -1251,7 +1251,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1262,7 +1262,7 @@ public partial class CardEffectFactory
                                                 bool opponentTurn = false,
                                                 bool isSkippable = false)
     {
-        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
+        return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isSkippableFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
@@ -1289,7 +1289,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1298,7 +1298,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
     }
 
     public static ActivateClass StartOfYourMainPhaseClass(CardSource card,
@@ -1306,7 +1306,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1315,7 +1315,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
     }
 
     public static ActivateClass EndOfYourTurnClass(CardSource card,
@@ -1323,7 +1323,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1332,7 +1332,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
     }
 
     public static ActivateClass YourTurnClass(CardSource card,
@@ -1340,7 +1340,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1349,7 +1349,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, false, isSkippable);
     }
 
     #endregion
@@ -1361,7 +1361,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1370,7 +1370,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
     }
 
     public static ActivateClass StartOfYourOpponentsMainPhaseClass(CardSource card,
@@ -1378,7 +1378,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1387,7 +1387,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
     }
 
     public static ActivateClass EndOfYourOpponentsTurnClass(CardSource card,
@@ -1395,7 +1395,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1404,7 +1404,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
     }
 
     public static ActivateClass OpponentsTurnClass(CardSource card,
@@ -1412,7 +1412,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1421,7 +1421,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, false, true, isSkippable);
     }
 
     #endregion
@@ -1433,7 +1433,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1442,7 +1442,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, true, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, true, isSkippable);
     }
 
     public static ActivateClass AllTurnsClass(CardSource card,
@@ -1450,7 +1450,7 @@ public partial class CardEffectFactory
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
-                                                Func<Hashtable, bool> isOptionalFunction = null,
+                                                Func<Hashtable, bool> isSkippableFunction = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
                                                 Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
@@ -1459,7 +1459,7 @@ public partial class CardEffectFactory
                                                 bool isLinked = false,
                                                 bool isSkippable = false)
     {
-        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isOptionalFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, true, isSkippable);
+        return TurnTimingClass(card, effectName, activateCoroutine, effectDescription, optional, isSkippableFunction, additionalUseCondition, additionalActivateCondition, maxCountPerTurn, hashValue, isInherited, isLinked, true, true, isSkippable);
     }
 
     #endregion

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -832,8 +832,8 @@ public partial class CardEffectFactory
                                                                     Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine, 
                                                                     Func<string, string> effectDescription,
                                                                     bool optional,
-                                                                    Func<Hashtable, bool> additionalUseCondition = null,
-                                                                    Func<Hashtable, bool> additionalActivateCondition = null, 
+                                                                    Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                                    Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null, 
                                                                     Func<Hashtable, bool> isOptionalFunction = null,
                                                                     bool isSkippable = false,
                                                                     int maxCountPerTurn = -1,
@@ -909,8 +909,8 @@ public partial class CardEffectFactory
 
     public static ActivateClass ActivateClass(CardSource card,
                                                 string effectName,
-                                                Func<Hashtable, bool> canUseCondition,
-                                                Func<Hashtable, bool> canActivateCondition,
+                                                Func<Hashtable, ActivateClass, bool> canUseCondition,
+                                                Func<Hashtable, ActivateClass, bool> canActivateCondition,
                                                 Func<Hashtable, ActivateClass, IEnumerator> activateCoroutine,
                                                 string effectDescription,
                                                 bool optional,
@@ -924,8 +924,8 @@ public partial class CardEffectFactory
                                                 )
     {
         ActivateClass activateClass = new ActivateClass();
-        activateClass.SetUpICardEffect(effectName, canUseCondition, card);
-        activateClass.SetUpActivateClass(canActivateCondition, hashtable => activateCoroutine(hashtable, activateClass), maxCountPerTurn, optional, effectDescription);
+        activateClass.SetUpICardEffect(effectName, hashtable => canUseCondition(hashtable, activateClass), card);
+        activateClass.SetUpActivateClass(hashtable => canActivateCondition(hashtable, activateClass), hashtable => activateCoroutine(hashtable, activateClass), maxCountPerTurn, optional, effectDescription);
         activateClass.SetHashString(hashValue);
         activateClass.SetIsSecurityEffect(isSecurityEffect);
         activateClass.SetIsOptionalOverride(isOptionalFunction);
@@ -943,8 +943,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -957,17 +957,17 @@ public partial class CardEffectFactory
             return permanent == card.PermanentOfThisCard();
         }
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
                     CardEffectCommons.CanTriggerOnMove(hashtable, PermanentCondition) && 
-                    (additionalUseCondition == null || additionalUseCondition(hashtable));
+                    (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) && 
-                (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
 
@@ -981,8 +981,8 @@ public partial class CardEffectFactory
                                             string effectDescription,
                                             bool optional,
                                             Func<Hashtable, bool> isOptionalFunction = null,
-                                            Func<Hashtable, bool> additionalUseCondition = null,
-                                            Func<Hashtable, bool> additionalActivateCondition = null,
+                                            Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                            Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                             int maxCountPerTurn = -1,
                                             string hashValue = null,
                                             bool isInherited = false,
@@ -990,17 +990,17 @@ public partial class CardEffectFactory
     {
         return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, false, isSkippable: isSkippable);
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
                 CardEffectCommons.CanTriggerOnPlay(hashtable, card) && 
-                (additionalUseCondition == null || additionalUseCondition(hashtable));
+                (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) && 
-                (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
 
@@ -1014,8 +1014,8 @@ public partial class CardEffectFactory
                                                         string effectDescription,
                                                         bool optional,
                                                         Func<Hashtable, bool> isOptionalFunction = null,
-                                                        Func<Hashtable, bool> additionalUseCondition = null,
-                                                        Func<Hashtable, bool> additionalActivateCondition = null,
+                                                        Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                        Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                         int maxCountPerTurn = -1,
                                                         string hashValue = null,
                                                         bool isInherited = false,
@@ -1024,17 +1024,17 @@ public partial class CardEffectFactory
     {
         return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
                 CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card) && 
-                (additionalUseCondition == null || additionalUseCondition(hashtable));
+                (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) && 
-                (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
 
@@ -1047,8 +1047,8 @@ public partial class CardEffectFactory
                                                     string effectDescription,
                                                     bool optional,
                                                     Func<Hashtable, bool> isOptionalFunction = null,
-                                                    Func<Hashtable, bool> additionalUseCondition = null,
-                                                    Func<Hashtable, bool> additionalActivateCondition = null,
+                                                    Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                    Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                     int maxCountPerTurn = -1,
                                                     string hashValue = null,
                                                     bool isInherited = false,
@@ -1057,17 +1057,17 @@ public partial class CardEffectFactory
     {
         return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
                 CardEffectCommons.CanTriggerOnAttack(hashtable, card) && 
-                (additionalUseCondition == null || additionalUseCondition(hashtable));
+                (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) && 
-                (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
 
@@ -1081,8 +1081,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1091,17 +1091,17 @@ public partial class CardEffectFactory
     {
         return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.CanTriggerOnDeletion(hashtable, card) && 
-                (additionalUseCondition == null || additionalUseCondition(hashtable));
+                (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return ((!(isInherited || isLinked) && CardEffectCommons.CanActivateOnDeletion(card)) 
                     || ((isInherited || isLinked) && CardEffectCommons.CanActivateOnDeletionInherited(hashtable, card)))
-                && (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                && (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
 
@@ -1115,8 +1115,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1126,17 +1126,17 @@ public partial class CardEffectFactory
     {
         return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
                 CardEffectCommons.CanTriggerWhenLinking(hashtable, null, card) &&
-                (additionalUseCondition == null || additionalUseCondition(hashtable));
+                (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
-                (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
 
@@ -1150,17 +1150,17 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 bool isSkippable = false)
     {
         ActivateClass activateClass = ActivateClass(card, effectName, CanUseCondition, additionalActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, -1, null, false, false, true, isSkippable);
         return activateClass;
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.CanTriggerSecurityEffect(hashtable, card) &&
-                (additionalUseCondition == null || additionalUseCondition(hashtable));
+                (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
     }
 
@@ -1174,8 +1174,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1184,18 +1184,18 @@ public partial class CardEffectFactory
     {
         return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card)
                 && CardEffectCommons.CanTriggerOnAttack(hashtable, card)
                 && (additionalUseCondition == null 
-                    || additionalUseCondition(hashtable));
+                    || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
-                (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
 
     }
@@ -1210,8 +1210,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1222,18 +1222,18 @@ public partial class CardEffectFactory
         activateClass.SetIsCounterEffect(true);
         return activateClass;
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card)
                 && CardEffectCommons.CanTriggerOnPermanentAttack(hashtable, permanent => CardEffectCommons.IsOpponentPermanent(permanent, card))
                 && (additionalUseCondition == null 
-                    || additionalUseCondition(hashtable));
+                    || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
-                (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
 
     }
@@ -1252,8 +1252,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1264,18 +1264,18 @@ public partial class CardEffectFactory
     {
         return ActivateClass(card, effectName, CanUseCondition, CanActivateCondition, activateCoroutine, effectDescription, optional, isOptionalFunction, maxCountPerTurn, hashValue, isInherited, isLinked, isSkippable: isSkippable);
 
-        bool CanUseCondition(Hashtable hashtable)
+        bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card)
                 && (!yourTurn || CardEffectCommons.IsOwnerTurn(card))
                 && (!opponentTurn || CardEffectCommons.IsOpponentTurn(card))
-                && (additionalUseCondition == null || additionalUseCondition(hashtable));
+                && (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
-        bool CanActivateCondition(Hashtable hashtable)
+        bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
             return CardEffectCommons.IsExistOnBattleArea(card) &&
-                (additionalActivateCondition == null || additionalActivateCondition(hashtable));
+                (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
 
     }
@@ -1290,8 +1290,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1307,8 +1307,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1324,8 +1324,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1341,8 +1341,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1362,8 +1362,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1379,8 +1379,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1396,8 +1396,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1413,8 +1413,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1434,8 +1434,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,
@@ -1451,8 +1451,8 @@ public partial class CardEffectFactory
                                                 string effectDescription,
                                                 bool optional,
                                                 Func<Hashtable, bool> isOptionalFunction = null,
-                                                Func<Hashtable, bool> additionalUseCondition = null,
-                                                Func<Hashtable, bool> additionalActivateCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalUseCondition = null,
+                                                Func<Hashtable, ActivateClass, bool> additionalActivateCondition = null,
                                                 int maxCountPerTurn = -1,
                                                 string hashValue = null,
                                                 bool isInherited = false,

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -26,7 +26,7 @@ public abstract class ICardEffect
         SetCanActivateCondition(null);
 
         SetIsOptional(false);
-        SetIsOptionalOverride(null);
+        SetIsSkippableFunction(null);
         SetUseOptional(false);
         SetIsDeclarative(false);
         SetIsInheritedEffect(false);
@@ -286,13 +286,13 @@ public abstract class ICardEffect
     #region Override IsOptional with a function
 
     Func<Hashtable, bool> _isOptionalFunction = null;
-    public bool IsOptionalCondition(Hashtable hashtable)
+    public bool IsSkippableCondition(Hashtable hashtable)
     {
         if (_isOptionalFunction != null) return _isOptionalFunction(hashtable);
         return IsOptional;
     }
 
-    public void SetIsOptionalOverride(Func<Hashtable, bool> isOptionalOverride)
+    public void SetIsSkippableFunction(Func<Hashtable, bool> isOptionalOverride)
     {
         _isOptionalFunction = isOptionalOverride;
     }
@@ -305,7 +305,7 @@ public abstract class ICardEffect
 
     public bool IsSkippable(Hashtable hashtable)
     {
-        return _isSkippable || IsOptionalCondition(hashtable);
+        return _isSkippable || IsSkippableCondition(hashtable);
     }
 
     public void SetIsSkippable(bool isSkippable)
@@ -1025,7 +1025,7 @@ public static class ActivateICardEffectExtensionClass
 
     public static IEnumerator Activate_Optional(this ActivateICardEffect activateICardEffect, Hashtable hash)
     {
-        if (((ICardEffect)activateICardEffect).IsOptionalCondition(hash))
+        if (((ICardEffect)activateICardEffect).IsOptional)
         {
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<OptionalSkill>().SelectOptional((ICardEffect)activateICardEffect, hash));
         }
@@ -1091,7 +1091,7 @@ public static class ActivateICardEffectExtensionClass
 
     public static IEnumerator Activate_Execute(this ActivateICardEffect activateICardEffect, Hashtable hash)
     {
-        if (((ICardEffect)activateICardEffect).UseOptional || !((ICardEffect)activateICardEffect).IsOptionalCondition(hash))
+        if (((ICardEffect)activateICardEffect).UseOptional || !((ICardEffect)activateICardEffect).IsOptional)
         {
             ((ICardEffect)activateICardEffect).OnProcessCallbuck?.Invoke();
             ((ICardEffect)activateICardEffect).SetOnProcessCallbuck(null);
@@ -1164,7 +1164,7 @@ public static class ActivateICardEffectExtensionClass
         {
             UnityEngine.Debug.Log($"Activate_Optional_Effect_Execute: {((ICardEffect)activateICardEffect).EffectSourceCard.BaseENGCardNameFromEntity}");
             //Optional effect activation selection
-            if (((ICardEffect)activateICardEffect).IsOptionalCondition(hash))
+            if (((ICardEffect)activateICardEffect).IsOptional)
             {
                 if (isCheckOptional)
                 {
@@ -1226,7 +1226,7 @@ public static class ActivateICardEffectExtensionClass
     public static IEnumerator Activate_Effect_Execute(this ActivateICardEffect activateICardEffect, Hashtable hash, UnityAction<ICardEffect> useEffectCallback)
     {
         //cost → effect processing
-        if (((ICardEffect)activateICardEffect).UseOptional || !((ICardEffect)activateICardEffect).IsOptionalCondition(hash))
+        if (((ICardEffect)activateICardEffect).UseOptional || !((ICardEffect)activateICardEffect).IsOptional)
         {
             useEffectCallback?.Invoke((ICardEffect)activateICardEffect);
 


### PR DESCRIPTION
Realized somewhat overdue that I should enable the sharedeffectfactory to pass through ActivateClass so we can still do things like check CanPlayPermanent in additionalUse/ActivateConditions