### PR TITLE
Update EX9_074.cs

### DIFF
--- a/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
+++ b/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
@@ -299,7 +299,11 @@ namespace DCGO.CardEffects.EX9
                         }
                     }
                 }
-            }
+                    if (permanentToDelete.Count > 0)
+{
+                            yield return ContinuousController.instance.StartCoroutine(
+                                new DestroyPermanentsClass(isNotImmune, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
+}
             #endregion
 
             #region All Turns

--- a/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
+++ b/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
@@ -200,17 +200,19 @@ namespace DCGO.CardEffects.EX9
                 if (colours.Count >= 6 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)))
                 {
                     List<Permanent> permanentToDelete = new List<Permanent>();
-                    List<CardColor> selectableColors = new List<CardColor>();
                     List<Permanent> isNotImmune = new List<Permanent>();
+                    List<CardColor> selectableColors = new List<CardColor>();
 
                     foreach (string cardColor in DataBase.CardColorNameDictionary.Values)
                     {
-                        CardColor compareColor = DictionaryUtility.GetCardColor(cardColor.Trim(), DataBase.CardColorNameDictionary);
+                        CardColor compareColor = DictionaryUtility.GetCardColor(
+                            cardColor.Trim(),
+                            DataBase.CardColorNameDictionary);
 
                         bool CanSelectOpponentDigimon(Permanent permanent)
                         {
-                            return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) &&
-                                   permanent.TopCard.CardColors.Contains(compareColor);
+                            return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                                && permanent.TopCard.CardColors.Contains(compareColor);
                         }
 
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentDigimon))
@@ -219,18 +221,27 @@ namespace DCGO.CardEffects.EX9
                         }
                     }
 
+                    selectableColors = selectableColors
+                        .OrderBy(color =>
+                            card.Owner.Enemy.GetBattleAreaDigimons().Count(permanent =>
+                                CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                                && permanent.TopCard.CardColors.Contains(color)))
+                        .ToList();
+
                     foreach (CardColor deletableColor in selectableColors)
                     {
                         bool CanSelectOpponentDigimon(Permanent permanent)
                         {
                             return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
                                 && permanent.TopCard.CardColors.Contains(deletableColor)
+                                && !permanentToDelete.Contains(permanent)
                                 && CanTargetCondition_ByPreSelecetedList(permanentToDelete, permanent);
                         }
 
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentDigimon))
                         {
-                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                            SelectPermanentEffect selectPermanentEffect =
+                                GManager.instance.GetComponent<SelectPermanentEffect>();
 
                             selectPermanentEffect.SetUp(
                                 selectPlayer: card.Owner,
@@ -245,26 +256,30 @@ namespace DCGO.CardEffects.EX9
                                 mode: SelectPermanentEffect.Mode.Custom,
                                 cardEffect: activateClass);
 
-                            selectPermanentEffect.SetUpCustomMessage($"Select 1 {deletableColor} Digimon to delete", $"Opponent is selecting 1 {deletableColor} Digimon to delete");
+                            selectPermanentEffect.SetUpCustomMessage(
+                                $"Select 1 {deletableColor} Digimon to delete",
+                                $"Opponent is selecting 1 {deletableColor} Digimon to delete");
 
-                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                            yield return ContinuousController.instance.StartCoroutine(
+                                selectPermanentEffect.Activate());
+                        }
+
+                        IEnumerator DigimonToDelete(Permanent permanent)
+                        {
+                            if (permanent != null)
+                            {
+                                permanentToDelete.Add(permanent);
+                            }
+
+                            yield return null;
                         }
                     }
 
-                    bool CanTargetCondition_ByPreSelecetedList(List<Permanent> permanents, Permanent permanent)
+                    bool CanTargetCondition_ByPreSelecetedList(
+                        List<Permanent> permanents,
+                        Permanent permanent)
                     {
-                        if (permanentToDelete.Contains(permanent))
-                            return false;
-
-                        return true;
-                    }
-
-                    IEnumerator DigimonToDelete(Permanent permanent)
-                    {
-                        if (permanent != null)
-                            permanentToDelete.Add(permanent);
-
-                        yield return null;
+                        return !permanentToDelete.Contains(permanent);
                     }
 
                     if (permanentToDelete.Count > 0)
