### PR TITLE
Fix Both X7-SMs and more cards can skip asking if only 1 location

### DIFF
--- a/Assets/Scripts/CardEffect/BT12/White/BT12_112.cs
+++ b/Assets/Scripts/CardEffect/BT12/White/BT12_112.cs
@@ -402,7 +402,7 @@ namespace DCGO.CardEffects.BT12
                 {
                     if (cardSource == card)
                     {
-                        DigiXrosConditionElement element = new DigiXrosConditionElement(CanSelectCardCondition, "1 Digimon card with [Xros Heart] or [Blue Flare] trait");
+                        DigiXrosConditionElement element = new DigiXrosConditionElement(CanSelectCardCondition, "1 Digimon card with [Xros Heart] or [Blue Flare] trait", true);
 
                         bool CanSelectCardCondition(CardSource cardSource)
                         {

--- a/Assets/Scripts/CardEffect/BT21/Red/BT21_030.cs
+++ b/Assets/Scripts/CardEffect/BT21/Red/BT21_030.cs
@@ -55,7 +55,7 @@ namespace DCGO.CardEffects.BT21
                 {
                     if (cardSource == card)
                     {
-                        DigiXrosConditionElement element = new DigiXrosConditionElement(CanSelectCardCondition, "1 Digimon card with [Xros Heart] or [Blue Flare] trait");
+                        DigiXrosConditionElement element = new DigiXrosConditionElement(CanSelectCardCondition, "1 Digimon card with [Xros Heart] or [Blue Flare] trait", true);
 
                         bool CanSelectCardCondition(CardSource cardSource)
                         {

--- a/Assets/Scripts/Script/SelectDigiXrosClass.cs
+++ b/Assets/Scripts/Script/SelectDigiXrosClass.cs
@@ -387,8 +387,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 
                     if (_endSelectDigiXros)
                     {
-                        _endSelectDigiXros = false;
-                        //break; TODO: Removed for not triggering digixros in all situations
+                        _endSelectDigiXros = false;//Reset here in case of leftover from previous digixros
                     }
 
                     bool canSelectHand = false;
@@ -470,7 +469,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                         }
                     }
 
-                    else if (canSelectActions.Count == 2 && digiXrosCondition.CanTargetCondition_ByPreSelecetedList == null && !element.skipAllIfNoSelect)
+                    else if (canSelectActions.Count == 2 && !element.skipAllIfNoSelect)
                     {
                         SetTargetDigiXrossIndex(card.Owner.PlayerID, actions.IndexOf(canSelectActions[0]));
                     }
@@ -553,6 +552,11 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                     if (0 <= _targetIndex && _targetIndex <= actions.Count - 1)
                     {
                         yield return ContinuousController.instance.StartCoroutine(actions[_targetIndex]());
+
+                        if (_endSelectDigiXros)
+                        {
+                            break;//Perform here where the value will only just have been set by the above routine
+                        }
 
                         if (!card.Owner.isYou && GManager.instance.IsAI)
                         {

--- a/Assets/Scripts/Script/SelectDigiXrosClass.cs
+++ b/Assets/Scripts/Script/SelectDigiXrosClass.cs
@@ -2,13 +2,14 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
-using Photon;
 using Photon.Pun;
 using System;
-using UnityEngine.Events;
 
 public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 {
+    private static WaitForSeconds _waitForSeconds0_4 = new WaitForSeconds(0.4f);
+    private static WaitForSeconds _waitForSeconds0_3 = new WaitForSeconds(0.3f);
+
     public List<CardSource> selectedDigicrossCards { get; private set; } = new List<CardSource>();
     public List<AddDigivolutionCardsInfo> addDigivolutionCardInfos { get; private set; } = new List<AddDigivolutionCardsInfo>();
     public List<CardSource> excludedCards { get; private set; } = new List<CardSource>();
@@ -424,11 +425,11 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                         }
                     }
 
-                    Func<IEnumerator> _SelectHandCard = () => SelectHandCard(digiXrosCondition, element, card);
-                    Func<IEnumerator> _SelectBattleAreaDigimon = () => SelectBattleAreaPermanent(digiXrosCondition, element, card);
-                    Func<IEnumerator> _SelectTrashCard = () => SelectTrashCard(digiXrosCondition, element, card);
-                    Func<IEnumerator> _SelectTamerDigivolutionCard = () => SelectTamerDigivolutionCard(digiXrosCondition, element, card);
-                    Func<IEnumerator> _EndSelectDigiXros = () => EndSelectDigiXros();
+                    IEnumerator _SelectHandCard() => SelectHandCard(digiXrosCondition, element, card);
+                    IEnumerator _SelectBattleAreaDigimon() => SelectBattleAreaPermanent(digiXrosCondition, element, card);
+                    IEnumerator _SelectTrashCard() => SelectTrashCard(digiXrosCondition, element, card);
+                    IEnumerator _SelectTamerDigivolutionCard() => SelectTamerDigivolutionCard(digiXrosCondition, element, card);
+                    IEnumerator _EndSelectDigiXros() => EndSelectDigiXros();
 
                     List<Func<IEnumerator>> actions = new List<Func<IEnumerator>>() { _SelectHandCard, _SelectBattleAreaDigimon, _SelectTrashCard, _SelectTamerDigivolutionCard, _EndSelectDigiXros };
 
@@ -560,7 +561,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 
                         if (!card.Owner.isYou && GManager.instance.IsAI)
                         {
-                            yield return new WaitForSeconds(0.3f);
+                            yield return _waitForSeconds0_3;
                         }
                     }
                 }
@@ -569,7 +570,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
 
         if (selectedDigicrossCards.Count >= 1)
         {
-            yield return new WaitForSeconds(0.4f);
+            yield return _waitForSeconds0_4;
         }
 
         GManager.instance.GetComponent<Effects>().OffShowCard2();
@@ -623,7 +624,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                     {
                         if (digiXrosCondition.CanTargetCondition_ByPreSelecetedList != null || element.skipAllIfNoSelect)
                         {
-                            EndSelectDigiXros();
+                            StartCoroutine(EndSelectDigiXros());
                         }
                     }
                 }
@@ -681,7 +682,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                     {
                         if (digiXrosCondition.CanTargetCondition_ByPreSelecetedList != null || element.skipAllIfNoSelect)
                         {
-                            EndSelectDigiXros();
+                            StartCoroutine(EndSelectDigiXros());
                         }
                     }
                 }
@@ -743,7 +744,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                     {
                         if (digiXrosCondition.CanTargetCondition_ByPreSelecetedList != null || element.skipAllIfNoSelect)
                         {
-                            EndSelectDigiXros();
+                            StartCoroutine(EndSelectDigiXros());
                         }
                     }
                 }
@@ -798,7 +799,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                             {
                                 if (digiXrosCondition.CanTargetCondition_ByPreSelecetedList != null || element.skipAllIfNoSelect)
                                 {
-                                    EndSelectDigiXros();
+                                    StartCoroutine(EndSelectDigiXros());
                                 }
                             }
                         }
@@ -863,7 +864,7 @@ public class SelectDigiXrosClass : MonoBehaviourPunCallbacks
                     {
                         if (digiXrosCondition.CanTargetCondition_ByPreSelecetedList != null || element.skipAllIfNoSelect)
                         {
-                            EndSelectDigiXros();
+                            StartCoroutine(EndSelectDigiXros());
                         }
                     }
                 }


### PR DESCRIPTION
Ok I think I see what it was doing before that wasn't working, and this should allow Shoutmon X7: Superior Modes to say when they are finished.
While I was at it, ensured cards with conditions like "With different names/card numbers" don't need to ask which location to take from if there is only one location. If they no select it will still end the overall selection.