### PR TITLE
Do not prevent inherited on deletions from activating

### DIFF
--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -388,7 +388,7 @@ public abstract class ICardEffect
         {
             if (EffectSourceCard != null)
             {
-                if (EffectSourceCard.PermanentOfThisCard() != null)
+                if (EffectSourceCard.PermanentOfThisCard() != null && !IsOnDeletion)
                 {
                     if (IsInheritedEffect || IsLinkedEffect)
                     {


### PR DESCRIPTION
I believe this is the culprit for inherited on deletions not able to activate if they go back to the field. In that case PermanentofThisCard is not null, so they fail these checks. None of these checks make sense for an OnDeletion, so skipping them, and the on deletions own can activate condition will check the topcard is still in the right place.