@@ -279,7 +294,8 @@ namespace DCGO.CardEffects.EX9
 
                         if (isNotImmune.Count > 0)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(isNotImmune, hashtable).Destroy());
+                            yield return ContinuousController.instance.StartCoroutine(
+                                new DestroyPermanentsClass(isNotImmune, hashtable).Destroy());
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
+++ b/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
@@ -66,7 +66,7 @@ namespace DCGO.CardEffects.EX9
                         }
 
                         AssemblyCondition assemblyCondition = new AssemblyCondition(
-                            element:element,
+                            element: element,
                             CanTargetCondition_ByPreSelecetedList: CanTargetCondition_ByPreSelecetedList,
                             selectMessage: "7 level 4 [DM] trait Digimon cards w/different names",
                             elementCount: 7,
@@ -110,15 +110,15 @@ namespace DCGO.CardEffects.EX9
 
             bool CanSelectCardCondition(CardSource cardSource)
             {
-                return cardSource.IsDigimon 
-                    && cardSource.HasLevel 
-                    && cardSource.Level <= 4 
+                return cardSource.IsDigimon
+                    && cardSource.HasLevel
+                    && cardSource.Level <= 4
                     && cardSource.HasDMTraits;
             }
 
             bool CanSelectPermanentCondition(Permanent permanent, List<CardColor> cardColors)
             {
-                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) 
+                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
                     && permanent.TopCard.CardColors.Exists(color => cardColors.Contains(color));
             }
 
@@ -295,15 +295,11 @@ namespace DCGO.CardEffects.EX9
                         if (isNotImmune.Count > 0)
                         {
                             yield return ContinuousController.instance.StartCoroutine(
-                                new DestroyPermanentsClass(isNotImmune, hashtable).Destroy());
+                        new DestroyPermanentsClass(isNotImmune, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
                         }
                     }
                 }
