### PR TITLE
Update Ascension fix remove Permanent logic to fix NPE

### DIFF
--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Ascension.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Ascension.cs
@@ -50,48 +50,4 @@ public partial class CardEffectCommons
         }
     }
     #endregion
-
-    #region Target 1 Digimon gains [Ascension]
-    public static IEnumerator GainAscension(Permanent targetPermanent, EffectDuration effectDuration, ICardEffect activateClass)
-    {
-        if (targetPermanent == null) yield break;
-        if (!IsPermanentExistsOnBattleArea(targetPermanent)) yield break;
-        if (activateClass == null) yield break;
-        if (activateClass.EffectSourceCard == null) yield break;
-
-        CardSource card = activateClass.EffectSourceCard;
-
-        bool CanUseCondition()
-        {
-            if (IsPermanentExistsOnBattleArea(targetPermanent))
-            {
-                if (!targetPermanent.TopCard.CanNotBeAffected(activateClass))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        ActivateClass ascension = CardEffectFactory.AscensionEffect(
-            targetPermanent: targetPermanent,
-            isInheritedEffect: false,
-            condition: CanUseCondition,
-            rootCardEffect: activateClass,
-            card: activateClass.EffectSourceCard);
-
-        AddEffectToPermanent(
-            targetPermanent: targetPermanent,
-            effectDuration: effectDuration,
-            card: card,
-            cardEffect: ascension,
-            timing: EffectTiming.OnDestroyedAnyone);
-
-        if (!targetPermanent.TopCard.CanNotBeAffected(activateClass))
-        {
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateBuffEffect(targetPermanent));
-        }
-    }
-    #endregion
 }

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Ascension.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Ascension.cs
@@ -7,71 +7,28 @@ using UnityEngine;
 public partial class CardEffectFactory
 {
     #region Trigger effect of [Ascension] on oneself
-    public static ICardEffect AscensionSelfEffect(bool isInheritedEffect, CardSource card, Func<bool> condition)
+    public static ICardEffect AscensionSelfEffect(bool isInheritedEffect, CardSource card, Func<bool> condition, bool isLinkedEffect = false)
     {
-        Permanent targetPermanent = card.PermanentOfThisCard();
-
-        bool CanUseCondition()
-        {
-            if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
-            {
-                if (condition == null || condition())
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        return AscensionEffect(
-            targetPermanent: targetPermanent,
-            isInheritedEffect: isInheritedEffect,
-            condition: CanUseCondition,
-            rootCardEffect: null, card);
-    }
-    #endregion
-
-    #region Trigger effect of [Ascension]
-    public static ActivateClass AscensionEffect(Permanent targetPermanent, bool isInheritedEffect, Func<bool> condition, ICardEffect rootCardEffect, CardSource card)
-    {
-        if (targetPermanent == null) return null;
-        if (targetPermanent.TopCard == null) return null;
-        if (card == null) return null;
-
         ActivateClass activateClass = new ActivateClass();
         activateClass.SetUpICardEffect("Ascension", CanUseCondition, card);
         activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, DataBase.AscensionEffectDescription());
         activateClass.SetIsInheritedEffect(isInheritedEffect);
-
-        if (rootCardEffect != null)
-        {
-            activateClass.SetIsInheritedEffect(false);
-            activateClass.SetEffectSourcePermanent(targetPermanent);
-            activateClass.SetRootCardEffect(rootCardEffect);
-        }
+        activateClass.SetIsLinkedEffect(isLinkedEffect);
 
         bool CanUseCondition(Hashtable hashtable)
         {
-            if (CardEffectCommons.CanTriggerPermanentAscension(hashtable, (permanent) => permanent == targetPermanent))
-            {
-                if (condition == null || condition())
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return CardEffectCommons.CanTriggerAscension(hashtable, card)
+                && (condition == null || condition());
         }
 
         bool CanActivateCondition(Hashtable hashtable)
         {
-            return CardEffectCommons.CanActivateAscension(hashtable, targetPermanent.TopCard);
+            return CardEffectCommons.CanActivateAscension(hashtable, card);
         }
 
         IEnumerator ActivateCoroutine(Hashtable _hashtable)
         {
-            return CardEffectCommons.AscensionProcess(_hashtable, activateClass, targetPermanent.TopCard);
+            return CardEffectCommons.AscensionProcess(_hashtable, activateClass, card);
         }
 
         return activateClass;


### PR DESCRIPTION
Ascension cannot ever be a permanent effect because of being an on deletion type effect, it was experiencing a NPE when trying to refer to the permanent in the trash.
Removed all Permanent and granting logic for now, if we ever have an effect that grants Ascension it will probably have to be done through an AddSkillEffect.