### PR TITLE
Create BT26_001 Yokomon (+ new OnAddLibraryAnyone timing)

### DIFF
--- a/Assets/Scripts/CardEffect/BT10/White/BT10_086.cs
+++ b/Assets/Scripts/CardEffect/BT10/White/BT10_086.cs
@@ -308,7 +308,7 @@ namespace DCGO.CardEffects.BT10
                             returnedToLibrary = true;
 
                             yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(
-                                new List<CardSource>() { cardSource }));
+                                new List<CardSource>() { cardSource }, cardEffect: activateClass));
                         }
                     }
 
@@ -488,7 +488,7 @@ namespace DCGO.CardEffects.BT10
                         {
                             returnedToLibrary = true;
 
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { cardSource }));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { cardSource }, cardEffect: activateClass));
                         }
                     }
 

--- a/Assets/Scripts/CardEffect/BT12/Purple/BT12_110.cs
+++ b/Assets/Scripts/CardEffect/BT12/Purple/BT12_110.cs
@@ -67,7 +67,7 @@ namespace DCGO.CardEffects.BT12
                     {
                         List<CardSource> cardSources = new List<CardSource>() { card };
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "", true, true));
 

--- a/Assets/Scripts/CardEffect/BT12/White/BT12_112.cs
+++ b/Assets/Scripts/CardEffect/BT12/White/BT12_112.cs
@@ -327,7 +327,7 @@ namespace DCGO.CardEffects.BT12
 
                                     if (libraryCards.Count >= 1)
                                     {
-                                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(libraryCards));
+                                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(libraryCards, cardEffect: activateClass));
 
                                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(libraryCards, "Deck Bottom Cards", true, true));
                                     }

