### PR TITLE
Create BT26_011 Buraimon

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_011.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_011.cs
@@ -1,0 +1,114 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Buraimon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_011 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                    => targetPermanent.TopCard.ContainsTraits("TS");
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));
+            }
+            #endregion
+
+            #region Raid
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                cardEffects.Add(CardEffectFactory.RaidSelfEffect(isInheritedEffect: true, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving
+
+            string SharedEffectName = "Trash 1 [Chronomon]/[Shaman] card to Draw 2";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] By trashing 1 card with [Chronomon] in its text or the [Shaman] trait from your hand, <Draw 2>.";
+
+            bool CanSelectCardCondition(CardSource cardSource)
+                => cardSource.HasText("Chronomon") || cardSource.ContainsTraits("Shaman");
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                CardSource selectedCard = null;
+
+                SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                selectHandEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: CanSelectCardCondition,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: 1,
+                    canNoSelect: true,
+                    canEndNotMax: false,
+                    isShowOpponent: true,
+                    selectCardCoroutine: SelectCardCoroutine,
+                    afterSelectCardCoroutine: null,
+                    mode: SelectHandEffect.Mode.Discard,
+                    cardEffect: activateClass);
+
+                selectHandEffect.SetUpCustomMessage("Select 1 [Chronomon]/[Shaman] card to trash.", "The opponent is selecting 1 card to trash.");
+
+                yield return StartCoroutine(selectHandEffect.Activate());
+
+                IEnumerator SelectCardCoroutine(CardSource cardSource)
+                {
+                    selectedCard = cardSource;
+                    yield return null;
+                }
+
+                if (selectedCard != null)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 2, activateClass).Draw());
+                }
+            }
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
+                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), -1, true, SharedEffectDescription("On Play"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
+                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), -1, true, SharedEffectDescription("When Digivolving"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_011.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_011.cs
@@ -14,7 +14,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.None)
             {
                 static bool PermanentCondition(Permanent targetPermanent)
-                    => targetPermanent.TopCard.ContainsTraits("TS");
+                    => targetPermanent.TopCard.EqualsTraits("TS");
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
                     permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));
@@ -36,7 +36,7 @@ namespace DCGO.CardEffects.BT26
                 => $"[{tag}] By trashing 1 card with [Chronomon] in its text or the [Shaman] trait from your hand, <Draw 2>.";
 
             bool CanSelectCardCondition(CardSource cardSource)
-                => cardSource.HasText("Chronomon") || cardSource.ContainsTraits("Shaman");
+                => cardSource.HasText("Chronomon") || cardSource.EqualsTraits("Shaman");
 
             bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
                 => CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_011.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_011.cs
@@ -38,9 +38,8 @@ namespace DCGO.CardEffects.BT26
             bool CanSelectCardCondition(CardSource cardSource)
                 => cardSource.HasText("Chronomon") || cardSource.ContainsTraits("Shaman");
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ActivateClass activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -78,33 +77,16 @@ namespace DCGO.CardEffects.BT26
                 }
             }
 
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
-                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), -1, true, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName, CanUseCondition, card);
-                activateClass.SetUpActivateClass(hash => SharedCanActivateCondition(hash, activateClass), hash => SharedActivateCoroutine(hash, activateClass), -1, true, SharedEffectDescription("When Digivolving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName,
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                isSkippable: true,
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                onPlay: true,
+                whenDigivolving: true);
 
             #endregion
 

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_011.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_011.cs
@@ -24,7 +24,7 @@ namespace DCGO.CardEffects.BT26
             #region Raid
             if (timing == EffectTiming.OnAllyAttack)
             {
-                cardEffects.Add(CardEffectFactory.RaidSelfEffect(isInheritedEffect: true, card: card, condition: null));
+                cardEffects.Add(CardEffectFactory.RaidSelfEffect(isInheritedEffect: false, card: card, condition: null));
             }
             #endregion
 
@@ -88,6 +88,13 @@ namespace DCGO.CardEffects.BT26
                 onPlay: true,
                 whenDigivolving: true);
 
+            #endregion
+
+            #region Inherit
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                cardEffects.Add(CardEffectFactory.RaidSelfEffect(isInheritedEffect: true, card: card, condition: null));
+            }
             #endregion
 
             return cardEffects;


### PR DESCRIPTION
## Summary
- Implements BT26-011 Buraimon: alternate digivolution requirement (Lv.3 w/[TS] trait, cost 2), Raid (inherited), and the shared [On Play]/[When Digivolving] effect (by trashing 1 card with [Chronomon] in its text or the [Shaman] trait from hand, Draw 2).
- No open PR existed for this card yet (checked before starting).