### PR TITLE
Introduction of extension class for ease of static effects copy

### DIFF
--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -1276,4 +1276,66 @@ public static class ActivateICardEffectExtensionClass
     #endregion
 }
 
+public static class CopyICardEffectExtensions
+{
+    /// <summary>
+    /// Evaluates a list of card effects and expands any dynamic skill wrappers (IAddSkillEffect) 
+    /// into their underlying ICardEffects for a specific CardSource and Timing.
+    /// </summary>
+    public static IEnumerable<ICardEffect> FlattenEffects(this IEnumerable<ICardEffect> rawEffects, CardSource cardSource, EffectTiming timing = EffectTiming.None)
+    {
+        if (rawEffects == null) yield break;
+
+        foreach (var effect in rawEffects)
+        {
+            if (effect == null) continue;
+
+            yield return effect;
+
+            if (effect is IAddSkillEffect skillWrapper && skillWrapper.ShouldAddEffect(timing))
+            {
+                var grantedEffects = new List<ICardEffect>();
+                grantedEffects = skillWrapper.GetCardEffect(cardSource, grantedEffects, timing);
+
+                if (grantedEffects != null)
+                {
+                    foreach (var innerEffect in grantedEffects)
+                    {
+                        yield return innerEffect;
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets all active effects of type T (including dynamically granted skills) for a given card/permanent.
+    /// </summary>
+    public static IEnumerable<T> GetEffects<T>(this IEnumerable<ICardEffect> rawEffects, CardSource cardSource, EffectTiming timing = EffectTiming.None) where T : class
+    {
+        foreach (var effect in rawEffects.FlattenEffects(cardSource, timing))
+        {
+            if (effect is T matchedEffect)
+            {
+                yield return matchedEffect;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Checks if any active effect (including added skills) matches type T and satisfies a condition.
+    /// </summary>
+    public static bool HasEffect<T>(this IEnumerable<ICardEffect> rawEffects, CardSource cardSource, System.Predicate<T> condition = null, EffectTiming timing = EffectTiming.None) where T : class
+    {
+        foreach (var effect in rawEffects.GetEffects<T>(cardSource, timing))
+        {
+            if (condition == null || condition(effect))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
 #endregion

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -1276,13 +1276,16 @@ public static class ActivateICardEffectExtensionClass
     #endregion
 }
 
-public static class CopyICardEffectExtensions
+public static class CopyICardEffectExtensionClass
 {
     /// <summary>
     /// Evaluates a list of card effects and expands any dynamic skill wrappers (IAddSkillEffect) 
     /// into their underlying ICardEffects for a specific CardSource and Timing.
     /// </summary>
-    public static IEnumerable<ICardEffect> FlattenEffects(this IEnumerable<ICardEffect> rawEffects, CardSource cardSource, EffectTiming timing = EffectTiming.None)
+    public static IEnumerable<ICardEffect> FlattenEffects(
+        this IEnumerable<ICardEffect> rawEffects, 
+        EffectTiming timing  = EffectTiming.None,
+        EffectTiming timingLimit = EffectTiming.None)
     {
         if (rawEffects == null) yield break;
 
@@ -1292,10 +1295,10 @@ public static class CopyICardEffectExtensions
 
             yield return effect;
 
-            if (effect is IAddSkillEffect skillWrapper && skillWrapper.ShouldAddEffect(timing))
+            if (effect is IAddSkillEffect skillWrapper && skillWrapper.ShouldAddEffect(timingLimit))
             {
                 var grantedEffects = new List<ICardEffect>();
-                grantedEffects = skillWrapper.GetCardEffect(cardSource, grantedEffects, timing);
+                grantedEffects = skillWrapper.GetCardEffect(effect.EffectSourceCard, grantedEffects, timing);
 
                 if (grantedEffects != null)
                 {
@@ -1311,9 +1314,12 @@ public static class CopyICardEffectExtensions
     /// <summary>
     /// Gets all active effects of type T (including dynamically granted skills) for a given card/permanent.
     /// </summary>
-    public static IEnumerable<T> GetEffects<T>(this IEnumerable<ICardEffect> rawEffects, CardSource cardSource, EffectTiming timing = EffectTiming.None) where T : class
+    public static IEnumerable<T> GetFlatEffects<T>(
+        this IEnumerable<ICardEffect> rawEffects, 
+        EffectTiming timing  = EffectTiming.None,
+        EffectTiming timingLimit = EffectTiming.None) where T : class
     {
-        foreach (var effect in rawEffects.FlattenEffects(cardSource, timing))
+        foreach (var effect in rawEffects.FlattenEffects(timing, timingLimit))
         {
             if (effect is T matchedEffect)
             {
@@ -1325,9 +1331,14 @@ public static class CopyICardEffectExtensions
     /// <summary>
     /// Checks if any active effect (including added skills) matches type T and satisfies a condition.
     /// </summary>
-    public static bool HasEffect<T>(this IEnumerable<ICardEffect> rawEffects, CardSource cardSource, System.Predicate<T> condition = null, EffectTiming timing = EffectTiming.None) where T : class
+    public static bool HasEffect<T>(
+        this IEnumerable<ICardEffect> rawEffects, 
+        CardSource cardSource, 
+        System.Predicate<T> condition = null, 
+        EffectTiming timing = EffectTiming.None,
+        EffectTiming timingLimit = EffectTiming.None) where T : class
     {
-        foreach (var effect in rawEffects.GetEffects<T>(cardSource, timing))
+        foreach (var effect in rawEffects.GetFlatEffects<T>(timing, timingLimit))
         {
             if (condition == null || condition(effect))
             {

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -802,12 +802,7 @@ public abstract class ICardEffect
                 {
                     if (EffectDiscription.StartsWith("[On Deletion]"))
                     {
-                        // Permanent effectPermanent = EffectSourceCard.PermanentOfThisCard() ?? new Permanent(new List<CardSource>() { EffectSourceCard });
-
-                        // Hashtable hashtable = CardEffectCommons.OnDeletionHashtable(new List<Permanent>() { effectPermanent }, null, null, false);
-
-                        // if (CanTrigger(hashtable))
-                            return true;
+                        return true;
                     }
                 }
             }

--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System;
@@ -706,19 +706,10 @@ public class Permanent
         {
             foreach (Permanent permanent in player.GetFieldPermanents())
             {
-                foreach (ICardEffect cardEffect1 in permanent.EffectList(EffectTiming.None))
-                {
-                    if (cardEffect1 is IImmuneFromDPMinusEffect)
-                    {
-                        if (cardEffect1.CanUse(null))
-                        {
-                            if (((IImmuneFromDPMinusEffect)cardEffect1).ImmuneFromDPMinus(this, cardEffect))
-                            {
-                                return true;
-                            }
-                        }
-                    }
-                }
+                var immunityConfirmed = permanent.EffectList(EffectTiming.None)
+                .GetFlatEffects<IImmuneFromDPMinusEffect>()
+                .Any(e => ((ICardEffect)e).CanUse(null) && e.ImmuneFromDPMinus(this, cardEffect));
+                if (immunityConfirmed) return true;
             }
 
             foreach (ICardEffect cardEffect1 in player.EffectList(EffectTiming.None))
@@ -1765,19 +1756,20 @@ public class Permanent
             {
                 foreach (Permanent permanent in player.GetFieldPermanents())
                 {
+                    var sAttackEffects = permanent.EffectList(EffectTiming.None)
+                        .GetFlatEffects<IChangeSAttackEffect>()
+                        .Where(e => e.PermanentCondition(this));
+
                     #region 場のパーマネントの効果
-                    foreach (ICardEffect cardEffect in permanent.EffectList(EffectTiming.None))
+                    foreach (ICardEffect cardEffect in sAttackEffects)
                     {
-                        if (cardEffect is IChangeSAttackEffect)
+                        if (cardEffect.CanUse(null))
                         {
-                            if (cardEffect.CanUse(null))
+                            if (!TopCard.CanNotBeAffected(cardEffect))
                             {
-                                if (!TopCard.CanNotBeAffected(cardEffect))
+                                if (((IChangeSAttackEffect)cardEffect).isUpDown() == CalculateOrder.UpDownValue)
                                 {
-                                    if (((IChangeSAttackEffect)cardEffect).isUpDown() == CalculateOrder.UpDownValue)
-                                    {
-                                        cardEffects_ChangeDirectStrike.Add(cardEffect);
-                                    }
+                                    cardEffects_ChangeDirectStrike.Add(cardEffect);
                                 }
                             }
                         }
@@ -2739,8 +2731,8 @@ public class Permanent
                 {
                     #region 場のパーマネントの効果
                     var rushConfirmed = permanent.EffectList(EffectTiming.None)
-                        .GetEffects<IRushEffect>(permanent.TopCard, EffectTiming.None)
-                        .Any(e => e.HasRush(this));
+                        .GetFlatEffects<IRushEffect>()
+                        .Any(e => ((ICardEffect)e).CanTrigger(null) && e.HasRush(this));
                     if (rushConfirmed) return true;
                     #endregion
                 }

--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -2738,19 +2738,10 @@ public class Permanent
                 foreach (Permanent permanent in player.GetFieldPermanents())
                 {
                     #region 場のパーマネントの効果
-                    foreach (ICardEffect cardEffect in permanent.EffectList(EffectTiming.None))
-                    {
-                        if (cardEffect is IRushEffect)
-                        {
-                            if (cardEffect.CanTrigger(null))
-                            {
-                                if (((IRushEffect)cardEffect).HasRush(this))
-                                {
-                                    return true;
-                                }
-                            }
-                        }
-                    }
+                    var rushConfirmed = permanent.EffectList(EffectTiming.None)
+                        .GetEffects<IRushEffect>(permanent.TopCard, EffectTiming.None)
+                        .Any(e => e.HasRush(this));
+                    if (rushConfirmed) return true;
                     #endregion
                 }
 

--- a/Assets/Scripts/Script/Permanent.cs
+++ b/Assets/Scripts/Script/Permanent.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System;
@@ -942,29 +942,29 @@ public class Permanent
                 }
 
                 #region Effects of face up security
-                    foreach (CardSource cardSource in player.SecurityCards)
-                    {
-                        if (cardSource.IsFlipped)
-                            continue;
+                foreach (CardSource cardSource in player.SecurityCards)
+                {
+                    if (cardSource.IsFlipped)
+                        continue;
 
-                        foreach (ICardEffect cardEffect in cardSource.EffectList(EffectTiming.None))
+                    foreach (ICardEffect cardEffect in cardSource.EffectList(EffectTiming.None))
+                    {
+                        if (cardEffect is IChangeLinkMaxEffect)
                         {
-                            if (cardEffect is IChangeLinkMaxEffect)
+                            if (((IChangeLinkMaxEffect)cardEffect).PermanentCondition(this))
                             {
-                                if (((IChangeLinkMaxEffect)cardEffect).PermanentCondition(this))
+                                if (cardEffect.CanUse(null))
                                 {
-                                    if (cardEffect.CanUse(null))
+                                    if (!TopCard.CanNotBeAffected(cardEffect))
                                     {
-                                        if (!TopCard.CanNotBeAffected(cardEffect))
-                                        {
-                                            cardEffects_ChangeLinkedMax.Add(cardEffect);
-                                        }
+                                        cardEffects_ChangeLinkedMax.Add(cardEffect);
                                     }
                                 }
                             }
                         }
                     }
-                    #endregion
+                }
+                #endregion
 
                 #region player effect
                 foreach (ICardEffect cardEffect in player.EffectList(EffectTiming.None))
@@ -1757,8 +1757,7 @@ public class Permanent
                 foreach (Permanent permanent in player.GetFieldPermanents())
                 {
                     var sAttackEffects = permanent.EffectList(EffectTiming.None)
-                        .GetFlatEffects<IChangeSAttackEffect>()
-                        .Where(e => e.PermanentCondition(this));
+                        .GetFlatEffects<IChangeSAttackEffect>();
 
                     #region 場のパーマネントの効果
                     foreach (ICardEffect cardEffect in sAttackEffects)
@@ -1844,20 +1843,18 @@ public class Permanent
             {
                 foreach (Permanent permanent in player.GetFieldPermanents())
                 {
+                    var sAttackEffects = permanent.EffectList(EffectTiming.None)
+                        .GetFlatEffects<IChangeSAttackEffect>()
+                        .Where(e => e.PermanentCondition(this));
+
                     #region Effects of permanents in play
-                    foreach (ICardEffect cardEffect in permanent.EffectList(EffectTiming.None))
+                    foreach (ICardEffect cardEffect in sAttackEffects)
                     {
-                        if (cardEffect is IChangeSAttackEffect)
+                        if (cardEffect.CanUse(null))
                         {
-                            if (((IChangeSAttackEffect)cardEffect).PermanentCondition(this))
+                            if (!TopCard.CanNotBeAffected(cardEffect))
                             {
-                                if (cardEffect.CanUse(null))
-                                {
-                                    if (!TopCard.CanNotBeAffected(cardEffect))
-                                    {
-                                        cardEffects_ChangeDirectStrike.Add(cardEffect);
-                                    }
-                                }
+                                cardEffects_ChangeDirectStrike.Add(cardEffect);
                             }
                         }
                     }


### PR DESCRIPTION
What this accomplishes: Allows tracking security check boosts, rush and immunity to DP ailments gained through `AddSkillClass`;
What it doesn't accomplish: Doesn't fix the lack of Engage triggering after Blimpmon reveals and places an EX12 Chaosdramon under a BT12 Chaosdramon X, immediately proceeding with EoyT.

---

Closes: #558
Continuity to: #1509