--- a/Assets/Scripts/CardEffect/BT13/Blue/BT13_028.cs
+++ b/Assets/Scripts/CardEffect/BT13/Blue/BT13_028.cs
@@ -293,7 +293,7 @@ namespace DCGO.CardEffects.BT13
                         {
                             if (cardSources.Count == 3)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/BT13/Blue/BT13_033.cs
+++ b/Assets/Scripts/CardEffect/BT13/Blue/BT13_033.cs
@@ -258,7 +258,7 @@ namespace DCGO.CardEffects.BT13
 
                                     yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(
                                         cardSources,
-                                        notAddLog: card.Owner.isYou));
+                                        notAddLog: card.Owner.isYou, cardEffect: activateClass));
 
                                     foreach (CardSource cardSource in cardSources)
                                     {

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_080.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_080.cs
@@ -471,7 +471,7 @@ namespace DCGO.CardEffects.BT13
                         {
                             if (cardSources.Count == 2)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_083.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_083.cs
@@ -466,7 +466,7 @@ namespace DCGO.CardEffects.BT13
                         {
                             if (cardSources.Count == 2)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/BT13/Purple/BT13_092.cs
+++ b/Assets/Scripts/CardEffect/BT13/Purple/BT13_092.cs
@@ -270,7 +270,7 @@ namespace DCGO.CardEffects.BT13
                         {
                             CardSource returnedCard = cardSources[0];
 
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/BT14/Black/BT14_005.cs
+++ b/Assets/Scripts/CardEffect/BT14/Black/BT14_005.cs
@@ -94,7 +94,7 @@ namespace DCGO.CardEffects.BT14
                             {
                                 cardSources.Reverse();
 
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                                 if (CardEffectCommons.IsExistOnBattleArea(card))
                                 {

--- a/Assets/Scripts/CardEffect/BT14/Black/BT14_061.cs
+++ b/Assets/Scripts/CardEffect/BT14/Black/BT14_061.cs
@@ -80,7 +80,7 @@ namespace DCGO.CardEffects.BT14
                         {
                             if (cardSources.Count == 1)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Top Cards", true, true));
 
@@ -161,7 +161,7 @@ namespace DCGO.CardEffects.BT14
                         {
                             if (cardSources.Count == 1)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Top Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/BT14/Black/BT14_098.cs
+++ b/Assets/Scripts/CardEffect/BT14/Black/BT14_098.cs
@@ -135,7 +135,7 @@ namespace DCGO.CardEffects.BT14
                             {
                                 cardSources.Reverse();
 
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
                                 returned = true;
                             }
                         }

--- a/Assets/Scripts/CardEffect/BT15/Purple/BT15_100.cs
+++ b/Assets/Scripts/CardEffect/BT15/Purple/BT15_100.cs
@@ -94,7 +94,7 @@ namespace DCGO.CardEffects.BT15
                     {
                         List<CardSource> cardSources = new List<CardSource>() { card };
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/BT16/Black/BT16_054.cs
+++ b/Assets/Scripts/CardEffect/BT16/Black/BT16_054.cs
@@ -100,7 +100,7 @@ namespace DCGO.CardEffects.BT16
                     {
                         cardSources.Reverse();
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                         if (CardEffectCommons.IsExistOnBattleArea(card))
                         {
@@ -180,7 +180,7 @@ namespace DCGO.CardEffects.BT16
                     {
                         cardSources.Reverse();
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                         if (CardEffectCommons.IsExistOnBattleArea(card))
                         {

--- a/Assets/Scripts/CardEffect/BT16/Black/BT16_065.cs
+++ b/Assets/Scripts/CardEffect/BT16/Black/BT16_065.cs
@@ -139,7 +139,7 @@ namespace DCGO.CardEffects.BT16
                         if (selectedCards.Count == 6)
                         {
                             selectedCards.Reverse();
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards, cardEffect: activateClass));
                         }
                     }
 

--- a/Assets/Scripts/CardEffect/BT16/White/BT16_083.cs
+++ b/Assets/Scripts/CardEffect/BT16/White/BT16_083.cs
@@ -286,7 +286,7 @@ namespace DCGO.CardEffects.BT16
                         {
                             if (cardSources.Count == 1)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Digi-Egg deck Bottom Cards", true, true));
                             }

--- a/Assets/Scripts/CardEffect/BT17/Black/BT17_060.cs
+++ b/Assets/Scripts/CardEffect/BT17/Black/BT17_060.cs
@@ -332,7 +332,7 @@ namespace DCGO.CardEffects.BT17
                             {
                                 selectedCards = sources.Clone();
                                 selectedCards.Reverse();
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards, cardEffect: activateClass));
                             }
                         }
 

--- a/Assets/Scripts/CardEffect/BT17/Purple/BT17_068.cs
+++ b/Assets/Scripts/CardEffect/BT17/Purple/BT17_068.cs
@@ -115,7 +115,7 @@ namespace DCGO.CardEffects.BT17
                             if (cardSources.Count == 1)
                             {
                                 yield return ContinuousController.instance.StartCoroutine(
-                                    CardObjectController.AddLibraryBottomCards(cardSources));
+                                    CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>()
                                     .ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));

--- a/Assets/Scripts/CardEffect/BT17/Purple/BT17_070.cs
+++ b/Assets/Scripts/CardEffect/BT17/Purple/BT17_070.cs
@@ -420,7 +420,7 @@ namespace DCGO.CardEffects.BT17
                             if (cardSources.Count == 7)
                             {
                                 yield return ContinuousController.instance.StartCoroutine(
-                                    CardObjectController.AddLibraryBottomCards(cardSources));
+                                    CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>()
                                     .ShowCardEffect(cardSources, "Deck Bottom Card", true, true));

--- a/Assets/Scripts/CardEffect/BT17/White/BT17_077.cs
+++ b/Assets/Scripts/CardEffect/BT17/White/BT17_077.cs
@@ -180,7 +180,7 @@ namespace DCGO.CardEffects.BT17
                     {
                         if (returnedSources.Count == 1)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(returnedSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(returnedSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(returnedSources, "Deck Bottom Cards", true, true));
                         }
@@ -215,7 +215,7 @@ namespace DCGO.CardEffects.BT17
 
                             IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Cards", true, true));
                             }
@@ -283,7 +283,7 @@ namespace DCGO.CardEffects.BT17
                     {
                         if (returnedSources.Count == 1)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(returnedSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(returnedSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(returnedSources, "Deck Bottom Cards", true, true));
                         }
@@ -318,7 +318,7 @@ namespace DCGO.CardEffects.BT17
 
                             IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Cards", true, true));
                             }

--- a/Assets/Scripts/CardEffect/BT18/Red/BT18_019.cs
+++ b/Assets/Scripts/CardEffect/BT18/Red/BT18_019.cs
@@ -218,7 +218,7 @@ namespace DCGO.CardEffects.BT18
                         {
                             sources.Reverse();
 
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(sources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(sources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(card.Owner.AddMemory(1 * sources.Count, activateClass));
                         }
@@ -338,7 +338,7 @@ namespace DCGO.CardEffects.BT18
                     {
                         if (cardSources.Count == 2)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/BT18/Yellow/BT18_033.cs
+++ b/Assets/Scripts/CardEffect/BT18/Yellow/BT18_033.cs
@@ -102,7 +102,7 @@ namespace DCGO.CardEffects.BT18
                         {
                             if (cardSources.Count == 1)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/BT19/Purple/BT19_074.cs
+++ b/Assets/Scripts/CardEffect/BT19/Purple/BT19_074.cs
@@ -305,7 +305,7 @@ namespace DCGO.CardEffects.BT19
                         {
                             cardSources.Reverse();
 
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                             if (card.Owner.Enemy.SecurityCards.Count >= 1)
                             {

--- a/Assets/Scripts/CardEffect/BT19/Red/BT19_101.cs
+++ b/Assets/Scripts/CardEffect/BT19/Red/BT19_101.cs
@@ -110,7 +110,7 @@ namespace DCGO.CardEffects.BT19
                         {
                             if (cardSources.Count == 1)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Top Cards", true, true));
 
@@ -227,7 +227,7 @@ namespace DCGO.CardEffects.BT19
                         {
                             if (cardSources.Count == 1)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Top Cards", true, true));
 
@@ -344,7 +344,7 @@ namespace DCGO.CardEffects.BT19
                         {
                             if (cardSources.Count == 1)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Top Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/BT19/Yellow/BT19_094.cs
+++ b/Assets/Scripts/CardEffect/BT19/Yellow/BT19_094.cs
@@ -61,7 +61,7 @@ namespace DCGO.CardEffects.BT19
                     {
                         List<CardSource> cardSources = new List<CardSource>() { card };
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_082.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_082.cs
@@ -98,7 +98,7 @@ namespace DCGO.CardEffects.BT20
                     {
                         if (cardSources.Count == 3)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_096.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_096.cs
@@ -60,7 +60,7 @@ namespace DCGO.CardEffects.BT20
 
                         List<CardSource> cardSources = new List<CardSource>() { card };
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/BT20/Purple/BT20_098.cs
+++ b/Assets/Scripts/CardEffect/BT20/Purple/BT20_098.cs
@@ -113,7 +113,7 @@ namespace DCGO.CardEffects.BT20
                             // Return opponent's cards from trash to the bottom of their deck
 
                             yield return ContinuousController.instance.StartCoroutine(
-                                CardObjectController.AddLibraryBottomCards(selectedCardsToReturn));
+                                CardObjectController.AddLibraryBottomCards(selectedCardsToReturn, cardEffect: activateClass));
 
                             // For each returned card, choose a card from your trash with the same level, then play them
 

--- a/Assets/Scripts/CardEffect/BT23/Black/BT23_057.cs
+++ b/Assets/Scripts/CardEffect/BT23/Black/BT23_057.cs
@@ -133,7 +133,7 @@ namespace DCGO.CardEffects.BT23
                         if (selectedCards.Count == 3)
                         {
                             selectedCards.Reverse();
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards, cardEffect: activateClass));
                         }
                     }
 

--- a/Assets/Scripts/CardEffect/BT23/Purple/BT23_097.cs
+++ b/Assets/Scripts/CardEffect/BT23/Purple/BT23_097.cs
@@ -45,7 +45,7 @@ namespace DCGO.CardEffects.BT23
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
                     List<CardSource> cardSources = new List<CardSource>() { card };
-                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Card", true, true));
 
                     if (card.Owner.LibraryCards.Contains(card))

--- a/Assets/Scripts/CardEffect/BT23/Red/BT23_015.cs
+++ b/Assets/Scripts/CardEffect/BT23/Red/BT23_015.cs
@@ -295,7 +295,7 @@ namespace DCGO.CardEffects.BT23
 
                     if (selectedCards.Any())
                     {
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards, cardEffect: activateClass));
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(selectedCards, "Deck Bottom Cards", true, true));
                     }
                 }

--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_096.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_096.cs
@@ -45,7 +45,7 @@ namespace DCGO.CardEffects.BT24
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
                     List<CardSource> cardSources = new List<CardSource>() { card };
-                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Card", true, true));
 
                     if (card.Owner.LibraryCards.Contains(card))

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_001.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_001.cs
@@ -23,16 +23,13 @@ namespace DCGO.CardEffects.BT26
                 string EffectDescription()
                     => "[Your Turn] [Once Per Turn] When your effects add to decks, this Digimon may digivolve into a Digimon card with [Chronomon] in its text in the hand with the cost reduced by 1.";
 
-                // Approximates "your effects" by checking who owns the returned card, since
-                // AddLibraryTopCards/BottomCards don't carry which player's effect caused the
-                // move (same limitation the existing OnReturnCardsToLibraryFromTrash timing has).
-                bool CardSourceCondition(CardSource cardSource)
-                    => cardSource.Owner == card.Owner;
+                bool CardEffectCondition(ICardEffect cardEffect)
+                    => CardEffectCommons.IsOwnerEffect(cardEffect, card);
 
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card)
-                        && CardEffectCommons.CanTriggerOnAddLibrary(hashtable, CardSourceCondition);
+                        && CardEffectCommons.CanTriggerOnAddLibrary(hashtable, null, CardEffectCondition);
 
                 bool CanActivateCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
@@ -46,7 +43,7 @@ namespace DCGO.CardEffects.BT26
                         targetPermanent: card.PermanentOfThisCard(),
                         cardCondition: CardCondition,
                         payCost: true,
-                        reduceCostTuple: (1, CardCondition),
+                        reduceCostTuple: (1, null),
                         fixedCostTuple: null,
                         ignoreDigivolutionRequirementFixedCost: -1,
                         isHand: true,

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_001.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_001.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Yokomon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_001 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Inherit
+            if (timing == EffectTiming.OnAddLibraryAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Digivolve into [Chronomon] card in hand, cost -1", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("BT26_001_Inherit");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Your Turn] [Once Per Turn] When your effects add to decks, this Digimon may digivolve into a Digimon card with [Chronomon] in its text in the hand with the cost reduced by 1.";
+
+                bool CardSourceCondition(CardSource cardSource)
+                    => cardSource.Owner == card.Owner;
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.IsOwnerTurn(card)
+                        && CardEffectCommons.CanTriggerOnAddLibrary(hashtable, CardSourceCondition);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                bool CardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon && cardSource.HasText("Chronomon");
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                        targetPermanent: card.PermanentOfThisCard(),
+                        cardCondition: CardCondition,
+                        payCost: true,
+                        reduceCostTuple: (1, CardCondition),
+                        fixedCostTuple: null,
+                        ignoreDigivolutionRequirementFixedCost: -1,
+                        isHand: true,
+                        activateClass: activateClass,
+                        successProcess: null,
+                        isOptional: true));
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_001.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_001.cs
@@ -23,6 +23,9 @@ namespace DCGO.CardEffects.BT26
                 string EffectDescription()
                     => "[Your Turn] [Once Per Turn] When your effects add to decks, this Digimon may digivolve into a Digimon card with [Chronomon] in its text in the hand with the cost reduced by 1.";
 
+                // Approximates "your effects" by checking who owns the returned card, since
+                // AddLibraryTopCards/BottomCards don't carry which player's effect caused the
+                // move (same limitation the existing OnReturnCardsToLibraryFromTrash timing has).
                 bool CardSourceCondition(CardSource cardSource)
                     => cardSource.Owner == card.Owner;
 

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_009.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_009.cs
@@ -135,7 +135,7 @@ namespace DCGO.CardEffects.BT26
                         {
                             if (cardSources.Count >= 1)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
                             }
                         }
 

--- a/Assets/Scripts/CardEffect/BT4/Black/BT4_074.cs
+++ b/Assets/Scripts/CardEffect/BT4/Black/BT4_074.cs
@@ -120,7 +120,7 @@ public class BT4_074 : CEntity_Effect
                     {
                         selectedCards.Reverse();
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards, cardEffect: activateClass));
 
                         yield return ContinuousController.instance.StartCoroutine(card.Owner.AddMemory(2 * selectedCards.Count, activateClass));
                     }

--- a/Assets/Scripts/CardEffect/BT4/Green/BT4_095.cs
+++ b/Assets/Scripts/CardEffect/BT4/Green/BT4_095.cs
@@ -83,7 +83,7 @@ public class BT4_095 : CEntity_Effect
                     IEnumerator SelectCardCoroutine(CardSource cardSource)
                     {
                         yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(
-                            new List<CardSource>() { cardSource }));
+                            new List<CardSource>() { cardSource }, cardEffect: activateClass));
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT7/Red/BT7_015.cs
+++ b/Assets/Scripts/CardEffect/BT7/Red/BT7_015.cs
@@ -277,7 +277,7 @@ public class BT7_015 : CEntity_Effect
 
                                         if (libraryBottomCards.Count >= 1)
                                         {
-                                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(libraryBottomCards));
+                                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(libraryBottomCards, cardEffect: activateClass));
 
                                             if (!player.isYou)
                                             {

--- a/Assets/Scripts/CardEffect/BT8/Black/BT8_065.cs
+++ b/Assets/Scripts/CardEffect/BT8/Black/BT8_065.cs
@@ -164,7 +164,7 @@ public class BT8_065 : CEntity_Effect
                     {
                         if (libraryCards.Count == 1)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(libraryCards));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(libraryCards, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(
                                 libraryCards,
@@ -204,7 +204,7 @@ public class BT8_065 : CEntity_Effect
                             {
                                 cardSources.Reverse();
 
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/BT8/White/BT8_112.cs
+++ b/Assets/Scripts/CardEffect/BT8/White/BT8_112.cs
@@ -105,7 +105,7 @@ public class BT8_112 : CEntity_Effect
                     IEnumerator SelectCardCoroutine(CardSource cardSource)
                     {
                         yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(
-                            new List<CardSource>() { cardSource }));
+                            new List<CardSource>() { cardSource }, cardEffect: activateClass));
                     }
 
                     IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)

