### PR TITLE
Add methods for tracking that a Permanent is the same permanent between when it triggers and activates

### DIFF
--- a/Assets/Scripts/CardEffect/BT15/Black/BT15_066.cs
+++ b/Assets/Scripts/CardEffect/BT15/Black/BT15_066.cs
@@ -46,10 +46,7 @@ namespace DCGO.CardEffects.BT15
 
             #region Shared OP/WA
 
-            string SharedEffectName()
-            {
-                return "De-Digivolve 2 on 1 Digimon.";
-            }
+            string SharedEffectName = "De-Digivolve 2 on 1 Digimon.";
 
             string SharedEffectDescription(string tag)
             {
@@ -99,41 +96,14 @@ namespace DCGO.CardEffects.BT15
                 }
             }
 
-            #endregion
-
-            #region On Play
-
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition, (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card)
-                        && CardEffectCommons.IsExistOnBattleArea(card);
-                }
-            }
-
-            #endregion
-
-            #region When Attacking
-
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass(SharedCanActivateCondition, (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Attacking"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnAttack(hashtable, card)
-                        && CardEffectCommons.IsExistOnBattleArea(card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects
+                (ref cardEffects, timing, card,
+                    SharedEffectName,
+                    SharedActivateCoroutine,
+                    SharedEffectDescription,
+                    optional: false,
+                    onPlay: true,
+                    whenAttacking: true);
 
             #endregion
           
@@ -177,25 +147,13 @@ namespace DCGO.CardEffects.BT15
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.IsExistOnBattleArea(card))
-                    {
-                        if (CardEffectCommons.IsOpponentTurn(card))
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.IsOpponentTurn(card);
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.IsExistOnBattleArea(card))
-                    {
-                        return true;
-                    }
-
-                    return false;
+                    return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT23/Red/BT23_078.cs
+++ b/Assets/Scripts/CardEffect/BT23/Red/BT23_078.cs
@@ -36,13 +36,13 @@ namespace DCGO.CardEffects.BT23
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnBattleArea(card)
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, IsValidDigimon) || CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, IsValidDigimon);
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnBattleArea(card)
+                    return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card);
                 }
 

--- a/Assets/Scripts/CardEffect/EX10/Black/EX10_035.cs
+++ b/Assets/Scripts/CardEffect/EX10/Black/EX10_035.cs
@@ -213,6 +213,11 @@ namespace DCGO.CardEffects.EX10
 
             #region On Play/When Attacking Shared
 
+            string SharedEffectName = "De-digivolve 2, 2 digimon";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] <De-Digivolve 2> 2 of your opponent's Digimon. (Trash up to 2 cards from the top. You can't trash past level 3 cards.)";
+
             bool CanSelectPermanentCondition(Permanent permanent)
             {
                 return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
@@ -291,51 +296,14 @@ namespace DCGO.CardEffects.EX10
                 }
             }
 
-            #endregion
-
-            #region On Play
-
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("De-digivolve 2, 2 digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateSharedCondition, (hashtable) => SharedActivateCoroutine(hashtable, activateClass), -1, false, EffectDescription());
-                cardEffects.Add(activateClass);
-
-                string EffectDescription()
-                {
-                    return "[On Play] <De-Digivolve 2> 2 of your opponent's Digimon. (Trash up to 2 cards from the top. You can't trash past level 3 cards.)";
-                }
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleArea(card)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
-            }
-
-            #endregion
-
-            #region When Attacking
-
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("De-digivolve 2, 2 digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateSharedCondition, (hashtable) => SharedActivateCoroutine(hashtable, activateClass), -1, false, EffectDescription());
-                cardEffects.Add(activateClass);
-
-                string EffectDescription()
-                {
-                    return "[When Attacking] <De-Digivolve 2> 2 of your opponent's Digimon. (Trash up to 2 cards from the top. You can't trash past level 3 cards.)";
-                }
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleArea(card)
-                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-                }
-            }
+            CardEffectFactory.ActivateClassesForSharedEffects
+                (ref cardEffects, timing, card,
+                    SharedEffectName,
+                    SharedActivateCoroutine,
+                    SharedEffectDescription,
+                    optional: false,
+                    onPlay: true,
+                    whenAttacking: true);
 
             #endregion
 

