### PR TITLE
Add BT26-014 Darumamon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -27,7 +26,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.None)
             {
                 AddAssemblyConditionClass addAssemblyConditionClass = new AddAssemblyConditionClass();
-                addAssemblyConditionClass.SetUpICardEffect($"Assembly", CanUseCondition, card);
+                addAssemblyConditionClass.SetUpICardEffect("Assembly", CanUseCondition, card);
                 addAssemblyConditionClass.SetUpAddAssemblyConditionClass(getAssemblyCondition: GetAssembly);
                 addAssemblyConditionClass.SetNotShowUI(true);
                 cardEffects.Add(addAssemblyConditionClass);
@@ -69,7 +68,6 @@ namespace DCGO.CardEffects.BT26
             #endregion
 
             #region Shared On Play / When Digivolving
-
             string SharedEffectName()
                 => "Delete 1 opponent's Digimon with 7000 DP or less";
 
@@ -80,17 +78,12 @@ namespace DCGO.CardEffects.BT26
                 => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
                     && permanent.DP <= card.Owner.MaxDP_DeleteEffect(7000, activateClass);
 
-            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
-                => CardEffectCommons.HasMatchConditionPermanent(permanent => CanSelectPermanentCondition(permanent, activateClass));
-
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
                 bool CanSelectPermanentConditionBound(Permanent permanent) => CanSelectPermanentCondition(permanent, activateClass);
 
                 if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentConditionBound))
                 {
-                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentConditionBound));
-
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                     selectPermanentEffect.SetUp(
@@ -98,7 +91,7 @@ namespace DCGO.CardEffects.BT26
                         canTargetCondition: CanSelectPermanentConditionBound,
                         canTargetCondition_ByPreSelecetedList: null,
                         canEndSelectCondition: null,
-                        maxCount: maxCount,
+                        maxCount: 1,
                         canNoSelect: false,
                         canEndNotMax: false,
                         selectPermanentCoroutine: null,
@@ -111,7 +104,6 @@ namespace DCGO.CardEffects.BT26
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
                 }
             }
-
             #endregion
 
             CardEffectFactory.ActivateClassesForSharedEffects(
@@ -120,7 +112,6 @@ namespace DCGO.CardEffects.BT26
                 SharedActivateCoroutine,
                 SharedEffectDescription,
                 optional: false,
-                additionalActivateCondition: SharedAdditionalActivateCondition,
                 onPlay: true,
                 whenDigivolving: true);
 
@@ -130,13 +121,14 @@ namespace DCGO.CardEffects.BT26
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Return [Shambala] card from trash to hand, then play 1 [TB] Digimon free", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
                     => "[On Deletion] You may return 1 card with the [Shambala] trait from your trash to the hand. Then, you may play 1 Digimon card with the [TB] trait and 6000 DP or less from your hand without paying the cost.";
 
                 bool CanSelectTrashCardCondition(CardSource cardSource)
-                    => cardSource.IsDigimon && cardSource.EqualsTraits("Shambala");
+                    => cardSource.EqualsTraits("Shambala");
 
                 bool CanSelectHandCardCondition(CardSource cardSource)
                     => cardSource.IsDigimon