-                    if (permanentToDelete.Count > 0)
-{
-                            yield return ContinuousController.instance.StartCoroutine(
-                                new DestroyPermanentsClass(isNotImmune, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
-}
+            }
             #endregion
 
             #region All Turns

--- a/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
+++ b/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 
 // Kimeramon
 namespace DCGO.CardEffects.EX9
@@ -35,24 +34,12 @@ namespace DCGO.CardEffects.EX9
 
                         bool CanSelectCardCondition(CardSource cardSource)
                         {
-                            if (cardSource != null)
-                            {
-                                if (cardSource.Owner == card.Owner)
-                                {
-                                    if (cardSource.IsDigimon)
-                                    {
-                                        if (cardSource.IsLevel4 || cardSource.Level_Assembly.Contains(4))
-                                        {
-                                            if (cardSource.HasDMTraits)
-                                            {
-                                                return true;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            return false;
+                            return cardSource != null
+                                && cardSource.Owner == card.Owner
+                                && cardSource.IsDigimon
+                                && (cardSource.IsLevel4
+                                    || cardSource.Level_Assembly.Contains(4))
+                                && cardSource.HasDMTraits;
                         }
 
                         bool CanTargetCondition_ByPreSelecetedList(List<CardSource> cardSources, CardSource cardSource)
@@ -94,445 +81,238 @@ namespace DCGO.CardEffects.EX9
             #endregion
 
             #region Sec +1
-
             if (timing == EffectTiming.None)
             {
-                cardEffects.Add(CardEffectFactory.ChangeSelfSAttackStaticEffect(
-                changeValue: 1,
-                isInheritedEffect: false,
-                card: card,
-                condition: null));
+                cardEffects.Add(CardEffectFactory.ChangeSelfSAttackStaticEffect(changeValue: 1, isInheritedEffect: false, card: card, condition: null));
             }
-
             #endregion
 
             #region Rush
-
             if (timing == EffectTiming.None)
             {
                 cardEffects.Add(CardEffectFactory.RushSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
             }
-
             #endregion
 
-            #region On Play
+            #region Shared OP / WD
+            string SharedEffectName = "Place Digimon from trash as top sources, delete enemy Digimon";
 
-            if (timing == EffectTiming.OnEnterFieldAnyone)
+            CardEffectFactory.ActivateClassesForSharedEffects
+            (ref cardEffects, timing, card,
+                SharedEffectName,
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                onPlay: true,
+                whenDigivolving: true);
+
+            string SharedEffectDescription(string tag) => $"[{tag}] You may place 1 level 4 or lower [DM] trait Digimon card from your trash as this Digimon's top digivolution card. Then, delete 1 of your opponent's Digimon with the same color as any of this Digimon's digivolution cards. If this Digimon has 6 or more colors in its digivolution cards, instead delete 1 of each of your opponent's Digimon with different colors.";
+
+            bool CanSelectCardCondition(CardSource cardSource)
             {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Place digimon from trash as top source card, delete digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
-                activateClass.SetIsDigimonEffect(true);
-                cardEffects.Add(activateClass);
+                return cardSource.IsDigimon 
+                    && cardSource.HasLevel 
+                    && cardSource.Level <= 4 
+                    && cardSource.HasDMTraits;
+            }
 
-                string EffectDiscription()
+            bool CanSelectPermanentCondition(Permanent permanent, List<CardColor> cardColors)
+            {
+                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) 
+                    && permanent.TopCard.CardColors.Exists(color => cardColors.Contains(color));
+            }
+
+            bool CanEndSelectCondition(List<Permanent> permanents)
+            {
+                if (permanents.Count <= 0)
+                    return false;
+
+                return true;
+            }
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
                 {
-                    return "[On Play] You may place 1 level 4 or lower [DM] trait Digimon card from your trash as this Digimon's top digivolution card. Then, delete 1 of your opponent's Digimon with the same color as any of this Digimon's digivolution cards. If this Digimon has 6 or more colors in its digivolution cards, instead delete 1 of each of your opponent's Digimon with different colors.";
-                }
+                    CardSource selectedCard = null;
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
 
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-                }
+                    selectCardEffect.SetUp(
+                        canTargetCondition: CanSelectCardCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        message: "Select 1 [DM] digimon to add as top source",
+                        maxCount: 1,
+                        canEndNotMax: true,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Custom,
+                        root: SelectCardEffect.Root.Trash,
+                        customRootCardList: null,
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
 
-                bool CanActivateCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleArea(card);
-                }
+                    selectCardEffect.SetUpCustomMessage("Select 1 [DM] digimon to add as top source", "The opponent is selecting 1 digimon to add as top source");
+                    yield return StartCoroutine(selectCardEffect.Activate());
 
-                bool CanSelectCardCondition(CardSource cardSource)
-                {
-                    return cardSource.IsDigimon && cardSource.HasLevel && cardSource.Level <= 4 && cardSource.HasDMTraits;
-                }
-
-                bool CanSelectPermanentCondition(Permanent permanent, List<CardColor> cardColors)
-                {
-                    return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) && permanent.TopCard.CardColors.Exists(color => cardColors.Contains(color));
-                }
-
-                bool CanEndSelectCondition(List<Permanent> permanents)
-                {
-                    if (permanents.Count <= 0)
-                        return false;
-
-                    return true;
-                }
-
-                IEnumerator ActivateCoroutine(Hashtable hashtable)
-                {
-                    if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
                     {
-                        CardSource selectedCard = null;
-                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, CanSelectCardCondition));
-                        SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+                        selectedCard = cardSource;
+                        yield return null;
+                    }
 
-                        selectCardEffect.SetUp(
-                                    canTargetCondition: CanSelectCardCondition,
-                                    canTargetCondition_ByPreSelecetedList: null,
-                                    canEndSelectCondition: null,
-                                    canNoSelect: () => true,
-                                    selectCardCoroutine: SelectCardCoroutine,
-                                    afterSelectCardCoroutine: null,
-                                    message: "Select 1 [DM] digimon to add as top source",
-                                    maxCount: maxCount,
-                                    canEndNotMax: true,
-                                    isShowOpponent: true,
-                                    mode: SelectCardEffect.Mode.Custom,
-                                    root: SelectCardEffect.Root.Trash,
-                                    customRootCardList: null,
-                                    canLookReverseCard: true,
-                                    selectPlayer: card.Owner,
-                                    cardEffect: activateClass);
+                    if (selectedCard != null)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddExecutingCard(selectedCard));
+                        yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsTop(new List<CardSource>() { selectedCard }, activateClass));
+                    }
+                }
 
-                        selectCardEffect.SetUpCustomMessage("Select 1 [DM] digimon to add as top source", "The opponent is selecting 1 digimon to add as top source");
-                        yield return StartCoroutine(selectCardEffect.Activate());
+                List<CardColor> colours = card.PermanentOfThisCard().DigivolutionCards
+                    .Filter(x => !x.IsFlipped)
+                    .SelectMany(e => e.CardColors)
+                    .Distinct()
+                    .ToList();
 
