### PR TITLE
Update BT24_023.cs

### DIFF
--- a/Assets/Scripts/CardEffect/BT24/Blue/BT24_023.cs
+++ b/Assets/Scripts/CardEffect/BT24/Blue/BT24_023.cs
@@ -136,13 +136,23 @@ namespace DCGO.CardEffects.BT24
                             yield return null;
                         }
 
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.GainCanNotSuspendPlayerEffect(
-                                permanentCondition: (permanent) => permanent == selectedPermanent,
-                                effectDuration: EffectDuration.UntilOpponentTurnEnd,
-                                activateClass: activateClass,
-                                isOnlyActivePhase: false,
-                                effectName: "Can't Suspend"
-                            ));
+                        if (selectedPermanent != null)
+                        {
+                            CanNotSuspendClass canNotSuspendClass = new CanNotSuspendClass();
+                            canNotSuspendClass.SetUpICardEffect("Can't Suspend", CanUseCondition1, card);
+                            canNotSuspendClass.SetUpCanNotSuspendClass(PermanentCondition: PermanentCondition);
+                            selectedPermanent.UntilOwnerTurnEndEffects.Add((_timing) => canNotSuspendClass);
+
+                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateDebuffEffect(selectedPermanent));
+
+                            bool CanUseCondition1(Hashtable hashtable)
+                            {
+                                return selectedPermanent.TopCard != null
+                                    && !selectedPermanent.TopCard.CanNotBeAffected(activateClass);
+                            }
+
+                            bool PermanentCondition(Permanent permanent) => permanent == selectedPermanent;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Hello! This is my first time contributing to this project, and I'm just getting to know the codebase. 

### Bug 
I found a bug with Calmaramon (`BT24_023`) where the "can't suspend" effect was not applying to opponent's Tamers when played by effects.


I updated `BT24_023.cs` to apply the `CanNotSuspendClass` effect directly onto the selected permanent's `UntilOwnerTurnEndEffects` instead of the player. This is the same logic as i saw used for cards like Whamon (`BT24_029`) or Crescemon (`BT22_073`). 

Hopefully, these changes fix the bug! Thanks for the review.
