### PR TITLE
Fix playing multiple digimon and digixros/assembly

### DIFF
--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -738,23 +738,28 @@ public class PlayCardClass
 
             #endregion
 
-            #region select DigiXros
-
-            if (card.HasDigiXros && !isEvolution)
+            if (CardSources.Count == 1) //Do Digixros in this loop if playing 1 card as they will be needed to calculate cost, else will be done just before play
             {
-                yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectDigiXrosClass>().Select(card));
+
+                #region select DigiXros
+
+                if (card.HasDigiXros && !isEvolution)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectDigiXrosClass>().Select(card));
+                }
+
+                #endregion
+
+                #region select Assembly
+
+                if (card.HasAssembly && !isEvolution)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectAssemblyClass>().Select(card));
+                }
+
+                #endregion
+
             }
-
-            #endregion
-
-            #region select Assembly
-
-            if (card.HasAssembly && !isEvolution)
-            {
-                yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectAssemblyClass>().Select(card));
-            }
-
-            #endregion
 
             #region Bounce Tamer of Burst digivolution
 
@@ -1195,7 +1200,9 @@ public class PlayPermanentClass
     bool _activateETB = true;
     int[] _jogressEvoRootsFrameIDs = null;
     int _digiXrosCount = 0;
+    int _maxDigixrosCount = 0;
     int _assemblyCount = 0;
+    int _maxAssemblyCount = 0;
     bool _burstDigivolved = false;
     int[] _appFusionFrameIDs = null;
     bool _appFusion = false;
@@ -1219,14 +1226,39 @@ public class PlayPermanentClass
         {
             yield return ContinuousController.instance.StartCoroutine(card.Owner.brainStormObject.CloseBrainstrorm(card));
 
+            if (_cardSources.Count > 1) //Do Digixros in this loop if playing more than 1 card as they shouldn't be paying cost and can then correctly work for each card being played
+            {
+
+                #region select DigiXros
+
+                if (card.HasDigiXros && !isEvolution)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectDigiXrosClass>().Select(card));
+                }
+
+                #endregion
+
+                #region select Assembly
+
+                if (card.HasAssembly && !isEvolution)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectAssemblyClass>().Select(card));
+                }
+
+                #endregion
+
+            }
+
             if (GManager.instance.GetComponent<SelectDigiXrosClass>().playCard == card)
             {
                 _digiXrosCount = GManager.instance.GetComponent<SelectDigiXrosClass>().selectedDigicrossCards.Count;
+                _maxDigixrosCount = Math.Max(_digiXrosCount, _maxDigixrosCount);
             }
 
             if (GManager.instance.GetComponent<SelectAssemblyClass>().playCard == card)
             {
                 _assemblyCount = GManager.instance.GetComponent<SelectAssemblyClass>().selectedAssemblyCards.Count;
+                _maxAssemblyCount = Math.Max(_assemblyCount, _maxAssemblyCount);
             }
 
             bool isFromDigimonDigivolutionCards = card.Owner.GetFieldPermanents().Some((permanent) => permanent.DigivolutionCards.Contains(card));

--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -745,6 +745,7 @@ public class PlayCardClass
 
                 if (card.HasDigiXros && !isEvolution)
                 {
+                    GManager.instance.GetComponent<SelectDigiXrosClass>().SetExcludedCards(CardSources);
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectDigiXrosClass>().Select(card));
                 }
 
@@ -754,6 +755,7 @@ public class PlayCardClass
 
                 if (card.HasAssembly && !isEvolution)
                 {
+                    GManager.instance.GetComponent<SelectAssemblyClass>().SetExcludedCards(CardSources);
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectAssemblyClass>().Select(card));
                 }
 
@@ -1233,6 +1235,7 @@ public class PlayPermanentClass
 
                 if (card.HasDigiXros && !isEvolution)
                 {
+                    GManager.instance.GetComponent<SelectDigiXrosClass>().SetExcludedCards(_cardSources);
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectDigiXrosClass>().Select(card));
                 }
 
@@ -1242,6 +1245,7 @@ public class PlayPermanentClass
 
                 if (card.HasAssembly && !isEvolution)
                 {
+                    GManager.instance.GetComponent<SelectAssemblyClass>().SetExcludedCards(_cardSources);
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<SelectAssemblyClass>().Select(card));
                 }
 

--- a/Assets/Scripts/Script/SelectAssemblyClass.cs
+++ b/Assets/Scripts/Script/SelectAssemblyClass.cs
@@ -11,6 +11,7 @@ public class SelectAssemblyClass : MonoBehaviourPunCallbacks
 {
     public List<CardSource> selectedAssemblyCards { get; private set; } = new List<CardSource>();
     public List<AddDigivolutionCardsInfo> addDigivolutionCardInfos { get; private set; } = new List<AddDigivolutionCardsInfo>();
+    public List<CardSource> excludedCards { get; private set; } = new List<CardSource>();
     public CardSource playCard { get; private set; } = null;
 
     public void ResetSelectAssemblyClass()
@@ -23,6 +24,11 @@ public class SelectAssemblyClass : MonoBehaviourPunCallbacks
     public void AddDigivolutionCardInfos(AddDigivolutionCardsInfo digivolutionCardsInfo)
     {
         addDigivolutionCardInfos.Add(digivolutionCardsInfo);
+    }
+
+    public void SetExcludedCards(List<CardSource> excluded)
+    {
+        excludedCards = excluded;
     }
 
     #region Is Trash Card
@@ -43,6 +49,9 @@ public class SelectAssemblyClass : MonoBehaviourPunCallbacks
     #region Can Select Assembly
     bool CanSelectAssembly(AssemblyConditionElement element, CardSource targetCard, CardSource card)
     {
+        if (excludedCards.Contains(targetCard))
+            return false;
+
         if (card != targetCard)
         {
             if (card != null)

--- a/Assets/Scripts/Script/SelectDigiXrosClass.cs
+++ b/Assets/Scripts/Script/SelectDigiXrosClass.cs
@@ -11,6 +11,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 {
     public List<CardSource> selectedDigicrossCards { get; private set; } = new List<CardSource>();
     public List<AddDigivolutionCardsInfo> addDigivolutionCardInfos { get; private set; } = new List<AddDigivolutionCardsInfo>();
+    public List<CardSource> excludedCards { get; private set; } = new List<CardSource>();
     public CardSource playCard { get; private set; } = null;
 
     public void ResetSelectDigiXrosClass()
@@ -23,6 +24,11 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
     public void AddDigivolutionCardInfos(AddDigivolutionCardsInfo digivolutionCardsInfo)
     {
         addDigivolutionCardInfos.Add(digivolutionCardsInfo);
+    }
+
+    public void SetExcludedCards(List<CardSource> excluded)
+    {
+        excludedCards = excluded;
     }
 
     #region Max Trash Count
@@ -300,6 +306,9 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
     #region Can Select DigiXros
     bool CanSelectDigiXros(DigiXrosConditionElement element, CardSource targetCard, CardSource card)
     {
+        if (excludedCards.Contains(targetCard))
+            return false;
+            
         if (card != targetCard)
         {
             if (card != null)


### PR DESCRIPTION
Been able to test that single Digixros still works correctly, Assembly should be the exact same then.
Need a deck for testing playing multiple at once.

Works off the principle that no effect that plays multiple digimon at once makes you pay for them, so in those scenarios it is safe to move the digixros/assembly to after when costs are paid, in this case immediately before playing each individual card.