### PR TITLE
Fixed Select DNA Condition by Effect Causing Desync

### DIFF
--- a/Assets/Scripts/Script/SelectDNACondition.cs
+++ b/Assets/Scripts/Script/SelectDNACondition.cs
@@ -11,14 +11,16 @@ public class SelectDNACondition : MonoBehaviourPunCallbacks
     public void SetUp
         (Player SelectPlayer,
         CardSource targetDNA,
-        Func<int, IEnumerator> SelectDNACoroutine)
+        Func<int, IEnumerator> SelectDNACoroutine,
+        bool IsLocal = false)
     {
         _selectPlayer = SelectPlayer;
         _targetDNA = targetDNA;
         _selectDNACoroutine = SelectDNACoroutine;
         _notDoSync = false;
         _isDigivolutionCost = false;
-    }
+        _isLocal = IsLocal;
+}
 
     Player _selectPlayer = null;
     CardSource _targetDNA = null;
@@ -27,6 +29,7 @@ public class SelectDNACondition : MonoBehaviourPunCallbacks
     public int _selectedCount = 0;
     bool _notDoSync = false;
     bool _isDigivolutionCost = false;
+    bool _isLocal = false;
 
     public void ResetSelectDNAConditionClass()
     {
@@ -68,7 +71,7 @@ public class SelectDNACondition : MonoBehaviourPunCallbacks
                 string selectPlayerMessage = "Which DNA do you want?";
                 string notSelectPlayerMessage = "The opponent is choosing from which DNA to do.";
 
-                GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: _targetDNA.Owner, selectPlayerMessage: selectPlayerMessage, notSelectPlayerMessage: notSelectPlayerMessage);
+                GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: _targetDNA.Owner, selectPlayerMessage: selectPlayerMessage, notSelectPlayerMessage: notSelectPlayerMessage, _isLocal);
 
                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
 

--- a/Assets/Scripts/Script/SelectJogressEffect.cs
+++ b/Assets/Scripts/Script/SelectJogressEffect.cs
@@ -187,7 +187,7 @@ public class SelectJogressEffect : MonoBehaviour
             {
                 #region select DNA condition
                 SelectDNACondition selectDNACondition = GManager.instance.GetComponent<SelectDNACondition>();
-                selectDNACondition.SetUp(_card.Owner, _card, SelectDNA);
+                selectDNACondition.SetUp(_card.Owner, _card, SelectDNA, _isLocal);
 
                 yield return ContinuousController.instance.StartCoroutine(selectDNACondition.Activate());
 

--- a/Assets/Scripts/Script/UserSelectionManager.cs
+++ b/Assets/Scripts/Script/UserSelectionManager.cs
@@ -9,6 +9,7 @@ public class UserSelectionManager : MonoBehaviourPunCallbacks
 {
     bool _endSelect = false;
     int _selectedIntValue = 0;
+    bool _isLocal = false;
     bool _selectedBoolValue => getBoolFromInt(_selectedIntValue);
     public int SelectedIntValue => _selectedIntValue;
     public bool SelectedBoolValue => _selectedBoolValue;
@@ -98,11 +99,12 @@ public class UserSelectionManager : MonoBehaviourPunCallbacks
         yield return new WaitWhile(() => GManager.instance.commandText.gameObject.activeSelf);
     }
 
-    public void SetIntSelection(List<SelectionElement<int>> selectionElements, Player selectPlayer, string selectPlayerMessage, string notSelectPlayerMessage)
+    public void SetIntSelection(List<SelectionElement<int>> selectionElements, Player selectPlayer, string selectPlayerMessage, string notSelectPlayerMessage, bool IsLocal = false)
     {
         _endSelect = false;
         _selectedIntValue = 0;
         _selectPlayer = selectPlayer;
+        _isLocal = IsLocal;
 
         if (selectPlayer.isYou)
         {
@@ -112,7 +114,7 @@ public class UserSelectionManager : MonoBehaviourPunCallbacks
 
             foreach (SelectionElement<int> selectionElement in selectionElements)
             {
-                command_SelectCommands.Add(new Command_SelectCommand(selectionElement.Message, () => SetInt_RPC(selectPlayer.PlayerID, selectionElement.Value), selectionElement.SpriteIndex));
+                command_SelectCommands.Add(new Command_SelectCommand(selectionElement.Message, () => SendSelection(selectionElement.Value), selectionElement.SpriteIndex));
             }
 
             GManager.instance.selectCommandPanel.SetUpCommandButton(command_SelectCommands);
@@ -132,25 +134,31 @@ public class UserSelectionManager : MonoBehaviourPunCallbacks
                     canSelectValue.Add(selectionElement.Value);
                 }
 
-                if (canSelectValue.Count >= 1)
-                {
-                    SetInt_RPC(selectPlayer.PlayerID, canSelectValue[UnityEngine.Random.Range(0, canSelectValue.Count)]);
-                }
-
-                else
-                {
-                    SetInt_RPC(selectPlayer.PlayerID, 0);
-                }
+                int value = canSelectValue.Count >= 1 ? canSelectValue[UnityEngine.Random.Range(0, canSelectValue.Count)] : 0;
+                SendSelection(value);
             }
             #endregion
         }