--- a/Assets/Scripts/CardEffect/BT9/White/BT9_083.cs
+++ b/Assets/Scripts/CardEffect/BT9/White/BT9_083.cs
@@ -110,7 +110,7 @@ public class BT9_083 : CEntity_Effect
                         {
                             List<CardSource> libraryCards = card.Owner.Enemy.TrashCards.Clone();
 
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(libraryCards));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(libraryCards, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(libraryCards, "Deck Bottom Cards", true, true));
                         }
@@ -146,7 +146,7 @@ public class BT9_083 : CEntity_Effect
 
                             IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Cards", true, true));
                             }

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_071.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_071.cs
@@ -162,7 +162,7 @@ namespace DCGO.CardEffects.EX10
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { card }));
+                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { card }, cardEffect: activateClass));
 
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(new List<CardSource>() { card }, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/EX10/Purple/EX10_074.cs
+++ b/Assets/Scripts/CardEffect/EX10/Purple/EX10_074.cs
@@ -201,7 +201,7 @@ namespace DCGO.CardEffects.EX10
                         if (selectedCards.Count == 2)
                         {
                             selectedCards.Reverse();
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards, cardEffect: activateClass));
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Top Cards", true, true));
                             cardsAdded = true;
                         }

--- a/Assets/Scripts/CardEffect/EX10/White/EX10_068.cs
+++ b/Assets/Scripts/CardEffect/EX10/White/EX10_068.cs
@@ -173,7 +173,7 @@ namespace DCGO.CardEffects.EX10
 
                         if (selectedCards.Count > 0)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(selectedCards, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/EX11/Red/EX11_012.cs
+++ b/Assets/Scripts/CardEffect/EX11/Red/EX11_012.cs
@@ -91,7 +91,7 @@ namespace DCGO.CardEffects.EX11
 
                     IEnumerator SelectCardCoroutine(CardSource cardSource)
                     {
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { cardSource }));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { cardSource }, cardEffect: activateClass));
 
                         yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPetrificationToken(activateClass));
                     }