-                        IEnumerator SelectCardCoroutine(CardSource cardSource)
+                if (colours.Count <= 5 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CanSelectPermanentCondition(permanent, colours)))
+                {
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: permanent => CanSelectPermanentCondition(permanent, colours),
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Destroy,
+                        cardEffect: activateClass);
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                }
+
+                if (colours.Count >= 6 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)))
+                {
+                    List<Permanent> permanentToDelete = new List<Permanent>();
+                    List<CardColor> selectableColors = new List<CardColor>();
+                    List<Permanent> isNotImmune = new List<Permanent>();
+
+                    foreach (string cardColor in DataBase.CardColorNameDictionary.Values)
+                    {
+                        CardColor compareColor = DictionaryUtility.GetCardColor(cardColor.Trim(), DataBase.CardColorNameDictionary);
+
+                        bool CanSelectOpponentDigimon(Permanent permanent)
                         {
-                            selectedCard = cardSource;
-                            yield return null;
+                            return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) &&
+                                   permanent.TopCard.CardColors.Contains(compareColor);
                         }
 
-                        if (selectedCard != null)
+                        if (CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentDigimon))
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddExecutingCard(selectedCard));
-                            yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsTop(new List<CardSource>() { selectedCard }, activateClass));
+                            selectableColors.Add(compareColor);
                         }
                     }
 
-                    List<CardColor> colours = card.PermanentOfThisCard().DigivolutionCards
-                                .Filter(x => !x.IsFlipped)
-                                .SelectMany(e => e.CardColors)
-                                .Distinct()
-                                .ToList();
-
-                    if (colours.Count <= 5 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CanSelectPermanentCondition(permanent, colours)))
+                    foreach (CardColor deletableColor in selectableColors)
                     {
-                        int maxCount1 = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(permanent => CanSelectPermanentCondition(permanent, colours)));
-                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                        bool CanSelectOpponentDigimon(Permanent permanent)
+                        {
+                            return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                                && permanent.TopCard.CardColors.Contains(deletableColor)
+                                && CanTargetCondition_ByPreSelecetedList(permanentToDelete, permanent);
+                        }
 
-                        selectPermanentEffect.SetUp(
-                            selectPlayer: card.Owner,
-                            canTargetCondition: permanent => CanSelectPermanentCondition(permanent, colours),
-                            canTargetCondition_ByPreSelecetedList: null,
-                            canEndSelectCondition: null,
-                            maxCount: maxCount1,
-                            canNoSelect: false,
-                            canEndNotMax: false,
-                            selectPermanentCoroutine: null,
-                            afterSelectPermanentCoroutine: null,
-                            mode: SelectPermanentEffect.Mode.Destroy,
-                            cardEffect: activateClass);
+                        if (CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentDigimon))
+                        {
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
-                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: CanSelectOpponentDigimon,
+                                canTargetCondition_ByPreSelecetedList: CanTargetCondition_ByPreSelecetedList,
+                                canEndSelectCondition: CanEndSelectCondition,
+                                maxCount: 1,
+                                canNoSelect: false,
+                                canEndNotMax: true,
+                                selectPermanentCoroutine: DigimonToDelete,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            selectPermanentEffect.SetUpCustomMessage($"Select 1 {deletableColor} Digimon to delete", $"Opponent is selecting 1 {deletableColor} Digimon to delete");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                        }
                     }
 