--- a/Assets/Scripts/Script/CardEffectCommons/GameContextDeterminarion.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GameContextDeterminarion.cs
@@ -4,6 +4,100 @@ using System.Linq;
 
 public partial class CardEffectCommons
 {
+    public static Dictionary<ICardEffect, Permanent> CardPermanenceMap = new Dictionary<ICardEffect, Permanent>();
+
+    #region Trigger conditions - Capture current Permanent for card
+
+    public static bool IsExistOnFieldTrigger(CardSource card, ICardEffect cardEffect)
+    {
+        bool exists = IsExistOnField(card);
+        if (exists)
+            CardPermanenceMap[cardEffect] = card.PermanentOfThisCard();
+        return exists;
+    }
+
+    public static bool IsExistOnBreedingAreaTrigger(CardSource card, ICardEffect cardEffect)
+    {
+        bool exists = IsExistOnBreedingArea(card);
+        if (exists)
+            CardPermanenceMap[cardEffect] = card.PermanentOfThisCard();
+        return exists;
+    }
+
+    public static bool IsExistOnBattleAreaTrigger(CardSource card, ICardEffect cardEffect)
+    {
+        bool exists = IsExistOnBattleArea(card);
+        if (exists)
+            CardPermanenceMap[cardEffect] = card.PermanentOfThisCard();
+        return exists;
+    }
+
+    public static bool IsExistOnBattleAreaDigimonTrigger(CardSource card, ICardEffect cardEffect)
+    {
+        bool exists = IsExistOnBattleAreaDigimon(card);
+        if (exists)
+            CardPermanenceMap[cardEffect] = card.PermanentOfThisCard();
+        return exists;
+    }
+
+    public static bool IsExistDigivolutionCardsTrigger(CardSource card, ICardEffect cardEffect)
+    {
+        bool exists = IsExistDigivolutionCards(card);
+        if (exists)
+            CardPermanenceMap[cardEffect] = card.PermanentOfThisCard();
+        return exists;
+    }
+
+    public static bool IsExistLinkedTrigger(CardSource card, ICardEffect cardEffect)
+    {
+        bool exists = IsExistLinked(card);
+        if (exists)
+            CardPermanenceMap[cardEffect] = card.PermanentOfThisCard();
+        return exists;
+    }
+
+    #endregion
+
+    #region Activate conditions - Check card is still part of the same Permanent
+
+    public static bool IsExistOnFieldActivate(CardSource card, ICardEffect cardEffect)
+    {
+        Permanent permanent = null;
+        return IsExistOnField(card) && CardPermanenceMap.TryGetValue(cardEffect, out permanent) && permanent == card.PermanentOfThisCard();
+    }
+
+    public static bool IsExistOnBreedingAreaActivate(CardSource card, ICardEffect cardEffect)
+    {
+        Permanent permanent = null;
+        return IsExistOnBreedingArea(card) && CardPermanenceMap.TryGetValue(cardEffect, out permanent) && permanent == card.PermanentOfThisCard();
+    }
+
+    public static bool IsExistOnBattleAreaActivate(CardSource card, ICardEffect cardEffect)
+    {
+        Permanent permanent = null;
+        return IsExistOnBattleArea(card) && CardPermanenceMap.TryGetValue(cardEffect, out permanent) && permanent == card.PermanentOfThisCard();
+    }
+
+    public static bool IsExistOnBattleAreaDigimonActivate(CardSource card, ICardEffect cardEffect)
+    {
+        Permanent permanent = null;
+        return IsExistOnBattleAreaDigimon(card) && CardPermanenceMap.TryGetValue(cardEffect, out permanent) && permanent == card.PermanentOfThisCard();
+    }
+
+    public static bool IsExistDigivolutionCardsActivate(CardSource card, ICardEffect cardEffect)
+    {
+        Permanent permanent = null;
+        return IsExistDigivolutionCards(card) && CardPermanenceMap.TryGetValue(cardEffect, out permanent) && permanent == card.PermanentOfThisCard();
+    }
+
+    public static bool IsExistLinkedActivate(CardSource card, ICardEffect cardEffect)
+    {
+        Permanent permanent = null;
+        return IsExistLinked(card) && CardPermanenceMap.TryGetValue(cardEffect, out permanent) && permanent == card.PermanentOfThisCard();
+    }
+
+    #endregion
+
     #region Whether the card is in the field
 
     public static bool IsExistOnField(CardSource card)

--- a/Assets/Scripts/Script/CardEffectFactory.cs
+++ b/Assets/Scripts/Script/CardEffectFactory.cs
@@ -959,14 +959,14 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass) &&
                     CardEffectCommons.CanTriggerOnMove(hashtable, PermanentCondition) && 
                     (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) && 
