### PR TITLE
Create BT26_008 Kotemon

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_008.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_008.cs
@@ -14,7 +14,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.None)
             {
                 static bool PermanentCondition(Permanent targetPermanent)
-                    => targetPermanent.TopCard.ContainsTraits("Shambala") || targetPermanent.TopCard.ContainsTraits("TS");
+                    => targetPermanent.TopCard.EqualsTraits("Shambala") || targetPermanent.TopCard.EqualsTraits("TS");
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
                     permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
@@ -30,7 +30,7 @@ namespace DCGO.CardEffects.BT26
 
             bool CanSelectPermanentCondition(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
-                    && (permanent.TopCard.ContainsTraits("Shambala") || permanent.TopCard.ContainsTraits("TS"));
+                    && (permanent.TopCard.EqualsTraits("Shambala") || permanent.TopCard.EqualsTraits("TS"));
 
             bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
                 => CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_008.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_008.cs
@@ -32,9 +32,8 @@ namespace DCGO.CardEffects.BT26
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                     && (permanent.TopCard.ContainsTraits("Shambala") || permanent.TopCard.ContainsTraits("TS"));
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -65,35 +64,15 @@ namespace DCGO.CardEffects.BT26
                 }
             }
 
-            #region When Moving
-            if (timing == EffectTiming.OnMove)
-            {
-                bool PermanentCondition(Permanent permanent) => permanent == card.PermanentOfThisCard();
-
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
-                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Moving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnMove(hashtable, PermanentCondition);
-            }
-            #endregion
-
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
-                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName,
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                whenMoving: true,
+                onPlay: true);
 
             #endregion
 

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_008.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_008.cs
@@ -32,9 +32,6 @@ namespace DCGO.CardEffects.BT26
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                     && (permanent.TopCard.EqualsTraits("Shambala") || permanent.TopCard.EqualsTraits("TS"));
 
-            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
-                => CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
-
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
                 SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
@@ -70,7 +67,6 @@ namespace DCGO.CardEffects.BT26
                 SharedActivateCoroutine,
                 SharedEffectDescription,
                 optional: false,
-                additionalActivateCondition: SharedAdditionalActivateCondition,
                 whenMoving: true,
                 onPlay: true);
 

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_008.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_008.cs
@@ -1,0 +1,111 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Kotemon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_008 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                    => targetPermanent.TopCard.ContainsTraits("Shambala") || targetPermanent.TopCard.ContainsTraits("TS");
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
+            }
+            #endregion
+
+            #region Shared When Moving / On Play
+
+            string SharedEffectName = "1 [Shambala]/[TS] Digimon gains Piercing and +3000 DP for the turn";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] 1 of your [Shambala] or [TS] trait Digimon gains <Piercing> and +3000 DP for the turn.";
+
+            bool CanSelectPermanentCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                    && (permanent.TopCard.ContainsTraits("Shambala") || permanent.TopCard.ContainsTraits("TS"));
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                selectPermanentEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: CanSelectPermanentCondition,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: 1,
+                    canNoSelect: false,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: SelectPermanentCoroutine,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Custom,
+                    cardEffect: activateClass);
+
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(
+                        CardEffectCommons.GainPierce(targetPermanent: permanent, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+
+                    yield return ContinuousController.instance.StartCoroutine(
+                        CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: 3000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                }
+            }
+
+            #region When Moving
+            if (timing == EffectTiming.OnMove)
+            {
+                bool PermanentCondition(Permanent permanent) => permanent == card.PermanentOfThisCard();
+
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
+                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Moving"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnMove(hashtable, PermanentCondition);
+            }
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
+                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #endregion
+
+            #region Inherited Effect
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.ChangeSelfDPStaticEffect(
+                    changeValue: 2000, isInheritedEffect: true, card: card, condition: () => CardEffectCommons.IsOwnerTurn(card)));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements BT26-008 Kotemon: alternate digivolution requirement (Lv.2 w/[Shambala]/[TS] trait, cost 0), shared [When Moving]/[On Play] effect (1 of your [Shambala] or [TS] trait Digimon gains Piercing and +3000 DP for the turn), and the Inherited Effect (+2000 DP on your turn).
- No open PR existed for this card yet (checked before starting).