+
+        void SendSelection(int value)
+        {
+            if (_isLocal)
+            {
+                SetIntForPlayer(selectPlayer.PlayerID, value);
+            }
+            else
+            {
+                SetInt_RPC(selectPlayer.PlayerID, value);
+            }
+        }
     }
 
-    public void SetBoolSelection(List<SelectionElement<bool>> selectionElements, Player selectPlayer, string selectPlayerMessage, string notSelectPlayerMessage)
+    public void SetBoolSelection(List<SelectionElement<bool>> selectionElements, Player selectPlayer, string selectPlayerMessage, string notSelectPlayerMessage, bool IsLocal = false)
     {
         _endSelect = false;
         _selectedIntValue = 0;
         _selectPlayer = selectPlayer;
+        _isLocal = IsLocal;
 
         if (selectPlayer.isYou)
         {
@@ -160,7 +168,7 @@ public class UserSelectionManager : MonoBehaviourPunCallbacks
 
             foreach (SelectionElement<bool> selectionElement in selectionElements)
             {
-                command_SelectCommands.Add(new Command_SelectCommand(selectionElement.Message, () => SetBool_RPC(selectPlayer.PlayerID, selectionElement.Value), selectionElement.SpriteIndex));
+                command_SelectCommands.Add(new Command_SelectCommand(selectionElement.Message, () => SendSelection(selectionElement.Value), selectionElement.SpriteIndex));
             }
 
             GManager.instance.selectCommandPanel.SetUpCommandButton(command_SelectCommands);
@@ -180,17 +188,22 @@ public class UserSelectionManager : MonoBehaviourPunCallbacks
                     canSelectValue.Add(selectionElement.Value);
                 }
 
-                if (canSelectValue.Count >= 1)
-                {
-                    SetBool_RPC(selectPlayer.PlayerID, canSelectValue[UnityEngine.Random.Range(0, canSelectValue.Count)]);
-                }
-
-                else
-                {
-                    SetBool_RPC(selectPlayer.PlayerID, false);
-                }
+                bool value = canSelectValue.Count >= 1 ? canSelectValue[UnityEngine.Random.Range(0, canSelectValue.Count)] : false;
+                SendSelection(value);
             }
             #endregion
+        }
+
+        void SendSelection(bool value)
+        {
+            if (_isLocal)
+            {
+                SetBoolForPlayer(selectPlayer.PlayerID, value);
+            }
+            else
+            {
+                SetBool_RPC(selectPlayer.PlayerID, value);
+            }
         }
     }
 }


### PR DESCRIPTION
Another situation where a local selection is happening but the selection player is sending data they shouldn't. This honestly doesn't need to be a local selection and I'm temped clean some of this code up and make it not, but technical we send less data this way.