-                    if (colours.Count >= 6 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)))
+                    bool CanTargetCondition_ByPreSelecetedList(List<Permanent> permanents, Permanent permanent)
                     {
-                        List<Permanent> permanentToDelete = new List<Permanent>();
-                        List<CardColor> selectableColors = new List<CardColor>();
+                        if (permanentToDelete.Contains(permanent))
+                            return false;
 
-                        foreach (string cardColor in DataBase.CardColorNameDictionary.Values)
+                        return true;
+                    }
+
+                    IEnumerator DigimonToDelete(Permanent permanent)
+                    {
+                        if (permanent != null)
+                            permanentToDelete.Add(permanent);
+
+                        yield return null;
+                    }
+
+                    if (permanentToDelete.Count > 0)
+                    {
+                        foreach (Permanent permanent in permanentToDelete)
                         {
-
-                            CardColor compareColor = DictionaryUtility.GetCardColor(cardColor.Trim(), DataBase.CardColorNameDictionary);
-
-                            bool CanSelectOpponentDigimon(Permanent permanent)
+                            if (permanent.CanBeDestroyedBySkill(activateClass))
                             {
-                                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) &&
-                                       permanent.TopCard.CardColors.Contains(compareColor);
-                            }
-
-                            if (CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentDigimon))
-                            {
-                                selectableColors.Add(compareColor);
-                            }
-                        }
-
-                        foreach(CardColor deletableColor in selectableColors)
-                        {
-
-                            bool CanSelectOpponentDigimon(Permanent permanent)
-                            {
-                                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) &&
-                                       permanent.TopCard.CardColors.Contains(deletableColor) &&
-                                       CanTargetCondition_ByPreSelecetedList(permanentToDelete, permanent);
-                            }
-
-                            if (CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentDigimon))
-                            {
-                                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                                selectPermanentEffect.SetUp(
-                                    selectPlayer: card.Owner,
-                                    canTargetCondition: CanSelectOpponentDigimon,
-                                    canTargetCondition_ByPreSelecetedList: CanTargetCondition_ByPreSelecetedList,
-                                    canEndSelectCondition: CanEndSelectCondition,
-                                    maxCount: 1,
-                                    canNoSelect: false,
-                                    canEndNotMax: true,
-                                    selectPermanentCoroutine: DigimonToDelete,
-                                    afterSelectPermanentCoroutine: null,
-                                    mode: SelectPermanentEffect.Mode.Custom,
-                                    cardEffect: activateClass);
-
-                                selectPermanentEffect.SetUpCustomMessage($"Select 1 {deletableColor.ToString()} Digimon to delete", $"Opponent is selecting 1 {deletableColor.ToString()} Digimon to delete");
-
-                                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                                isNotImmune.Add(permanent);
                             }
                         }
 
-                        bool CanTargetCondition_ByPreSelecetedList(List<Permanent> permanents, Permanent permanent)
+                        if (isNotImmune.Count > 0)
                         {
-                            if (permanentToDelete.Contains(permanent)) 
-                                return false;
-                            
-                            return true;
-                        }
-
-                        IEnumerator DigimonToDelete (Permanent permanent)
-                        {
-                            if(permanent != null)
-                                permanentToDelete.Add(permanent);
-
-                            yield return null;
-                        }
-
-                        if(permanentToDelete.Count > 0)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(permanentToDelete, hashtable).Destroy());
+                            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(isNotImmune, hashtable).Destroy());
                         }
                     }
                 }
             }