@@ -157,7 +149,6 @@ namespace DCGO.CardEffects.BT26
                     if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectTrashCardCondition))
                     {
                         SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
-                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, CanSelectTrashCardCondition));
 
                         selectCardEffect.SetUp(
                             canTargetCondition: CanSelectTrashCardCondition,
@@ -167,7 +158,7 @@ namespace DCGO.CardEffects.BT26
                             selectCardCoroutine: null,
                             afterSelectCardCoroutine: null,
                             message: "Select 1 [Shambala] card to return to hand.",
-                            maxCount: maxCount,
+                            maxCount: 1,
                             canEndNotMax: false,
                             isShowOpponent: true,
                             mode: SelectCardEffect.Mode.AddHand,
@@ -200,6 +191,7 @@ namespace DCGO.CardEffects.BT26
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Play 1 [TB] Digimon free", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 activateClass.SetIsInheritedEffect(true);
                 cardEffects.Add(activateClass);
 

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Darumamon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_014 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("Shambala");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 4));
+            }
+            #endregion
+
+            #region Assembly
+            if (timing == EffectTiming.None)
+            {
+                AddAssemblyConditionClass addAssemblyConditionClass = new AddAssemblyConditionClass();
+                addAssemblyConditionClass.SetUpICardEffect($"Assembly", CanUseCondition, card);
+                addAssemblyConditionClass.SetUpAddAssemblyConditionClass(getAssemblyCondition: GetAssembly);
+                addAssemblyConditionClass.SetNotShowUI(true);
+                cardEffects.Add(addAssemblyConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return true;
+                }
+
+                AssemblyCondition GetAssembly(CardSource cardSource)
+                {
+                    if (cardSource == card)
+                    {
+                        AssemblyConditionElement element = new AssemblyConditionElement(CanSelectCardCondition);
+
+                        bool CanSelectCardCondition(CardSource cardSource)
+                        {
+                            return cardSource != null
+                                && cardSource.Owner == card.Owner
+                                && cardSource.IsDigimon
+                                && cardSource.HasLevel
+                                && cardSource.Level <= 4
+                                && cardSource.ContainsTraits("TB");
+                        }
+
+                        AssemblyCondition assemblyCondition = new AssemblyCondition(
+                            element: element,
+                            selectMessage: "1 level 4 or lower [TB] trait Digimon card",
+                            elementCount: 1,
+                            reduceCost: 2);
+
+                        return assemblyCondition;
+                    }
+
+                    return null;
+                }
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving
+
+            string SharedEffectName()
+                => "Delete 1 opponent's Digimon with 7000 DP or less";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] Delete 1 of your opponent's Digimon with 7000 DP or less.";
+
+            bool CanSelectPermanentCondition(Permanent permanent, ICardEffect activateClass)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                    && permanent.DP <= card.Owner.MaxDP_DeleteEffect(7000, activateClass);
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && CardEffectCommons.HasMatchConditionPermanent(permanent => CanSelectPermanentCondition(permanent, activateClass));
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                bool CanSelectPermanentConditionBound(Permanent permanent) => CanSelectPermanentCondition(permanent, activateClass);
+
+                if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentConditionBound))
+                {
+                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentConditionBound));
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectPermanentConditionBound,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: maxCount,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Destroy,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon with 7000 DP or less to delete.", "The opponent is selecting 1 Digimon with 7000 DP or less to delete.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                }
+            }
+
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Digivolving"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region On Deletion
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Return [Shambala] card from trash to hand, then play 1 [TB] Digimon free", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[On Deletion] You may return 1 card with the [Shambala] trait from your trash to the hand. Then, you may play 1 Digimon card with the [TB] trait and 6000 DP or less from your hand without paying the cost.";
+
+                bool CanSelectTrashCardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon && cardSource.ContainsTraits("Shambala");
+
+                bool CanSelectHandCardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon
+                        && cardSource.ContainsTraits("TB")
+                        && cardSource.HasDP && cardSource.CardDP <= 6000
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOnDeletion(hashtable, card, activateClass);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass)
+                        && (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectTrashCardCondition)
+                            || CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectHandCardCondition));
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectTrashCardCondition))
+                    {
+                        SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, CanSelectTrashCardCondition));
+
+                        selectCardEffect.SetUp(
+                            canTargetCondition: CanSelectTrashCardCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            canNoSelect: () => true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            message: "Select 1 [Shambala] card to return to hand.",
+                            maxCount: maxCount,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            mode: SelectCardEffect.Mode.AddHand,
+                            root: SelectCardEffect.Root.Trash,
+                            customRootCardList: null,
+                            canLookReverseCard: true,
+                            selectPlayer: card.Owner,
+                            cardEffect: activateClass);
+
+                        selectCardEffect.SetUpCustomMessage("Select 1 [Shambala] card to return to hand.", "The opponent is selecting 1 [Shambala] card to return to hand.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+                    }
+
+                    if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectHandCardCondition))
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                            canTargetCondition: CanSelectHandCardCondition,
+                            root: SelectCardEffect.Root.Hand,
+                            cardEffect: activateClass,
+                            payCost: false));
+                    }
+                }
+            }
+            #endregion
+
+            #region Inherit
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play 1 [TB] Digimon free", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[On Deletion] You may play 1 Digimon card with the [TB] trait and 6000 DP or less from your hand without paying the cost.";
+
+                bool CanSelectHandCardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon
+                        && cardSource.ContainsTraits("TB")
+                        && cardSource.HasDP && cardSource.CardDP <= 6000
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOnDeletion(hashtable, card, activateClass);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectHandCardCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                        canTargetCondition: CanSelectHandCardCondition,
+                        root: SelectCardEffect.Root.Hand,
+                        cardEffect: activateClass,
+                        payCost: false));
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Shambala");
+                    return targetPermanent.TopCard.EqualsTraits("Shambala");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 4));
@@ -50,7 +50,7 @@ namespace DCGO.CardEffects.BT26
                                 && cardSource.IsDigimon
                                 && cardSource.HasLevel
                                 && cardSource.Level <= 4
