### PR TITLE
Implement timestamping for ability ordering

### DIFF
--- a/Assets/Scripts/CardEffect/BT25/Red/BT25_104.cs
+++ b/Assets/Scripts/CardEffect/BT25/Red/BT25_104.cs
@@ -215,6 +215,7 @@ namespace DCGO.CardEffects.BT25
                     isInheritedEffect: false, 
                     card: card, 
                     condition: MakeDigimonCondition);
+                changeBaseDPClass.SetActivatedTime(card.Owner.TurnStartTime, card.ChangedLocationTime);
 
                 cardEffects.Add(changeBaseDPClass);
                 #endregion

--- a/Assets/Scripts/CardEffect/BT3/Red/BT3_014.cs
+++ b/Assets/Scripts/CardEffect/BT3/Red/BT3_014.cs
@@ -96,6 +96,7 @@ public class BT3_014 : CEntity_Effect
                                     ChangeBaseDPClass changeDPClass = new ChangeBaseDPClass();
                                     changeDPClass.SetUpICardEffect("Origin DP is 1000", CanUseCondition1, card);
                                     changeDPClass.SetUpChangeBaseDPClass(changeDPFunc: ChangeDP, permanentCondition: permanentCondition, isUpDownFunc: _isUpDown, isMinusDPFunc: () => false);
+                                    changeDPClass.SetActivatedTime(DateTime.Now);
                                     selectedPermanent.UntilEachTurnEndEffects.Add((_timing) => changeDPClass);
 
                                     if (!selectedPermanent.TopCard.CanNotBeAffected(activateClass))

--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -4894,6 +4894,8 @@ public class IDegeneration
                 _permanent.ShowingPermanentCard.ShowPermanentData(true);
                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().RemoveDigivolveRootEffect(cardSource, _permanent));
 
+                _permanent.TopCard.SetChangedLocationTime();//register that the new topcard just became a top card for the purpose of the start of timestamped continuous effects
+
                 count++;
             }
 
@@ -5068,6 +5070,8 @@ public class IMassDegeneration
 
                     _permanent.ShowingPermanentCard.ShowPermanentData(true);
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().RemoveDigivolveRootEffect(cardSource, _permanent));
+
+                    _permanent.TopCard.SetChangedLocationTime();//register that the new topcard just became a top card for the purpose of the start of timestamped continuous effects
 
                     count++;
                 }
@@ -5932,6 +5936,8 @@ public class ITrashStack
 
                 _permanent.ShowingPermanentCard.ShowPermanentData(true);
                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().RemoveDigivolveRootEffect(cardSource, _permanent));
+
+                _permanent.TopCard.SetChangedLocationTime();//register that the new topcard just became a top card for the purpose of the start of timestamped continuous effects
 
                 count++;
             }

--- a/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/ChangeOriginDP.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/ChangeOriginDP.cs
@@ -33,6 +33,8 @@ public partial class CardEffectCommons
 
         ChangeBaseDPClass changeBaseDPClass = CardEffectFactory.ChangeBaseDPStaticEffect(targetPermanent: targetPermanent, changeValue: changeValue, isInheritedEffect: false, card: card, condition: CanUseCondition);
 
+        changeBaseDPClass.SetActivatedTime(DateTime.Now);
+
         AddEffectToPermanent(targetPermanent: targetPermanent, effectDuration: effectDuration, card: card, cardEffect: changeBaseDPClass, timing: EffectTiming.None);
 
         if (!targetPermanent.TopCard.CanNotBeAffected(activateClass))

--- a/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/TamerBecomesDigimonThatCanNotDigivolve.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GiveEffect/GiveEffectToPermanent/TamerBecomesDigimonThatCanNotDigivolve.cs
@@ -45,6 +45,7 @@ public partial class CardEffectCommons
             isInheritedEffect: false, 
             card: card, 
             condition: CanUseCondition);
