### PR TITLE
Fix treating tamer turned digimon as still not having DP

### DIFF
--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -4485,7 +4485,7 @@ public class IBattle
     {
         hashtable = new Hashtable();
 
-        if (AttackingPermanent != null && AttackingPermanent.TopCard.HasDP)
+        if (AttackingPermanent != null && AttackingPermanent.HasDP)
         {
             bool IsExistingDefender()
             {
@@ -4496,7 +4496,7 @@ public class IBattle
                     {
                         if (DefendingPermanent.TopCard != null)
                         {
-                            return DefendingPermanent.TopCard.HasDP;
+                            return DefendingPermanent.HasDP;
                         }
                     }
                     else if (DefendingCard != null)


### PR DESCRIPTION
Because it was checking the card instead of the permanent it was treating tamers as having no dp even when they had been turned into digimon.