### PR TITLE
Fix dual cards in hand show option colours for cost

### DIFF
--- a/Assets/Scripts/Script/CardSource.cs
+++ b/Assets/Scripts/Script/CardSource.cs
@@ -3461,6 +3461,10 @@ public class CardSource : MonoBehaviour
 
     #endregion
 
+    #region whether this card is a dual card
+    public bool IsDualCard => _cEntity_Base.IsDualCard;
+    #endregion
+
     #region Wheter this card is permanent
 
     public bool IsPermanent => _cEntity_Base.IsPermanent;

--- a/Assets/Scripts/Script/HandCard.cs
+++ b/Assets/Scripts/Script/HandCard.cs
@@ -722,16 +722,17 @@ public class HandCard : MonoBehaviour
     {
         if (CostText != null)
         {
+            List<CardColor> cardColors = cardSource.IsDualCard ? cardSource.DualCardColors : cardSource.CardColors;
             for (int i = CostIcons.Count - 1; i > -1; i--)
             {
                 CardColor cardColor = CardColor.None;
                 int value = CostIcons.Count - i - 1;
 
-                if (i >= CostIcons.Count - cardSource.CardColors.Count)
+                if (i >= CostIcons.Count - cardColors.Count)
                 {
-                    float fillAmount = (float)((CostIcons.Count - i) / (float)cardSource.CardColors.Count);
+                    float fillAmount = (float)((CostIcons.Count - i) / (float)cardColors.Count);
 
-                    cardColor = cardSource.CardColors[value];
+                    cardColor = cardColors[value];
                     CostIcons[i].color = DataBase.CardColor_ColorDarkDictionary[cardColor];
                     CostIcons[i].fillAmount = fillAmount;
                     CostIcons[i].gameObject.SetActive(true);


### PR DESCRIPTION
Tested locally, cards render fine still, but for dual cards will specifically show the colours associated with the option in the use cost circle