-
-            #endregion
-
-            #region When Digivolving
-
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Place digimon from trash as top source card, delete digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
-                activateClass.SetIsDigimonEffect(true);
-                cardEffects.Add(activateClass);
-
-                string EffectDiscription()
-                {
-                    return "[When Digivolving] You may place 1 level 4 or lower [DM] trait Digimon card from your trash as this Digimon's top digivolution card. Then, delete 1 of your opponent's Digimon with the same color as any of this Digimon's digivolution cards. If this Digimon has 6 or more colors in its digivolution cards, instead delete 1 of each of your opponent's Digimon with different colors.";
-                }
-
-                bool CanUseCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-                }
-
-                bool CanActivateCondition(Hashtable hashtable)
-                {
-                    return CardEffectCommons.IsExistOnBattleArea(card);
-                }
-
-                bool CanSelectCardCondition(CardSource cardSource)
-                {
-                    return cardSource.IsDigimon && cardSource.HasLevel && cardSource.Level <= 4 && cardSource.HasDMTraits;
-                }
-
-                bool CanSelectPermanentCondition(Permanent permanent, List<CardColor> cardColors)
-                {
-                    return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) && permanent.TopCard.CardColors.Exists(color => cardColors.Contains(color));
-                }
-
-                bool CanEndSelectCondition(List<Permanent> permanents)
-                {
-                    if (permanents.Count <= 0)
-                        return false;
-
-                    return true;
-                }
-
-                IEnumerator ActivateCoroutine(Hashtable hashtable)
-                {
-                    if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition))
-                    {
-                        CardSource selectedCard = null;
-                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, CanSelectCardCondition));
-                        SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
-
-                        selectCardEffect.SetUp(
-                                    canTargetCondition: CanSelectCardCondition,
-                                    canTargetCondition_ByPreSelecetedList: null,
-                                    canEndSelectCondition: null,
-                                    canNoSelect: () => true,
-                                    selectCardCoroutine: SelectCardCoroutine,
-                                    afterSelectCardCoroutine: null,
-                                    message: "Select 1 [DM] digimon to add as top source",
-                                    maxCount: maxCount,
-                                    canEndNotMax: true,
-                                    isShowOpponent: true,
-                                    mode: SelectCardEffect.Mode.Custom,
-                                    root: SelectCardEffect.Root.Trash,
-                                    customRootCardList: null,
-                                    canLookReverseCard: true,
-                                    selectPlayer: card.Owner,
-                                    cardEffect: activateClass);
-
-                        selectCardEffect.SetUpCustomMessage("Select 1 [DM] digimon to add as top source", "The opponent is selecting 1 digimon to add as top source");
-                        yield return StartCoroutine(selectCardEffect.Activate());
-
-                        IEnumerator SelectCardCoroutine(CardSource cardSource)
-                        {
-                            selectedCard = cardSource;
-                            yield return null;
-                        }
-
-                        if (selectedCard != null)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddExecutingCard(selectedCard));
-                            yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsTop(new List<CardSource>() { selectedCard }, activateClass));
-                        }
-                    }
-
-                    List<CardColor> colours = card.PermanentOfThisCard().DigivolutionCards
-                                .Filter(x => !x.IsFlipped)
-                                .SelectMany(e => e.CardColors)
-                                .Distinct()
-                                .ToList();
-
-                    if (colours.Count <= 5 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CanSelectPermanentCondition(permanent, colours)))
-                    {
-                        int maxCount1 = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(permanent => CanSelectPermanentCondition(permanent, colours)));
-                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                        selectPermanentEffect.SetUp(
-                            selectPlayer: card.Owner,
-                            canTargetCondition: permanent => CanSelectPermanentCondition(permanent, colours),
-                            canTargetCondition_ByPreSelecetedList: null,
-                            canEndSelectCondition: null,
-                            maxCount: maxCount1,
-                            canNoSelect: false,
-                            canEndNotMax: false,
-                            selectPermanentCoroutine: null,
-                            afterSelectPermanentCoroutine: null,
-                            mode: SelectPermanentEffect.Mode.Destroy,
-                            cardEffect: activateClass);
-
-                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-                    }
-
-                    if (colours.Count >= 6 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)))
-                    {
-                        List<Permanent> permanentToDelete = new List<Permanent>();
-                        List<CardColor> selectableColors = new List<CardColor>();
-
-                        foreach (string cardColor in DataBase.CardColorNameDictionary.Values)
-                        {
-
-                            CardColor compareColor = DictionaryUtility.GetCardColor(cardColor.Trim(), DataBase.CardColorNameDictionary);
-
-                            bool CanSelectOpponentDigimon(Permanent permanent)
-                            {
-                                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) &&
-                                       permanent.TopCard.CardColors.Contains(compareColor);
-                            }
-
-                            if (CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentDigimon))
-                            {
-                                selectableColors.Add(compareColor);
-                            }
-                        }
-
-                        foreach (CardColor deletableColor in selectableColors)
-                        {
-
-                            bool CanSelectOpponentDigimon(Permanent permanent)
-                            {
-                                return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) &&
-                                       permanent.TopCard.CardColors.Contains(deletableColor) &&
-                                       CanTargetCondition_ByPreSelecetedList(permanentToDelete, permanent);
-                            }
-
-                            if (CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentDigimon))
-                            {
-                                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                                selectPermanentEffect.SetUp(
-                                    selectPlayer: card.Owner,
-                                    canTargetCondition: CanSelectOpponentDigimon,
-                                    canTargetCondition_ByPreSelecetedList: CanTargetCondition_ByPreSelecetedList,
-                                    canEndSelectCondition: CanEndSelectCondition,
-                                    maxCount: 1,
-                                    canNoSelect: false,
-                                    canEndNotMax: true,
-                                    selectPermanentCoroutine: DigimonToDelete,
-                                    afterSelectPermanentCoroutine: null,
-                                    mode: SelectPermanentEffect.Mode.Custom,
-                                    cardEffect: activateClass);
-
-                                selectPermanentEffect.SetUpCustomMessage($"Select 1 {deletableColor.ToString()} Digimon to delete", $"Opponent is selecting 1 {deletableColor.ToString()} Digimon to delete");
-
-                                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-                            }
-                        }
-
-                        bool CanTargetCondition_ByPreSelecetedList(List<Permanent> permanents, Permanent permanent)
-                        {
-                            if (permanentToDelete.Contains(permanent))
-                                return false;
-
-                            return true;
-                        }
-
-                        IEnumerator DigimonToDelete(Permanent permanent)
-                        {
-                            if (permanent != null)
-                                permanentToDelete.Add(permanent);
-
-                            yield return null;
-                        }
-
-                        if (permanentToDelete.Count > 0)
-                        {
-                            Hashtable _hashtable = new Hashtable();
-                            hashtable.Add("CardEffect", activateClass);
-                            yield return ContinuousController.instance.StartCoroutine(new DestroyPermanentsClass(permanentToDelete, _hashtable).Destroy());
-                        }
-                    }
-                }
-            }
-
             #endregion
 
             #region All Turns