+            return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass) && 
                 (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
@@ -992,14 +992,14 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass) &&
                 CardEffectCommons.CanTriggerOnPlay(hashtable, card) && 
                 (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) && 
+            return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass) && 
                 (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
@@ -1026,14 +1026,14 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass) &&
                 CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card) && 
                 (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) && 
+            return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass) && 
                 (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
@@ -1059,14 +1059,14 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass) &&
                 CardEffectCommons.CanTriggerOnAttack(hashtable, card) && 
                 (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) && 
+            return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass) && 
                 (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
@@ -1127,14 +1127,14 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaDigimonTrigger(card, activateClass) &&
                 CardEffectCommons.CanTriggerWhenLinking(hashtable, null, card) &&
                 (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
         }
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaDigimonActivate(card, activateClass) &&
                 (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
     }
@@ -1185,7 +1185,7 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card)
+            return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                 && CardEffectCommons.CanTriggerOnAttack(hashtable, card)
                 && (additionalUseCondition == null 
                     || additionalUseCondition(hashtable, activateClass));
@@ -1193,7 +1193,7 @@ public partial class CardEffectFactory
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass) &&
                 (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
 
@@ -1223,7 +1223,7 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card)
+            return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                 && CardEffectCommons.CanTriggerOnPermanentAttack(hashtable, permanent => CardEffectCommons.IsOpponentPermanent(permanent, card))
                 && (additionalUseCondition == null 
                     || additionalUseCondition(hashtable, activateClass));
@@ -1231,7 +1231,7 @@ public partial class CardEffectFactory
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass) &&
                 (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
 
@@ -1265,7 +1265,7 @@ public partial class CardEffectFactory
 
         bool CanUseCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card)
+            return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                 && (!yourTurn || CardEffectCommons.IsOwnerTurn(card))
                 && (!opponentTurn || CardEffectCommons.IsOpponentTurn(card))
                 && (additionalUseCondition == null || additionalUseCondition(hashtable, activateClass));
@@ -1273,7 +1273,7 @@ public partial class CardEffectFactory
 
         bool CanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
         {
-            return CardEffectCommons.IsExistOnBattleArea(card) &&
+            return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass) &&
                 (additionalActivateCondition == null || additionalActivateCondition(hashtable, activateClass));
         }
 

--- a/Assets/Scripts/Script/TurnStateMachine.cs
+++ b/Assets/Scripts/Script/TurnStateMachine.cs
@@ -1397,6 +1397,7 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
             UseCardEffect = null;
             AttackingPermanent = null;
             DefendingPermanent = null;
+            CardEffectCommons.CardPermanenceMap = new Dictionary<ICardEffect, Permanent>();
         }
         #endregion
     }
@@ -3287,6 +3288,8 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
 
         #region Reset status until end of turn
         GManager.instance.attackProcess.AttackCount = 0;
+
+        CardEffectCommons.CardPermanenceMap = new Dictionary<ICardEffect, Permanent>();
 
         foreach (Player player in gameContext.Players)
         {


### PR DESCRIPTION
Aim is to ensure if for example an On Play is triggered, that Digimon is deleted and played again before the On Play can activate, the original On Play should not be able to activate because the Digimon is not the same one that triggered the effect