--- a/Assets/Scripts/CardEffect/EX12/Blue/EX12_030.cs
+++ b/Assets/Scripts/CardEffect/EX12/Blue/EX12_030.cs
@@ -217,7 +217,7 @@ namespace DCGO.CardEffects.EX12
 
                             cardSources.Reverse();
 
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             string selectPlayerMessage = "Will you unsuspend this card?";
                             string notSelectPlayerMessage = "The opponent is choosing if they will unsuspend.";

--- a/Assets/Scripts/CardEffect/EX3/Black/EX3_054.cs
+++ b/Assets/Scripts/CardEffect/EX3/Black/EX3_054.cs
@@ -104,7 +104,7 @@ namespace DCGO.CardEffects.EX3
                             {
                                 cardSources.Reverse();
 
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                                 int minusCount = cardSources.Count;
 

--- a/Assets/Scripts/CardEffect/EX3/Yellow/EX3_035.cs
+++ b/Assets/Scripts/CardEffect/EX3/Yellow/EX3_035.cs
@@ -326,7 +326,7 @@ namespace DCGO.CardEffects.EX3
                                         {
                                             if (cardSources.Count == 3)
                                             {
-                                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/EX5/Blue/EX5_015.cs
+++ b/Assets/Scripts/CardEffect/EX5/Blue/EX5_015.cs
@@ -315,7 +315,7 @@ namespace DCGO.CardEffects.EX5
                         {
                             if (cardSources.Count == 2)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/EX5/Blue/EX5_018.cs
+++ b/Assets/Scripts/CardEffect/EX5/Blue/EX5_018.cs
@@ -195,7 +195,7 @@ namespace DCGO.CardEffects.EX5
                         {
                             if (cardSources.Count == 2)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/EX5/Blue/EX5_026.cs
+++ b/Assets/Scripts/CardEffect/EX5/Blue/EX5_026.cs
@@ -225,7 +225,7 @@ public class EX5_026 : CEntity_Effect
                     {
                         if (cardSources.Count == 1)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/EX5/Yellow/EX5_074.cs
+++ b/Assets/Scripts/CardEffect/EX5/Yellow/EX5_074.cs
@@ -130,7 +130,7 @@ public class EX5_074 : CEntity_Effect
                     {
                         if (cardSources.Count >= 1)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 
@@ -247,7 +247,7 @@ public class EX5_074 : CEntity_Effect
                     {
                         if (cardSources.Count >= 1)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/EX6/Purple/EX6_054.cs
+++ b/Assets/Scripts/CardEffect/EX6/Purple/EX6_054.cs
@@ -372,7 +372,7 @@ namespace DCGO.CardEffects.EX6
 
                             IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Cards", true, true));
 
@@ -453,7 +453,7 @@ namespace DCGO.CardEffects.EX6
 
                             IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/EX7/Black/EX7_043.cs
+++ b/Assets/Scripts/CardEffect/EX7/Black/EX7_043.cs
@@ -173,7 +173,7 @@ namespace DCGO.CardEffects.EX7
                         cardSources.Reverse();
 
                         yield return ContinuousController.instance.StartCoroutine(
-                            CardObjectController.AddLibraryTopCards(cardSources));
+                            CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
 
                         if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentSharedCondition))
                         {

--- a/Assets/Scripts/CardEffect/EX7/Purple/EX7_072.cs
+++ b/Assets/Scripts/CardEffect/EX7/Purple/EX7_072.cs
@@ -46,7 +46,7 @@ namespace DCGO.CardEffects.EX7
                 {
                     List<CardSource> cardSources = new List<CardSource>() { card };
 
-                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/EX8/Purple/EX8_072.cs
+++ b/Assets/Scripts/CardEffect/EX8/Purple/EX8_072.cs
@@ -68,7 +68,7 @@ namespace DCGO.CardEffects.EX8
                     {
                         List<CardSource> cardSources = new List<CardSource>() { card };
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Bottom Card", true, true));
 

--- a/Assets/Scripts/CardEffect/EX9/Black/EX9_057.cs
+++ b/Assets/Scripts/CardEffect/EX9/Black/EX9_057.cs
@@ -145,7 +145,7 @@ namespace DCGO.CardEffects.EX9
 
                         if (willReturn)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(negamonCards));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(negamonCards, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(negamonCards, "Digi-Egg deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/LM/Black/LM_031.cs
+++ b/Assets/Scripts/CardEffect/LM/Black/LM_031.cs
@@ -189,7 +189,7 @@ namespace DCGO.CardEffects.LM
                             {
                                 if (cardSources.Count == 1)
                                 {
-                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
                                 }
                             }
                         }

--- a/Assets/Scripts/CardEffect/LM/Blue/LM_005.cs
+++ b/Assets/Scripts/CardEffect/LM/Blue/LM_005.cs
@@ -338,7 +338,7 @@ namespace DCGO.CardEffects.LM
                         {
                             if (cardSources.Count == 3)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/LM/Blue/LM_028.cs
+++ b/Assets/Scripts/CardEffect/LM/Blue/LM_028.cs
@@ -189,7 +189,7 @@ namespace DCGO.CardEffects.LM
                             {
                                 if (cardSources.Count == 1)
                                 {
-                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
                                 }
                             }
                         }

--- a/Assets/Scripts/CardEffect/LM/Green/LM_030.cs
+++ b/Assets/Scripts/CardEffect/LM/Green/LM_030.cs
@@ -189,7 +189,7 @@ namespace DCGO.CardEffects.LM
                             {
                                 if (cardSources.Count == 1)
                                 {
-                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
                                 }
                             }
                         }

--- a/Assets/Scripts/CardEffect/LM/Purple/LM_032.cs
+++ b/Assets/Scripts/CardEffect/LM/Purple/LM_032.cs
@@ -189,7 +189,7 @@ namespace DCGO.CardEffects.LM
                             {
                                 if (cardSources.Count == 1)
                                 {
-                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
                                 }
                             }
                         }

--- a/Assets/Scripts/CardEffect/LM/Red/LM_027.cs
+++ b/Assets/Scripts/CardEffect/LM/Red/LM_027.cs
@@ -189,7 +189,7 @@ namespace DCGO.CardEffects.LM
                             {
                                 if (cardSources.Count == 1)
                                 {
-                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
                                 }
                             }
                         }

--- a/Assets/Scripts/CardEffect/LM/Yellow/LM_020.cs
+++ b/Assets/Scripts/CardEffect/LM/Yellow/LM_020.cs
@@ -140,7 +140,7 @@ namespace DCGO.CardEffects.LM
 
                             if (selectedCard != null)
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(new List<CardSource>() { selectedCard }));
+                                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(new List<CardSource>() { selectedCard }, cardEffect: activateClass));
                             }
 
                             ContinuousController.instance.PlaySE(GManager.instance.ShuffleSE);

--- a/Assets/Scripts/CardEffect/LM/Yellow/LM_029.cs
+++ b/Assets/Scripts/CardEffect/LM/Yellow/LM_029.cs
@@ -189,7 +189,7 @@ namespace DCGO.CardEffects.LM
                             {
                                 if (cardSources.Count == 1)
                                 {
-                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources));
+                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardSources, cardEffect: activateClass));
                                 }
                             }
                         }