-                                && cardSource.ContainsTraits("TB");
+                                && cardSource.EqualsTraits("TB");
                         }
 
                         AssemblyCondition assemblyCondition = new AssemblyCondition(
@@ -135,11 +135,11 @@ namespace DCGO.CardEffects.BT26
                     => "[On Deletion] You may return 1 card with the [Shambala] trait from your trash to the hand. Then, you may play 1 Digimon card with the [TB] trait and 6000 DP or less from your hand without paying the cost.";
 
                 bool CanSelectTrashCardCondition(CardSource cardSource)
-                    => cardSource.IsDigimon && cardSource.ContainsTraits("Shambala");
+                    => cardSource.IsDigimon && cardSource.EqualsTraits("Shambala");
 
                 bool CanSelectHandCardCondition(CardSource cardSource)
                     => cardSource.IsDigimon
-                        && cardSource.ContainsTraits("TB")
+                        && cardSource.EqualsTraits("TB")
                         && cardSource.HasDP && cardSource.CardDP <= 6000
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
 
@@ -207,7 +207,7 @@ namespace DCGO.CardEffects.BT26
 
                 bool CanSelectHandCardCondition(CardSource cardSource)
                     => cardSource.IsDigimon
-                        && cardSource.ContainsTraits("TB")
+                        && cardSource.EqualsTraits("TB")
                         && cardSource.HasDP && cardSource.CardDP <= 6000
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
 

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
@@ -55,6 +55,7 @@ namespace DCGO.CardEffects.BT26
 
                         AssemblyCondition assemblyCondition = new AssemblyCondition(
                             element: element,
+                            CanTargetCondition_ByPreSelecetedList: null,
                             selectMessage: "1 level 4 or lower [TB] trait Digimon card",
                             elementCount: 1,
                             reduceCost: 2);

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_014.cs
@@ -79,9 +79,8 @@ namespace DCGO.CardEffects.BT26
                 => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
                     && permanent.DP <= card.Owner.MaxDP_DeleteEffect(7000, activateClass);
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && CardEffectCommons.HasMatchConditionPermanent(permanent => CanSelectPermanentCondition(permanent, activateClass));
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionPermanent(permanent => CanSelectPermanentCondition(permanent, activateClass));
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -114,33 +113,15 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Digivolving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName(),
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                onPlay: true,
+                whenDigivolving: true);
 
             #region On Deletion
             if (timing == EffectTiming.OnDestroyedAnyone)


### PR DESCRIPTION
## Summary
- Implements BT26-014 Darumamon's card effect.
- Alternate digivolution requirement: Lv.4 w/[Shambala] trait, cost 3.
- Assembly -2: 1 level 4 or lower [TB] trait Digimon card.
- [On Play] [When Digivolving] Delete 1 of your opponent's Digimon with 7000 DP or less.
- [On Deletion] You may return 1 [Shambala] trait card from your trash to the hand. Then, you may play 1 [TB] trait Digimon card with 6000 DP or less from your hand without paying the cost.
- Inherited [On Deletion] You may play 1 [TB] trait Digimon card with 6000 DP or less from your hand without paying the cost.