### PR TITLE
Update Retaliation.cs

### DIFF
--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Retaliation.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Retaliation.cs
@@ -21,8 +21,7 @@ public partial class CardEffectCommons
 
                     if (TopCard != null)
                     {
-                        bool sourceIsToken = cardEffect.EffectSourceCard?.IsToken ?? false;
-                        if (IsTopCardStillInTrash(cardEffect) || sourceIsToken)
+                        if (CanActivateOnDeletion(cardEffect.EffectSourceCard, cardEffect))
                         {
                             IBattle battle = GetBattleFromHashtable(hashtable);
 

--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Retaliation.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Retaliation.cs
@@ -21,7 +21,7 @@ public partial class CardEffectCommons
 
                     if (TopCard != null)
                     {
-                        if (CanActivateOnDeletion(cardEffect.EffectSourceCard, cardEffect))
+                        if (CanActivateOnDeletion(TopCard, cardEffect))
                         {
                             IBattle battle = GetBattleFromHashtable(hashtable);
 


### PR DESCRIPTION
Proposal of boilerplate removal

Observing no instances of `CardSources` being passed `null` in arguments, I am bringing up replacing recent changes on retaliation, whose behavior already is reflected in a function implemented to check `OnDeletion` activation