--- a/Assets/Scripts/CardEffect/P/Black/P_243.cs
+++ b/Assets/Scripts/CardEffect/P/Black/P_243.cs
@@ -159,7 +159,7 @@ namespace DCGO.CardEffects.P
                             {
                                 if (selectedCards.Count == 1)
                                 {
-                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards));
+                                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(selectedCards, cardEffect: activateClass));
                                     yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Top Cards", true, true));
                                     cardsAdded = true;
                                 }

--- a/Assets/Scripts/CardEffect/P/Blue/P_011.cs
+++ b/Assets/Scripts/CardEffect/P/Blue/P_011.cs
@@ -137,7 +137,7 @@ public class P_011 : CEntity_Effect
                     {
                         if (cardSources.Count == 3)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/P/Blue/P_047.cs
+++ b/Assets/Scripts/CardEffect/P/Blue/P_047.cs
@@ -131,7 +131,7 @@ public class P_047 : CEntity_Effect
                     {
                         if (cardSources.Count == 3)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/P/Blue/P_048.cs
+++ b/Assets/Scripts/CardEffect/P/Blue/P_048.cs
@@ -96,7 +96,7 @@ public class P_048 : CEntity_Effect
                     {
                         if (cardSources.Count == 3)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/P/Blue/P_089.cs
+++ b/Assets/Scripts/CardEffect/P/Blue/P_089.cs
@@ -292,7 +292,7 @@ public class P_089 : CEntity_Effect
                     {
                         if (cardSources.Count == 3)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/P/Red/P_170.cs
+++ b/Assets/Scripts/CardEffect/P/Red/P_170.cs
@@ -124,7 +124,7 @@ namespace DCGO.CardEffects.P
                         if (selectedCards.Count == 3)
                         {
                             selectedCards.Reverse();
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards, cardEffect: activateClass));
                         }
                     }
 

--- a/Assets/Scripts/CardEffect/P/Yellow/P_043.cs
+++ b/Assets/Scripts/CardEffect/P/Yellow/P_043.cs
@@ -85,7 +85,7 @@ public class P_043 : CEntity_Effect
                     {
                         if (cardSources.Count == 1)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/RB1/Blue/RB1_014.cs
+++ b/Assets/Scripts/CardEffect/RB1/Blue/RB1_014.cs
@@ -274,7 +274,7 @@ public class RB1_014 : CEntity_Effect
                     {
                         if (cardSources.Count == 3)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/RB1/Blue/RB1_016.cs
+++ b/Assets/Scripts/CardEffect/RB1/Blue/RB1_016.cs
@@ -401,7 +401,7 @@ public class RB1_016 : CEntity_Effect
                     {
                         if (cardSources.Count == 3)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/CardEffect/RB1/Purple/RB1_028.cs
+++ b/Assets/Scripts/CardEffect/RB1/Purple/RB1_028.cs
@@ -88,7 +88,7 @@ public class RB1_028 : CEntity_Effect
                     {
                         if (cardSources.Count == 1)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect(cardSources, "Deck Bottom Cards", true, true));
 

--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -2436,7 +2436,7 @@ public class DeckBottomBounceClass
             DeckBouncedPermanents.Add(permanent);
         }
 
-        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(deckBottomCards));
+        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(deckBottomCards, cardEffect: cardEffect));
 
         #endregion
 
@@ -2602,7 +2602,7 @@ public class DeckTopBounceClass
             DeckBouncedPermanents.Add(permanent);
         }
 
-        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(deckTopCards));
+        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(deckTopCards, cardEffect: cardEffect));
 
         #endregion
 
@@ -2833,7 +2833,7 @@ public class HandBounceClaass
             }
             else
             {
-                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { topCard }));
+                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { topCard }, cardEffect: cardEffect));
             }
         }
 
@@ -3673,7 +3673,7 @@ public class IPutSecurityPermanent
             }
             else
             {
-                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { topCard }));
+                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource>() { topCard }, cardEffect: cardEffect));
             }
         }
 
@@ -5449,7 +5449,7 @@ public class ReturnToLibraryBottomDigivolutionCardsClass
 
         #endregion
 
-        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(_cardSources));
+        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(_cardSources, cardEffect: CardEffect));
     }
 }
 

--- a/Assets/Scripts/Script/CardEffectCommons/CanUseEffects/OnAddLibrary.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/CanUseEffects/OnAddLibrary.cs
@@ -9,42 +9,20 @@ public partial class CardEffectCommons
     #region Can trigger "When cards are added to the library" effect, regardless of origin
     public static bool CanTriggerOnAddLibrary(Hashtable hashtable, Func<CardSource, bool> cardCondition)
     {
-        if (hashtable != null)
+        List<CardSource> CardSources = GetCardSourcesFromHashtable(hashtable);
+
+        if (CardSources != null)
         {
-            if (hashtable.ContainsKey("CardSources"))
+            if (CardSources.Some(cardSource =>
+                cardSource != null
+                && !cardSource.IsBeingRevealed
+                && (cardCondition == null || cardCondition(cardSource))))
             {
-                if (hashtable["CardSources"] is List<CardSource> CardSources)
-                {
-                    if (CardSources != null)
-                    {
-                        if (CardSources.Some(cardSource => cardCondition == null || cardCondition(cardSource)))
-                        {
-                            return true;
-                        }
-                    }
-                }
+                return true;
             }
         }
 
         return false;
-    }
-    #endregion
-
-    #region The CardSources added to the library from an OnAddLibraryAnyone hashtable
-    public static List<CardSource> GetCardSourcesFromAddLibraryHashtable(Hashtable hashtable)
-    {
-        if (hashtable != null)
-        {
-            if (hashtable.ContainsKey("CardSources"))
-            {
-                if (hashtable["CardSources"] is List<CardSource> CardSources)
-                {
-                    return CardSources;
-                }
-            }
-        }
-
-        return null;
     }
     #endregion
 

