### PR TITLE
Implement BT26-103 Jupitermon: Wrath Mode

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Yellow.meta
+++ b/Assets/Scripts/CardEffect/BT26/Yellow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f0c6bed19b860843ba9eaca92be0974
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_103.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_103.cs
@@ -1,0 +1,157 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// Jupitermon: Wrath Mode
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_103 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.EqualsTraits("Olympos XII");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 5, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 6));
+            }
+            #endregion
+
+            #region Static Keywords
+            #region Piercing
+            if (timing == EffectTiming.OnDetermineDoSecurityCheck)
+            {
+                cardEffects.Add(CardEffectFactory.PierceSelfEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Reboot
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.RebootSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Succession
+            if (timing == EffectTiming.None)
+            {
+                bool CardCondition(CardSource cardSource) => cardSource.EqualsCardName("Jupitermon");
+
+                cardEffects.Add(CardEffectFactory.SuccessionSelfEffect(isInheritedEffect: false, card: card, condition: null, cardCondition: CardCondition));
+            }
+            #endregion
+            #endregion
+
+            #region Shared WD / Counter
+
+            string SharedEffectName = "Trash top security and <Recovery +2>";
+
+            string SharedHashString = "BT26_103_WD_Counter";
+
+            string SharedEffectDescription(string tag) => $"[{tag}] [Once Per Turn] Trash your top security card and <Recovery +2>.";
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                yield return ContinuousController.instance.StartCoroutine(new IDestroySecurity(
+                        player: card.Owner,
+                        destroySecurityCount: 1,
+                        cardEffect: activateClass,
+                        fromTop: true).DestroySecurity());
+
+                yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 2, activateClass).Recovery());
+            }
+
+            CardEffectFactory.ActivateClassesForSharedEffects
+                (ref cardEffects, timing, card,
+                    SharedEffectName,
+                    SharedActivateCoroutine,
+                    SharedEffectDescription,
+                    maxCountPerTurn: 1,
+                    hashValue: SharedHashString,
+                    optional: false,
+                    whenDigivolving: true,
+                    counter: true);
+
+            #endregion
+
+            #region All Turns
+            if (timing == EffectTiming.OnLoseSecurity)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Give an enemy Digimon -15k DP", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetHashString("BT26_103_AT");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "All Turns] [Once Per Turn] When security stacks are removed from, 1 of your opponent's Digimon gets -15000 DP until their turn ends.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                        && CardEffectCommons.CanTriggerWhenLoseSecurity(hashtable, (player) => player == card.Owner);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                }
+
+                bool IsOpponentsDigimon(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionPermanent(IsOpponentsDigimon))
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsOpponentsDigimon,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -15000.",
+                            "The opponent is selecting 1 Digimon that will get DP -15000.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(
+                                targetPermanent: permanent,
+                                changeValue: -15000,
+                                effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                                activateClass: activateClass));
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_103.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_103.cs
@@ -100,16 +100,16 @@ namespace DCGO.CardEffects.BT26
                 {
                     return "All Turns] [Once Per Turn] When security stacks are removed from, 1 of your opponent's Digimon gets -15000 DP until their turn ends.";
                 }
-
+                
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.CanTriggerWhenLoseSecurity(hashtable, (player) => player == card.Owner);
                 }
-
+                
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card);
+                    return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
                 }
 
                 bool IsOpponentsDigimon(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_103.cs.meta
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_103.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59c19ce70e5df494f8056e21009f07ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
@@ -9,8 +9,6 @@ public partial class CardEffectFactory
     /// from digivolution cards under this Permanent.
     /// </summary>
     public static AddSkillClass CopyDigivolutionCardEffects(
-        ref List<ICardEffect> cardEffects,
-        EffectTiming timing,
         CardSource card,
         bool isInheritedEffect = false,
         bool isLinkedEffect = false,
@@ -19,15 +17,10 @@ public partial class CardEffectFactory
         Func<Permanent, bool> permanentCondition = null,
         Func<CardSource, bool> cardSourceCondition = null,
         Func<CardSource, bool> cardCondition = null,
-        Func<ICardEffect, bool> effectCondition = null
+        Func<ICardEffect, bool> effectCondition = null,
+        bool isSuccession = false
         )
     {
-        
-        if (timing is not EffectTiming.None)
-        {
-            return null;
-        }
-
         bool DefaultCanUseCondition(Hashtable hashtable)
         {
             return CardEffectCommons.IsExistOnBattleArea(card);
@@ -64,7 +57,7 @@ public partial class CardEffectFactory
         cardSourceCondition ??= DefaultCardSourceCondition;
 
         AddSkillClass addSkillClass = new AddSkillClass();
-        addSkillClass.SetUpICardEffect("Copy Digivolution Card Effects", canUseCondition, card);
+        addSkillClass.SetUpICardEffect(isSuccession ? "Succession" : "Copy Digivolution Card Effects", canUseCondition, card);
         addSkillClass.SetIsInheritedEffect(isInheritedEffect);
         addSkillClass.SetIsLinkedEffect(isLinkedEffect);
 
@@ -144,7 +137,7 @@ public partial class CardEffectFactory
                             true,
                             activateClass));
                     }
-                    else
+                    else if (!isSuccession || cardEffect.EffectName != "Succession") // Succession can never copy another succession skill
                     {
                         getCardEffects.Add(cardEffect);
                         getCardEffects.Add(PermanentEffectFactory.AddDetailClass(
@@ -154,6 +147,9 @@ public partial class CardEffectFactory
                             cardEffect));
                     }
                 }
+                // If succession, break loop after first valid card to only copy topmost.
+                // break instead of return in case we ever need to perform more actions before returning
+                if (isSuccession) break; 
             }
 
             return getCardEffects;

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Succession.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Succession.cs
@@ -1,0 +1,19 @@
+public partial class CardEffectFactory
+{    
+    #region Trigger effect of [Succession] on oneself
+    public static ICardEffect SuccessionSelfEffect(bool isInheritedEffect, CardSource card, Func<bool> condition, Func<CardSource, bool> cardCondition, bool isLinkedEffect = false)
+    {
+        bool CanUseCondition(Hashtable hashtable)
+        {
+            return condition == null || condition();
+        }
+
+        return CopyDigivolutionCardEffects(card,
+                isInheritedEffect,
+                isLinkedEffect,
+                canUseCondition: CanUseCondition,
+                cardSourceCondition: cardCondition,
+                isSuccession: true);
+    }
+    #endregion
+}

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Succession.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Succession.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections;
+
 public partial class CardEffectFactory
 {    
     #region Trigger effect of [Succession] on oneself

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Succession.cs.meta
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Succession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 000907c45b4fc6641ab7408af77b87c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Built over https://github.com/DCGO2/DCGO/pull/1720 , We may want to merge that first but merging this would just close both

Succession does most of the special logic in the Copied effect factory method, in order to be most efficient it handles stopping after the topmost card there. The CEF Succession method is then mostly just a mapping from our usual Static Keyword format to the Copy factory.