-
             if (timing == EffectTiming.None)
             {
-                int count()
-                {
-                    if (CardEffectCommons.IsExistOnBattleArea(card))
-                    {
-                        return card.PermanentOfThisCard().DigivolutionCardsColors.Count;
-                    }
-
-                    return 0;
-                }
-
                 bool Condition()
                 {
-                    if (CardEffectCommons.IsExistOnBattleArea(card))
-                    {
-                        if (count() >= 1)
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
+                    return CardEffectCommons.IsExistOnBattleArea(card)
+                        && DigivolutionCardColors() >= 1;
                 }
 
-                cardEffects.Add(CardEffectFactory.ChangeSelfDPStaticEffect<Func<int>>(changeValue: () => 1000 * count(), isInheritedEffect: false, card: card, condition: Condition));
-            }
+                #region Amount of colors in this Digimon's digivolution cards
+                int DigivolutionCardColors()
+                {
+                    List<CardColor> cardColors = new List<CardColor>();
 
+                    foreach (CardSource source in card.PermanentOfThisCard().DigivolutionCards)
+                    {
+                        cardColors.AddRange(source.CardColors);
+                    }
+
+                    cardColors = cardColors.Distinct().ToList();
+
+                    return cardColors.Count;
+                }
+                #endregion
+
+                cardEffects.Add(CardEffectFactory.ChangeSelfDPStaticEffect<Func<int>>(changeValue: () => 1000 * DigivolutionCardColors(), isInheritedEffect: false, card: card, condition: Condition));
+            }
             #endregion
 
             return cardEffects;

--- a/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
+++ b/Assets/Scripts/CardEffect/EX9/White/EX9_074.cs
@@ -200,7 +200,6 @@ namespace DCGO.CardEffects.EX9
                 if (colours.Count >= 6 && CardEffectCommons.HasMatchConditionOpponentsPermanent(card, permanent => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)))
                 {
                     List<Permanent> permanentToDelete = new List<Permanent>();
-                    List<Permanent> isNotImmune = new List<Permanent>();
                     List<CardColor> selectableColors = new List<CardColor>();
 
                     foreach (string cardColor in DataBase.CardColorNameDictionary.Values)
@@ -284,19 +283,8 @@ namespace DCGO.CardEffects.EX9
 
                     if (permanentToDelete.Count > 0)
                     {
-                        foreach (Permanent permanent in permanentToDelete)
-                        {
-                            if (permanent.CanBeDestroyedBySkill(activateClass))
-                            {
-                                isNotImmune.Add(permanent);
-                            }
-                        }
-
-                        if (isNotImmune.Count > 0)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(
-                        new DestroyPermanentsClass(isNotImmune, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
-                        }
+                        yield return ContinuousController.instance.StartCoroutine(
+                            new DestroyPermanentsClass(permanentToDelete, CardEffectCommons.CardEffectHashtable(activateClass)).Destroy());
                     }
                 }
             }


### PR DESCRIPTION
Modernized card, shared OP/WD, changed deletion to not bypass immunities, changed color count method to new Susan method. We still have an issue that the 6+ deletion method is logically flawed in how you select targets.

Update: OK second commit has a method that might work for the 6+ deletion. Needs checking.