### PR TITLE
Update Retaliation.cs

### DIFF
--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Retaliation.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Retaliation.cs
@@ -21,7 +21,8 @@ public partial class CardEffectCommons
 
                     if (TopCard != null)
                     {
-                        if (IsTopCardStillInTrash(cardEffect))
+                        bool sourceIsToken = cardEffect.EffectSourceCard?.IsToken ?? false;
+                        if (IsTopCardStillInTrash(cardEffect) || sourceIsToken)
                         {
                             IBattle battle = GetBattleFromHashtable(hashtable);
 
@@ -31,30 +32,14 @@ public partial class CardEffectCommons
 
                                 if (battleHashtable != null)
                                 {
-                                    List<Permanent> LoserPermanents = GetLoserPermanentsFromHashtable(battleHashtable);
 
-                                    if (LoserPermanents != null)
+                                    List<Permanent> WinnerPermanents = GetWinnerPermanentsRealFromHashtable(battleHashtable);
+
+                                    if (WinnerPermanents != null)
                                     {
-                                        if (LoserPermanents.Some((permanent) => permanent.cardSources.Contains(TopCard)))
+                                        if (WinnerPermanents.Some(permanent => IsOpponentPermanent(permanent, TopCard)))
                                         {
-                                            #region Work out if opponent is still in play
-                                            if (LoserPermanents.Some(permanent => IsOpponentPermanent(permanent, TopCard)))// In case of tie, any other permanent is the opponent's digimon
-                                            {
-                                                return true;
-                                            } 
-                                            else
-                                            {
-                                                List<Permanent> WinnerPermanents = GetWinnerPermanentsRealFromHashtable(battleHashtable);
-
-                                                if (WinnerPermanents != null)
-                                                {
-                                                    if (WinnerPermanents.Some(permanent => IsOpponentPermanent(permanent, TopCard)))
-                                                    {
-                                                        return true;
-                                                    }
-                                                }
-                                            }
-                                            #endregion
+                                            return true;
                                         }
                                     }
                                 }


### PR DESCRIPTION
Fix for tokens and tie battles with protected adversaries

Initial tests: Ghoulmon (LM-044); Volée and Zerdrücken (Token)
TO-DO: Fortitude Tie Compatibility Validation (Argumentative)
Summary:
1. Consider winner(s) list transformations rather than loser(s) to act upon
2. Pedantic token test