### PR TITLE
OpT Effect ESS copy fix

### DIFF
--- a/Assets/Scripts/Script/CEntity_EffectController.cs
+++ b/Assets/Scripts/Script/CEntity_EffectController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -65,17 +65,31 @@ public class CEntity_EffectController : MonoBehaviour
 
                                     foreach (ICardEffect cardEffect in cardSource.cEntity_EffectController.cEntity_Effect.GetCardEffects(EffectTiming.None, permanent.TopCard))
                                     {
-                                        if (cardEffect is IAddSkillEffect)
+                                        if (cardEffect is IAddSkillEffect addCardEffect)
                                         {
                                             if (cardEffect.IsInheritedEffect == (cardSource == permanent.TopCard) || cardSource.IsFlipped)
                                             {
                                                 continue;
                                             }
 
-                                            if (((IAddSkillEffect)cardEffect).ShouldAddEffect(timing) && cardEffect.CanUse(null))
+                                            if (addCardEffect.ShouldAddEffect(timing) && cardEffect.CanUse(null))
                                             {
                                                 if (!card.CanNotBeAffected(cardEffect))
-                                                    GetCardEffects = ((IAddSkillEffect)cardEffect).GetCardEffect(card, GetCardEffects, timing);
+                                                {
+                                                    var SkillsToAdd = addCardEffect.GetCardEffect(card, GetCardEffects, timing);
+                                                    if (cardEffect.IsInheritedEffect)
+                                                    {
+                                                        foreach (var eff in SkillsToAdd)
+                                                        {
+                                                            if (eff.OriginalEffectSourceCard is not null)
+                                                            {
+                                                                eff.SetHashString(eff.HashString.Replace(permanent.TopCard.GetHashCode().ToString(), cardSource.GetHashCode().ToString()));
+                                                            }
+                                                        }
+                                                        cardEffect.SetOriginalEffectSourceCard(cardSource);
+                                                    }
+                                                    GetCardEffects = SkillsToAdd;
+                                                }
                                             }
                                         }
                                     }

--- a/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
@@ -85,7 +85,11 @@ public partial class CardEffectFactory
             foreach (CardSource cardSource in validSources(targetSources(sourceCard.PermanentOfThisCard().DigivolutionCards)))
             {
                 List<ICardEffect> toCopyEffects = cardSource.cEntity_EffectController.GetCardEffects_ExceptAddedEffects(_timing, sourceCard);
-                toCopyEffects.ForEach(eff => eff.SetOriginalEffectSourceCard(cardSource));
+                toCopyEffects.ForEach(eff =>
+                    {
+                        eff.SetOriginalEffectSourceCard(cardSource);
+                    }
+                );
                 toCopyEffects = toCopyEffects.Filter(
                     cardEffect => effectCondition == null || effectCondition(cardEffect)
                 );
@@ -167,9 +171,12 @@ public partial class CardEffectFactory
 
     private static string GenerateHashString(CardSource card, CardSource cardSource, string source, bool isInherited, bool isLinked)
     {
-        string sourceHashString = source ??= "";
-        string inherited = isInherited ? "-inherited" : "";
-        string linked = isLinked ? "-linked" : "";
-        return $"{card.CardIndex}-copying-{cardSource.CardIndex}-effect-{sourceHashString}{inherited}{linked}";
+        var sb = new System.Text.StringBuilder();
+        sb.Append(card is not null ? card.GetHashCode() : 0 );
+        sb.Append($"//copy//{cardSource.GetHashCode()}//effect");
+        sb.Append(source is not null && !source.Equals(string.Empty) ? $"//{source}" : "");
+        sb.Append(isInherited ? "//inherited" : "");
+        sb.Append(isLinked ? "//linked" : "");
+        return sb.ToString();
     }
 }


### PR DESCRIPTION
Affects mostly Gammamon's Ultimate/完全体 evos
~~Leaving as draft for further testing~~
Availability test now accounts for ultimate uniqueness (gammamon example) $\leftrightarrow$ multiple copy effects are now each unique while being source for the same permanent