### PR TITLE
Add BT26-012 Manekimon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
@@ -40,7 +40,7 @@ namespace DCGO.CardEffects.BT26
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
 
                 bool CanSelectCardCondition(CardSource cardSource)
-                    => cardSource.ContainsTraits("TB")
+                    => cardSource.EqualsTraits("TB")
                         && ((cardSource.IsOption && !cardSource.CanNotPlayThisOption)
                             || (cardSource.HasPlayCost && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2)));
 

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
@@ -41,8 +41,7 @@ namespace DCGO.CardEffects.BT26
 
                 bool CanSelectCardCondition(CardSource cardSource)
                     => cardSource.EqualsTraits("TB")
-                        && ((cardSource.IsOption && !cardSource.CanNotPlayThisOption)
-                            || (cardSource.HasPlayCost && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2)));
+                        && CardEffectCommons.CanPlayOrUse(cardSource, activateClass, fixedCost: cardSource.GetCostItself - 2);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
@@ -161,35 +161,35 @@ namespace DCGO.CardEffects.BT26
                         && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                        && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
-
-                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanSelectPermanentCondition,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: maxCount,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
-
-                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -2000.", "The opponent is selecting 1 Digimon that will get DP -2000.");
-
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -2000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectPermanentCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -2000.", "The opponent is selecting 1 Digimon that will get DP -2000.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -2000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                        }
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Manekimon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_012 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("Shambala");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));
+            }
+            #endregion
+
+            #region Main
+            if (timing == EffectTiming.OnDeclaration)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play/Use 1 [TB] trait card from hand for 2 less", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetHashString("BT26_012_Main");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Main] [Once Per Turn] You may play or use 1 card with the [TB] trait from your hand with the cost reduced by 2.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                    => cardSource.ContainsTraits("TB")
+                        && ((cardSource.IsOption && !cardSource.CanNotPlayThisOption)
+                            || (cardSource.HasPlayCost && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2)));
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool isUsed = false;
+
+                    CardSource selectedCard = null;
+
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectCardCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectHandEffect.SetUpCustomMessage("Select 1 card to play/use.", "The opponent is selecting 1 card to play/use.");
+                    selectHandEffect.SetUpCustomMessage_ShowCard("Played Card");
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
+                    {
+                        selectedCard = cardSource;
+                        yield return null;
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                    if (selectedCard != null)
+                    {
+                        isUsed = true;
+
+                        #region reduce cost
+                        int reduceCost = 2;
+
+                        ChangeCostClass changeCostClass = new ChangeCostClass();
+                        changeCostClass.SetUpICardEffect($"Play/Use Cost -{reduceCost}", CanUseCondition1, card);
+                        changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: PlayOrUseCondition, rootCondition: RootCondition, isUpDown: IsUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                        Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
+                        card.Owner.UntilCalculateFixedCostEffect.Add(getCardEffect);
+
+                        ICardEffect GetCardEffect(EffectTiming _timing)
+                            => _timing == EffectTiming.None ? changeCostClass : null;
+
+                        bool CanUseCondition1(Hashtable _hashtable) => true;
+
+                        bool PlayOrUseCondition(CardSource cardSource) => cardSource == selectedCard;
+
+                        bool RootCondition(SelectCardEffect.Root root) => true;
+
+                        bool IsUpDown() => true;
+
+                        int ChangeCost(CardSource cardSource, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                        {
+                            if (PlayOrUseCondition(cardSource))
+                            {
+                                cost -= reduceCost;
+                            }
+
+                            return cost;
+                        }
+                        #endregion
+
+                        if (selectedCard.IsOption)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
+                                cardSources: new List<CardSource> { selectedCard },
+                                activateClass: activateClass,
+                                payCost: true,
+                                root: SelectCardEffect.Root.Hand));
+                        }
+                        else
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                                cardSources: new List<CardSource> { selectedCard },
+                                activateClass: activateClass,
+                                payCost: true,
+                                isTapped: false,
+                                root: SelectCardEffect.Root.Hand,
+                                activateETB: true));
+                        }
+
+                        #region release reduction
+                        card.Owner.UntilCalculateFixedCostEffect.Remove(getCardEffect);
+                        #endregion
+                    }
+
+                    if (!isUsed) activateClass.RemoveUse();
+                }
+            }
+            #endregion
+
+            #region Inherit
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("DP -2000", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("BT26_012_Inherit");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[When Attacking] [Once Per Turn] 1 of your opponent's Digimon gets -2000 DP for the turn.";
+
+                bool CanSelectPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectPermanentCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: maxCount,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get DP -2000.", "The opponent is selecting 1 Digimon that will get DP -2000.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -2000, effectDuration: EffectDuration.UntilEachTurnEnd, activateClass: activateClass));
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Shambala");
+                    return targetPermanent.TopCard.EqualsTraits("Shambala");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_012.cs
@@ -36,7 +36,7 @@ namespace DCGO.CardEffects.BT26
                     => "[Main] [Once Per Turn] You may play or use 1 card with the [TB] trait from your hand with the cost reduced by 2.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
 
                 bool CanSelectCardCondition(CardSource cardSource)

--- a/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
@@ -281,6 +281,18 @@ public partial class CardEffectCommons
         #endregion
     }
 
+    #region CanPlayOrUse
+    public static bool CanPlayOrUse(CardSource cardSource, ICardEffect activateClass, SelectCardEffect.Root root = SelectCardEffect.Root.Hand, int fixedCost = -1)
+    {
+        return cardSource != null
+            && (cardSource.IsOption
+                && !cardSource.CanNotPlayThisOption
+                && cardSource.Owner.MaxMemoryCost >= fixedCost)
+            || (cardSource.HasPlayCost
+                && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: fixedCost > 0, cardEffect: activateClass, root: root, fixedCost: fixedCost));
+    }
+    #endregion
+
     //TODO: UseByEffect
 
     //TODO: PlayOrUseByEffect

--- a/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
@@ -294,18 +294,6 @@ public partial class CardEffectCommons
     }
     #endregion
 
-    #region CanPlayOrUse
-    public static bool CanPlayOrUse(CardSource cardSource, ICardEffect activateClass, SelectCardEffect.Root root = SelectCardEffect.Root.Hand, int fixedCost = -1)
-    {
-        return cardSource != null
-            && (cardSource.IsOption
-                && !cardSource.CanNotPlayThisOption
-                && cardSource.Owner.MaxMemoryCost >= fixedCost)
-            || (cardSource.HasPlayCost
-                && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: fixedCost > 0, cardEffect: activateClass, root: root, fixedCost: fixedCost));
-    }
-    #endregion
-
     //TODO: UseByEffect
 
     //TODO: PlayOrUseByEffect


### PR DESCRIPTION
## Summary
- Implements BT26-012 Manekimon's card effect.
- Alternate digivolution requirement: Lv.3 w/[Shambala] trait, cost 2.
- [Main] [Once Per Turn] You may play or use 1 card with the [TB] trait from your hand with the cost reduced by 2.
- Inherited [When Attacking] [Once Per Turn] 1 of your opponent's Digimon gets -2000 DP for the turn.