+        changeBaseDPClass.SetActivatedTime(DateTime.Now);
 
         AddEffectToPermanent(
             targetPermanent: targetPermanent, 

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/ArmorPurge.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/ArmorPurge.cs
@@ -64,6 +64,8 @@ public partial class CardEffectCommons
 
                         _permanent.HideDeleteEffect();
 
+                        _permanent.TopCard.SetChangedLocationTime();//register that the new topcard just became a top card for the purpose of the start of timestamped continuous effects
+
                         #region "When Top Card is Trashed" effect
                         #region Hashtable Setting
                         System.Collections.Hashtable hashtable = new System.Collections.Hashtable()

--- a/Assets/Scripts/Script/CardSource.cs
+++ b/Assets/Scripts/Script/CardSource.cs
@@ -117,6 +117,23 @@ public class CardSource : MonoBehaviour
 
     #endregion
 
+    #region Timestamp of the last time this card changed location, for continuous effects. This should include becoming a top card via de-digivolve or no longer being a top card due to digivolution
+
+    DateTime _changedLocationTime = DateTime.MinValue;
+
+    public DateTime ChangedLocationTime
+    {
+        get { return _changedLocationTime; }
+        private set { _changedLocationTime = value; }
+    }
+
+    public void SetChangedLocationTime()
+    {
+        ChangedLocationTime = DateTime.Now;
+    }
+
+    #endregion
+
     #region whether this card can be played
 
     public bool CanPlayFromHandDuringMainPhase
@@ -329,6 +346,7 @@ public class CardSource : MonoBehaviour
     {
         cEntity_EffectController.InitUseCountThisTurn();
         SetFace();
+        SetChangedLocationTime();
     }
 
     #endregion

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -698,6 +698,31 @@ public abstract class ICardEffect
 
     #endregion
 
+    #region When this effect was activated for comparison
+
+    DateTime _activatedTime = DateTime.MinValue;
+
+    public DateTime ActivatedTime
+    {
+        get { return _activatedTime; }
+        private set { _activatedTime = value; }
+    }
+
+    public void SetActivatedTime(params DateTime[] activationTimes)
+    {
+        if (activationTimes.Length > 0)
+        {
+            DateTime latest = activationTimes[0];
+            foreach (DateTime time in activationTimes)
+            {
+                if (time > latest) latest = time;
+            }
+            _activatedTime = latest;
+        }
+    }
+
+    #endregion
+
     #endregion
 
     #region Read only bool properties

--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -298,7 +298,7 @@ public class Permanent
                     }
                 }
 
-                foreach (ICardEffect cardEffect in cardEffects_ChangeDP_NotIsUpDown)
+                foreach (ICardEffect cardEffect in cardEffects_ChangeDP_NotIsUpDown.OrderBy(cardEffect => cardEffect.ActivatedTime))
                 {
                     if (cardEffect is IChangeBaseDPEffect)
                     {
@@ -469,7 +469,7 @@ public class Permanent
             
             DP += LinkedDP;
 
-            foreach (ICardEffect cardEffect in cardEffects_ChangeDP_NotIsUpDown)
+            foreach (ICardEffect cardEffect in cardEffects_ChangeDP_NotIsUpDown.OrderBy(cardEffect => cardEffect.ActivatedTime))
             {
                 if (cardEffect is IChangeDPEffect)
                 {

--- a/Assets/Scripts/Script/Player.cs
+++ b/Assets/Scripts/Script/Player.cs
@@ -948,6 +948,23 @@ public class Player : MonoBehaviour
 
     #endregion
 
+    #region Timestamp of the last time the player's turn started, for continuous effects.
+
+    DateTime _turnStartTime = DateTime.MinValue;
+
+    public DateTime TurnStartTime
+    {
+        get { return _turnStartTime; }
+        private set { _turnStartTime = value; }
+    }
+
+    public void SetTurnStartTime()
+    {
+        TurnStartTime = DateTime.Now;
+    }
+
+    #endregion
+
     #region トラッシュのカードオブジェクト
     public HandCard TrashHandCard;
     #endregion

--- a/Assets/Scripts/Script/TurnStateMachine.cs
+++ b/Assets/Scripts/Script/TurnStateMachine.cs
@@ -529,6 +529,8 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
     #region Active Phase
     IEnumerator ActivePhase()
     {
+        gameContext.TurnPlayer.SetTurnStartTime();
+
         foreach (Permanent permanent in gameContext.TurnPlayer.GetFieldPermanents())
         {
             permanent.UntilOwnerTurnStartEffects = new List<Func<EffectTiming, ICardEffect>>();


### PR DESCRIPTION
In order to ensure the correct DP is applied when multiple effects occur, changes to base DP need to be timestamped so they are ordered last to most recent, leaving the most recent as the one that applies. In order to do that for continuous effects, I also need to capture when the card with that effect changes location and when the turn starts, as the most recent of those is the timestamp of when the effect activated.

Other effects could be timestamped, but most don't need to be.

Tested this myself:
BT12 Marcus start of main phase, was 3k
Digivolved up to Burst mode, the marcus was now 12k
Activated effect of AD1 Marcus, targetting BT12 marcus again, was now 6k
following turn, it was 12K
Start of main used effect to become digimon and set to 3k, was correctly 3k
At all times had correct most recent DP