### PR TITLE
Fix remove link cost reduction after link

### DIFF
--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -3454,6 +3454,8 @@ public class ILinkCard
             yield return ContinuousController.instance.StartCoroutine(_permanent.AddLinkCard(_linkCard, _cardEffect));
 
         WasLinked = _permanent.LinkedCards.Contains(_linkCard);
+
+        _linkCard.Owner.UntilCalculateFixedCostEffect = new List<Func<EffectTiming, ICardEffect>>();
     }
 }
 #endregion


### PR DESCRIPTION
Fix for Tapmon and Onmon not being OPT, the cost reduction is currently not being cleared until the player plays another card