--- a/Assets/Scripts/Script/CardEffectCommons/CanUseEffects/OnAddLibrary.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/CanUseEffects/OnAddLibrary.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using System.Collections.Generic;
+using System;
+using System.Linq;
+using UnityEngine;
+
+public partial class CardEffectCommons
+{
+    #region Can trigger "When cards are added to the library" effect, regardless of origin
+    public static bool CanTriggerOnAddLibrary(Hashtable hashtable, Func<CardSource, bool> cardCondition)
+    {
+        if (hashtable != null)
+        {
+            if (hashtable.ContainsKey("CardSources"))
+            {
+                if (hashtable["CardSources"] is List<CardSource> CardSources)
+                {
+                    if (CardSources != null)
+                    {
+                        if (CardSources.Some(cardSource => cardCondition == null || cardCondition(cardSource)))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+    #endregion
+
+    #region The CardSources added to the library from an OnAddLibraryAnyone hashtable
+    public static List<CardSource> GetCardSourcesFromAddLibraryHashtable(Hashtable hashtable)
+    {
+        if (hashtable != null)
+        {
+            if (hashtable.ContainsKey("CardSources"))
+            {
+                if (hashtable["CardSources"] is List<CardSource> CardSources)
+                {
+                    return CardSources;
+                }
+            }
+        }
+
+        return null;
+    }
+    #endregion
+
+    #region Whether the OnAddLibraryAnyone hashtable was for the top or bottom of the library
+    public static bool IsAddLibraryTop(Hashtable hashtable)
+    {
+        if (hashtable != null)
+        {
+            if (hashtable.ContainsKey("IsTop"))
+            {
+                if (hashtable["IsTop"] is bool IsTop)
+                {
+                    return IsTop;
+                }
+            }
+        }
+
+        return false;
+    }
+    #endregion
+}

--- a/Assets/Scripts/Script/CardEffectCommons/CanUseEffects/OnAddLibrary.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/CanUseEffects/OnAddLibrary.cs
@@ -9,10 +9,25 @@ public partial class CardEffectCommons
     #region Can trigger "When cards are added to the library" effect, regardless of origin
     public static bool CanTriggerOnAddLibrary(Hashtable hashtable, Func<CardSource, bool> cardCondition)
     {
+        return CanTriggerOnAddLibrary(hashtable, cardCondition, null);
+    }
+
+    public static bool CanTriggerOnAddLibrary(Hashtable hashtable, Func<CardSource, bool> cardCondition, Func<ICardEffect, bool> cardEffectCondition)
+    {
         List<CardSource> CardSources = GetCardSourcesFromHashtable(hashtable);
 
         if (CardSources != null)
         {
+            if (cardEffectCondition != null)
+            {
+                ICardEffect CardEffect = GetCardEffectFromHashtable(hashtable);
+
+                if (CardEffect == null || !cardEffectCondition(CardEffect))
+                {
+                    return false;
+                }
+            }
+
             if (CardSources.Some(cardSource =>
                 cardSource != null
                 && !cardSource.IsBeingRevealed

--- a/Assets/Scripts/Script/CardEffectCommons/RevealLibrary.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/RevealLibrary.cs
@@ -477,7 +477,7 @@ public partial class CardEffectCommons
 
         if (remainingCards.Count == 1)
         {
-            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(remainingCards));
+            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(remainingCards, cardEffect: activateClass));
 
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(remainingCards, "Deck Bottom Card", true, true));
         }
@@ -511,9 +511,9 @@ public partial class CardEffectCommons
 
             yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
 
-            static IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
+            IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
             {
-                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources, cardEffect: activateClass));
 
                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources,
                 "Deck Bottom Cards", true, true));
@@ -534,7 +534,7 @@ public partial class CardEffectCommons
 
         if (remainingCards.Count == 1)
         {
-            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(remainingCards));
+            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(remainingCards, cardEffect: activateClass));
 
             yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(remainingCards, "Deck Top Card", true, true));
         }
@@ -568,13 +568,13 @@ public partial class CardEffectCommons
 
             yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
 
-            static IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
+            IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
             {
                 List<CardSource> topCards = cardSources.Clone();
 
                 topCards.Reverse();
 
-                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(topCards));
+                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(topCards, cardEffect: activateClass));
 
                 yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().ShowCardEffect2(cardSources, "Deck Top Cards", true, true));
             }

--- a/Assets/Scripts/Script/CardObjectController.cs
+++ b/Assets/Scripts/Script/CardObjectController.cs
@@ -856,6 +856,18 @@ public class CardObjectController : MonoBehaviour
             }
         }
         #endregion
+
+        #region "When cards are added to the library" effect, regardless of origin (hand/security/field/digivolution source/trash)
+
+        System.Collections.Hashtable addLibraryTopHashtable = new System.Collections.Hashtable()
+        {
+            {"CardSources", cardSources},
+            {"IsTop", true}
+        };
+
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(addLibraryTopHashtable, EffectTiming.OnAddLibraryAnyone));
+
+        #endregion
     }
     #endregion
 
@@ -949,6 +961,18 @@ public class CardObjectController : MonoBehaviour
                 PlayLog.OnAddLog?.Invoke(log);
             }
         }
+        #endregion
+
+        #region "When cards are added to the library" effect, regardless of origin (hand/security/field/digivolution source/trash)
+
+        System.Collections.Hashtable addLibraryBottomHashtable = new System.Collections.Hashtable()
+        {
+            {"CardSources", cardSources},
+            {"IsTop", false}
+        };
+
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(addLibraryBottomHashtable, EffectTiming.OnAddLibraryAnyone));
+
         #endregion
     }
     #endregion

--- a/Assets/Scripts/Script/CardObjectController.cs
+++ b/Assets/Scripts/Script/CardObjectController.cs
@@ -778,9 +778,17 @@ public class CardObjectController : MonoBehaviour
     #endregion
 
     #region place a card on top of the deck
-    public static IEnumerator AddLibraryTopCards(List<CardSource> cardSources, bool notAddLog = false)
+    public static IEnumerator AddLibraryTopCards(List<CardSource> cardSources, bool notAddLog = false, ICardEffect cardEffect = null)
     {
         if (cardSources.Count <= 0) yield break;
+
+        // Cards revealed from the library (eg. "reveal the top X cards" effects) and then returned
+        // there were never truly added from outside — track them here so they can be excluded from
+        // the OnAddLibraryAnyone trigger below.
+        bool WasAlreadyInLibrary(CardSource cardSource)
+            => cardSource.Owner.LibraryCards.Contains(cardSource) || cardSource.Owner.DigitamaLibraryCards.Contains(cardSource);
+
+        HashSet<CardSource> alreadyInLibraryCardSources = new HashSet<CardSource>(cardSources.Filter(WasAlreadyInLibrary));
 
         bool isFromTrash = cardSources.Some(cardSource => CardEffectCommons.IsExistOnTrash(cardSource));
 
@@ -823,7 +831,7 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.LibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.LibraryCards.Insert(0, cardSource);
-                        addedCardSources.Add(cardSource);
+                        if (!alreadyInLibraryCardSources.Contains(cardSource)) addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -832,7 +840,7 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.DigitamaLibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.DigitamaLibraryCards.Insert(0, cardSource);
-                        addedCardSources.Add(cardSource);
+                        if (!alreadyInLibraryCardSources.Contains(cardSource)) addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -861,14 +869,22 @@ public class CardObjectController : MonoBehaviour
         }
         #endregion
 
-        yield return ContinuousController.instance.StartCoroutine(FireOnAddLibraryAnyone(addedCardSources, isTop: true));
+        yield return ContinuousController.instance.StartCoroutine(FireOnAddLibraryAnyone(addedCardSources, isTop: true, cardEffect: cardEffect));
     }
     #endregion
 
     #region put a card at the bottom of the deck
-    public static IEnumerator AddLibraryBottomCards(List<CardSource> cardSources, bool notAddLog = false)
+    public static IEnumerator AddLibraryBottomCards(List<CardSource> cardSources, bool notAddLog = false, ICardEffect cardEffect = null)
     {
         if (cardSources.Count <= 0) yield break;
+
+        // Cards revealed from the library (eg. "reveal the top X cards" effects) and then returned
+        // there were never truly added from outside — track them here so they can be excluded from
+        // the OnAddLibraryAnyone trigger below.
+        bool WasAlreadyInLibrary(CardSource cardSource)
+            => cardSource.Owner.LibraryCards.Contains(cardSource) || cardSource.Owner.DigitamaLibraryCards.Contains(cardSource);
+
+        HashSet<CardSource> alreadyInLibraryCardSources = new HashSet<CardSource>(cardSources.Filter(WasAlreadyInLibrary));
 
         bool isFromTrash = cardSources.Some(cardSource => CardEffectCommons.IsExistOnTrash(cardSource));
 
@@ -923,7 +939,7 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.LibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.LibraryCards.Add(cardSource);
-                        addedCardSources.Add(cardSource);
+                        if (!alreadyInLibraryCardSources.Contains(cardSource)) addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -932,7 +948,7 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.DigitamaLibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.DigitamaLibraryCards.Add(cardSource);
-                        addedCardSources.Add(cardSource);
+                        if (!alreadyInLibraryCardSources.Contains(cardSource)) addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -961,19 +977,20 @@ public class CardObjectController : MonoBehaviour
         }
         #endregion
 
-        yield return ContinuousController.instance.StartCoroutine(FireOnAddLibraryAnyone(addedCardSources, isTop: false));
+        yield return ContinuousController.instance.StartCoroutine(FireOnAddLibraryAnyone(addedCardSources, isTop: false, cardEffect: cardEffect));
     }
     #endregion
 
     #region "When cards are added to the library" effect, regardless of origin (hand/security/field/digivolution source/trash)
-    static IEnumerator FireOnAddLibraryAnyone(List<CardSource> addedCardSources, bool isTop)
+    static IEnumerator FireOnAddLibraryAnyone(List<CardSource> addedCardSources, bool isTop, ICardEffect cardEffect = null)
     {
         if (addedCardSources.Count <= 0) yield break;
 
         System.Collections.Hashtable hashtable = new System.Collections.Hashtable()
         {
             {"CardSources", addedCardSources},
-            {"IsTop", isTop}
+            {"IsTop", isTop},
+            {"CardEffect", cardEffect}
         };
 
         yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(hashtable, EffectTiming.OnAddLibraryAnyone));

--- a/Assets/Scripts/Script/CardObjectController.cs
+++ b/Assets/Scripts/Script/CardObjectController.cs
@@ -778,7 +778,7 @@ public class CardObjectController : MonoBehaviour
     #endregion
 
     #region place a card on top of the deck
-    public static IEnumerator AddLibraryTopCards(List<CardSource> cardSources, bool notAddLog = false, ICardEffect cardEffect = null)
+    public static IEnumerator AddLibraryTopCards(List<CardSource> cardSources, ICardEffect cardEffect, bool notAddLog = false)
     {
         if (cardSources.Count <= 0) yield break;
 
@@ -876,7 +876,7 @@ public class CardObjectController : MonoBehaviour
     #endregion
 
     #region put a card at the bottom of the deck
-    public static IEnumerator AddLibraryBottomCards(List<CardSource> cardSources, bool notAddLog = false, ICardEffect cardEffect = null)
+    public static IEnumerator AddLibraryBottomCards(List<CardSource> cardSources, ICardEffect cardEffect, bool notAddLog = false)
     {
         if (cardSources.Count <= 0) yield break;
 

--- a/Assets/Scripts/Script/CardObjectController.cs
+++ b/Assets/Scripts/Script/CardObjectController.cs
@@ -801,6 +801,8 @@ public class CardObjectController : MonoBehaviour
             #endregion
         }
 
+        List<CardSource> addedCardSources = new List<CardSource>();
+
         foreach (CardSource cardSource in cardSources)
         {
             bool isFromHand = CardEffectCommons.IsExistOnHand(cardSource);
@@ -821,6 +823,7 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.LibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.LibraryCards.Insert(0, cardSource);
+                        addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -829,6 +832,7 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.DigitamaLibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.DigitamaLibraryCards.Insert(0, cardSource);
+                        addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -857,17 +861,7 @@ public class CardObjectController : MonoBehaviour
         }
         #endregion
 
-        #region "When cards are added to the library" effect, regardless of origin (hand/security/field/digivolution source/trash)
-
-        System.Collections.Hashtable addLibraryTopHashtable = new System.Collections.Hashtable()
-        {
-            {"CardSources", cardSources},
-            {"IsTop", true}
-        };
-
-        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(addLibraryTopHashtable, EffectTiming.OnAddLibraryAnyone));
-
-        #endregion
+        yield return ContinuousController.instance.StartCoroutine(FireOnAddLibraryAnyone(addedCardSources, isTop: true));
     }
     #endregion
 
@@ -907,6 +901,8 @@ public class CardObjectController : MonoBehaviour
             }
         }
 
+        List<CardSource> addedCardSources = new List<CardSource>();
+
         foreach (CardSource cardSource in cardSources.Clone())
         {
             bool isFromHand = CardEffectCommons.IsExistOnHand(cardSource);
@@ -927,6 +923,7 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.LibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.LibraryCards.Add(cardSource);
+                        addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -935,6 +932,7 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.DigitamaLibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.DigitamaLibraryCards.Add(cardSource);
+                        addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -963,17 +961,22 @@ public class CardObjectController : MonoBehaviour
         }
         #endregion
 
-        #region "When cards are added to the library" effect, regardless of origin (hand/security/field/digivolution source/trash)
+        yield return ContinuousController.instance.StartCoroutine(FireOnAddLibraryAnyone(addedCardSources, isTop: false));
+    }
+    #endregion
 
-        System.Collections.Hashtable addLibraryBottomHashtable = new System.Collections.Hashtable()
+    #region "When cards are added to the library" effect, regardless of origin (hand/security/field/digivolution source/trash)
+    static IEnumerator FireOnAddLibraryAnyone(List<CardSource> addedCardSources, bool isTop)
+    {
+        if (addedCardSources.Count <= 0) yield break;
+
+        System.Collections.Hashtable hashtable = new System.Collections.Hashtable()
         {
-            {"CardSources", cardSources},
-            {"IsTop", false}
+            {"CardSources", addedCardSources},
+            {"IsTop", isTop}
         };
 
-        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(addLibraryBottomHashtable, EffectTiming.OnAddLibraryAnyone));
-
-        #endregion
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.autoProcessing.StackSkillInfos(hashtable, EffectTiming.OnAddLibraryAnyone));
     }
     #endregion
 
@@ -1008,6 +1011,8 @@ public class CardObjectController : MonoBehaviour
             if (cardSource.IsDigiEgg)
             {
                 cardSource.Owner.DigitamaLibraryCards.Add(cardSource);
+
+                yield return ContinuousController.instance.StartCoroutine(FireOnAddLibraryAnyone(new List<CardSource>() { cardSource }, isTop: false));
             }
             else if (!cardSource.IsToken)
             {

--- a/Assets/Scripts/Script/CardObjectController.cs
+++ b/Assets/Scripts/Script/CardObjectController.cs
@@ -591,7 +591,7 @@ public class CardObjectController : MonoBehaviour
         List<CardSource> addedCards = cardSources.Filter(cardSource => !cardSource.IsDigiEgg && !cardSource.IsToken);
 
         if (eggCards.Count <= 0)
-            yield return ContinuousController.instance.StartCoroutine(AddLibraryBottomCards(eggCards));
+            yield return ContinuousController.instance.StartCoroutine(AddLibraryBottomCards(eggCards, cardEffect: cardEffect));
 
         if (addedCards.Count <= 0) yield break;
 
@@ -840,7 +840,9 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.DigitamaLibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.DigitamaLibraryCards.Insert(0, cardSource);
-                        if (!alreadyInLibraryCardSources.Contains(cardSource)) addedCardSources.Add(cardSource);
+                        // Ruling: OnAddLibraryAnyone should not trigger from cards added to the digi-egg deck.
+                        // Commented out (not removed) so this is easy to restore if that ruling changes.
+                        // if (!alreadyInLibraryCardSources.Contains(cardSource)) addedCardSources.Add(cardSource);
                     }
                 }
 
@@ -948,7 +950,9 @@ public class CardObjectController : MonoBehaviour
                     if (!cardSource.Owner.DigitamaLibraryCards.Contains(cardSource))
                     {
                         cardSource.Owner.DigitamaLibraryCards.Add(cardSource);
-                        if (!alreadyInLibraryCardSources.Contains(cardSource)) addedCardSources.Add(cardSource);
+                        // Ruling: OnAddLibraryAnyone should not trigger from cards added to the digi-egg deck.
+                        // Commented out (not removed) so this is easy to restore if that ruling changes.
+                        // if (!alreadyInLibraryCardSources.Contains(cardSource)) addedCardSources.Add(cardSource);
                     }
                 }
 

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -1040,7 +1040,8 @@ public enum EffectTiming
     OnRemovedField,
     OnLinkCardDiscarded,
     OnFaceUpSecurityIncreased,
-    OnLeaveFieldAnyone
+    OnLeaveFieldAnyone,
+    OnAddLibraryAnyone
 }
 
 #endregion

--- a/Assets/Scripts/Script/SelectCardEffect.cs
+++ b/Assets/Scripts/Script/SelectCardEffect.cs
@@ -750,7 +750,7 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
                     {
                         cardSource.SetFace();
 
-                        if (cardSource.IsDigiEgg) yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource> { cardSource }));
+                        if (cardSource.IsDigiEgg) yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(new List<CardSource> { cardSource }, cardEffect: _cardEffect));
                         else
                         {
                             if (cardSource.PermanentOfThisCard() != null)

--- a/Assets/Scripts/Script/SelectHandEffect.cs
+++ b/Assets/Scripts/Script/SelectHandEffect.cs
@@ -714,12 +714,12 @@ public class SelectHandEffect : MonoBehaviourPunCallbacks
 
                     case Mode.PutLibraryTop:
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(_targetCards));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(_targetCards, cardEffect: _cardEffect));
                         break;
 
                     case Mode.PutLibraryBottom:
 
-                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(_targetCards));
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(_targetCards, cardEffect: _cardEffect));
                         break;
 
                     case Mode.PutSecurityBottom:

--- a/Assets/Scripts/Script/TurnStateMachine.cs
+++ b/Assets/Scripts/Script/TurnStateMachine.cs
@@ -476,7 +476,7 @@ public class TurnStateMachine : MonoBehaviourPunCallbacks
                 #endregion
 
                 #region 手札のカードを山札の下に加える
-                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(player.HandCards.Clone(),true));
+                yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(player.HandCards.Clone(), cardEffect: null, notAddLog: true));
 
                 #region Log
                 if (_isRedraw)


### PR DESCRIPTION
## Summary
- Implements BT26-001 Yokomon's Inherited Effect: when your effects add a card to the deck (top or bottom, from any origin - hand, security, field, or a digivolution source of any card), this Digimon may digivolve into a Digimon card with [Chronomon] in its text in hand with the cost reduced by 1.
- **Adds `EffectTiming.OnAddLibraryAnyone`**, a new engine-level timing, because no existing one covered this. `CardObjectController.AddLibraryTopCards`/`AddLibraryBottomCards` (the shared functions every card-to-deck movement already passes through) previously only broadcast `OnReturnCardsToLibraryFromTrash`, and only when the source was specifically the trash. This new timing is stacked unconditionally at the end of both functions, after the move has already happened (not a "would" pre-check - `WhenReturntoLibraryAnyone` is specifically a pre-action interceptor for whole-permanent deck bounces and doesn't fit this card).
- Also wired into `AddSecurityCard`'s Digi-Egg-to-DigitamaLibrary path, the one other place cards silently entered a library without broadcasting anything.
- Adds `CardEffectCommons.CanTriggerOnAddLibrary` (reuses the existing `GetCardSourcesFromHashtable` helper, matches the sibling `CanTriggerWhenDiscardLibrary` convention of excluding mid-reveal/null cards) and `IsAddLibraryTop` to read the new timing's hashtable. Only cards actually inserted (not tokens, not dedupe-skipped) are broadcast.
- No open PR existed for this card yet (checked before starting).

**Known limitation:** "your effects add..." is approximated as "cards added to *your* deck" (`cardSource.Owner == card.Owner`), since `AddLibraryTopCards`/`AddLibraryBottomCards` don't carry which player's effect caused the move - the existing `OnReturnCardsToLibraryFromTrash` timing has this same limitation. Properly tracking the causing effect would require plumbing an `ICardEffect` parameter through both functions and their ~80 call sites; flagging as a follow-up rather than in scope here.