### PR TITLE
Add BT26-016 Chronomon: Holy Mode card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
+++ b/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
@@ -51,9 +51,6 @@ namespace DCGO.CardEffects.BT26
                     && card.PermanentOfThisCard() != null
                     && permanent.DP <= card.Owner.MaxDP_DeleteEffect(card.PermanentOfThisCard().DP, activateClass);
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
-
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
                 bool CanSelectDeleteTargetConditionBound(Permanent permanent) => CanSelectDeleteTargetCondition(permanent, activateClass);
@@ -130,50 +127,17 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
-                activateClass.SetHashString("BT26_016_OPT");
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
-                activateClass.SetHashString("BT26_016_OPT");
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
-
-            #region When Attacking
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
-                activateClass.SetHashString("BT26_016_OPT");
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName(),
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                maxCountPerTurn: 1,
+                hashValue: "BT26_016_OPT",
+                onPlay: true,
+                whenDigivolving: true,
+                whenAttacking: true);
 
             #region All Turns
             if (timing == EffectTiming.WhenRemoveField)

--- a/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
+++ b/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -39,7 +38,6 @@ namespace DCGO.CardEffects.BT26
             #endregion
 
             #region Shared On Play / When Digivolving / When Attacking
-
             string SharedEffectName()
                 => "May delete 1 opponent's Digimon with as much DP as this or less, then return 3 trashed cards for Recovery +1";
 
@@ -48,8 +46,11 @@ namespace DCGO.CardEffects.BT26
 
             bool CanSelectDeleteTargetCondition(Permanent permanent, ICardEffect activateClass)
                 => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
-                    && card.PermanentOfThisCard() != null
                     && permanent.DP <= card.Owner.MaxDP_DeleteEffect(card.PermanentOfThisCard().DP, activateClass);
+
+            bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionPermanent(permanent => CanSelectDeleteTargetCondition(permanent, activateClass))
+                    || card.Owner.TrashCards.Count + card.Owner.Enemy.TrashCards.Count >= 3;
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -59,8 +60,6 @@ namespace DCGO.CardEffects.BT26
 
                 if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetConditionBound))
                 {
-                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectDeleteTargetConditionBound));
-
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                     selectPermanentEffect.SetUp(
@@ -68,7 +67,7 @@ namespace DCGO.CardEffects.BT26
                         canTargetCondition: CanSelectDeleteTargetConditionBound,
                         canTargetCondition_ByPreSelecetedList: null,
                         canEndSelectCondition: null,
-                        maxCount: maxCount,
+                        maxCount: 1,
                         canNoSelect: true,
                         canEndNotMax: false,
                         selectPermanentCoroutine: null,
@@ -87,7 +86,6 @@ namespace DCGO.CardEffects.BT26
                     }
                 }
 
-                // "Cards in trashes" (plural) is read as either player's trash pile combined.
                 List<CardSource> combinedTrashPool = card.Owner.TrashCards.Clone().Concat(card.Owner.Enemy.TrashCards.Clone()).ToList();
 
                 if (combinedTrashPool.Count >= 3)
@@ -124,7 +122,7 @@ namespace DCGO.CardEffects.BT26
 
                     yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
 
-                    if (selectedCards.Count >= 3)
+                    if (selectedCards.Count == 3)
                     {
                         yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards));
 
@@ -136,7 +134,6 @@ namespace DCGO.CardEffects.BT26
 
                 if (!isUsed) activateClass.RemoveUse();
             }
-
             #endregion
 
             CardEffectFactory.ActivateClassesForSharedEffects(
@@ -144,7 +141,9 @@ namespace DCGO.CardEffects.BT26
                 SharedEffectName(),
                 SharedActivateCoroutine,
                 SharedEffectDescription,
+                additionalActivateCondition: AdditionalActivateCondition,
                 optional: false,
+                isSkippable: true,
                 maxCountPerTurn: 1,
                 hashValue: "BT26_016_OPT",
                 onPlay: true,
@@ -156,8 +155,7 @@ namespace DCGO.CardEffects.BT26
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Return top security card to prevent this Digimon from leaving", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
-                activateClass.SetIsSkippable(true);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
                 activateClass.SetHashString("BT26_016_AllTurns");
                 cardEffects.Add(activateClass);
 
@@ -174,53 +172,20 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    bool isUsed = false;
+                    List<CardSource> topSecurity = new List<CardSource>() { card.Owner.SecurityCards[0] };
+                    yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(topSecurity));
 
-                    Permanent thisPermanent = card.PermanentOfThisCard();
-                    CardSource topSecurityCard = card.Owner.SecurityCards[0];
+                    yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
+                        player: card.Owner,
+                        refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                        activateClass).ReduceSecurity());
 
-                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+                    card.PermanentOfThisCard().willBeRemoveField = false;
 
-                    selectCardEffect.SetUp(
-                        canTargetCondition: _ => true,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        canNoSelect: () => true,
-                        selectCardCoroutine: null,
-                        afterSelectCardCoroutine: AfterSelectCardCoroutine,
-                        message: "Return your top security card to the bottom of your deck to prevent this Digimon from leaving?",
-                        maxCount: 1,
-                        canEndNotMax: false,
-                        isShowOpponent: true,
-                        mode: SelectCardEffect.Mode.Custom,
-                        root: SelectCardEffect.Root.Security,
-                        customRootCardList: new List<CardSource>() { topSecurityCard },
-                        canLookReverseCard: true,
-                        selectPlayer: card.Owner,
-                        cardEffect: activateClass);
-
-                    selectCardEffect.SetUpCustomMessage("Return your top security card to the bottom of your deck to prevent this Digimon from leaving?", "The opponent is deciding whether to return their top security card to the bottom of their deck.");
-
-                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
-
-                    IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
-                    {
-                        if (cardSources.Count >= 1)
-                        {
-                            isUsed = true;
-
-                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
-
-                            thisPermanent.willBeRemoveField = false;
-
-                            thisPermanent.HideHandBounceEffect();
-                            thisPermanent.HideDeckBounceEffect();
-                            thisPermanent.HideWillRemoveFieldEffect();
-                            thisPermanent.HideDeleteEffect();
-                        }
-                    }
-
-                    if (!isUsed) activateClass.RemoveUse();
+                    card.PermanentOfThisCard().HideHandBounceEffect();
+                    card.PermanentOfThisCard().HideDeckBounceEffect();
+                    card.PermanentOfThisCard().HideWillRemoveFieldEffect();
+                    card.PermanentOfThisCard().HideDeleteEffect();
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
+++ b/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
@@ -165,11 +165,11 @@ namespace DCGO.CardEffects.BT26
                     => "[All Turns] [Once Per Turn] When this Digimon would leave the battle area, by returning your top security card to the bottom of the deck, it doesn't leave.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.CanTriggerWhenRemoveField(hashtable, card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && card.Owner.SecurityCards.Count >= 1;
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
+++ b/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
@@ -53,6 +53,8 @@ namespace DCGO.CardEffects.BT26
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
+                bool isUsed = false;
+
                 bool CanSelectDeleteTargetConditionBound(Permanent permanent) => CanSelectDeleteTargetCondition(permanent, activateClass);
 
                 if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetConditionBound))
@@ -70,13 +72,19 @@ namespace DCGO.CardEffects.BT26
                         canNoSelect: true,
                         canEndNotMax: false,
                         selectPermanentCoroutine: null,
-                        afterSelectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: AfterSelectPermanentCoroutine,
                         mode: SelectPermanentEffect.Mode.Destroy,
                         cardEffect: activateClass);
 
                     selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to delete.", "The opponent is selecting 1 Digimon to delete.");
 
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    IEnumerator AfterSelectPermanentCoroutine(List<Permanent> permanents)
+                    {
+                        if (permanents != null && permanents.Count > 0) isUsed = true;
+                        yield return null;
+                    }
                 }
 
                 // "Cards in trashes" (plural) is read as either player's trash pile combined.
@@ -121,8 +129,12 @@ namespace DCGO.CardEffects.BT26
                         yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards));
 
                         yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
+
+                        isUsed = true;
                     }
                 }
+
+                if (!isUsed) activateClass.RemoveUse();
             }
 
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
+++ b/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
@@ -174,6 +174,8 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
+                    bool isUsed = false;
+
                     Permanent thisPermanent = card.PermanentOfThisCard();
                     CardSource topSecurityCard = card.Owner.SecurityCards[0];
 
@@ -205,6 +207,8 @@ namespace DCGO.CardEffects.BT26
                     {
                         if (cardSources.Count >= 1)
                         {
+                            isUsed = true;
+
                             yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
 
                             thisPermanent.willBeRemoveField = false;
@@ -215,6 +219,8 @@ namespace DCGO.CardEffects.BT26
                             thisPermanent.HideDeleteEffect();
                         }
                     }
+
+                    if (!isUsed) activateClass.RemoveUse();
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
+++ b/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// Chronomon: Holy Mode
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_016 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.HasTSTraits;
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
+            }
+            #endregion
+
+            #region Piercing
+            if (timing == EffectTiming.OnDetermineDoSecurityCheck)
+            {
+                cardEffects.Add(CardEffectFactory.PierceSelfEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Engage
+            if (timing == EffectTiming.OnEndTurn)
+            {
+                cardEffects.Add(CardEffectFactory.EngageSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving / When Attacking
+
+            string SharedEffectName()
+                => "May delete 1 opponent's Digimon with as much DP as this or less, then return 3 trashed cards for Recovery +1";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] [Once Per Turn] You may delete 1 of your opponent's Digimon with as much DP as this Digimon or less. Then, by returning 3 cards in trashes to the bottom of the deck, <Recovery +1>.";
+
+            bool CanSelectDeleteTargetCondition(Permanent permanent, ICardEffect activateClass)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                    && card.PermanentOfThisCard() != null
+                    && permanent.DP <= card.Owner.MaxDP_DeleteEffect(card.PermanentOfThisCard().DP, activateClass);
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                bool CanSelectDeleteTargetConditionBound(Permanent permanent) => CanSelectDeleteTargetCondition(permanent, activateClass);
+
+                if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetConditionBound))
+                {
+                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectDeleteTargetConditionBound));
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectDeleteTargetConditionBound,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: maxCount,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Destroy,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to delete.", "The opponent is selecting 1 Digimon to delete.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                }
+
+                // "Cards in trashes" (plural) is read as either player's trash pile combined.
+                List<CardSource> combinedTrashPool = card.Owner.TrashCards.Clone().Concat(card.Owner.Enemy.TrashCards.Clone()).ToList();
+
+                if (combinedTrashPool.Count >= 3)
+                {
+                    List<CardSource> selectedCards = new List<CardSource>();
+
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: _ => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        message: "Select 3 cards in either trash to return to the bottom of your deck.",
+                        maxCount: 3,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Custom,
+                        root: SelectCardEffect.Root.Custom,
+                        customRootCardList: combinedTrashPool,
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
+                    {
+                        selectedCards.Add(cardSource);
+                        yield return null;
+                    }
+
+                    selectCardEffect.SetUpCustomMessage("Select 3 cards in either trash to return to the bottom of your deck.", "The opponent is selecting 3 cards in either trash to return to the bottom of their deck.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+
+                    if (selectedCards.Count >= 3)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(selectedCards));
+
+                        yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
+                    }
+                }
+            }
+
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
+                activateClass.SetHashString("BT26_016_OPT");
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
+                activateClass.SetHashString("BT26_016_OPT");
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
+                activateClass.SetHashString("BT26_016_OPT");
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+            }
+            #endregion
+
+            #region All Turns
+            if (timing == EffectTiming.WhenRemoveField)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Return top security card to prevent this Digimon from leaving", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
+                activateClass.SetHashString("BT26_016_AllTurns");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[All Turns] [Once Per Turn] When this Digimon would leave the battle area, by returning your top security card to the bottom of the deck, it doesn't leave.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.CanTriggerWhenRemoveField(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && card.Owner.SecurityCards.Count >= 1;
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    Permanent thisPermanent = card.PermanentOfThisCard();
+                    CardSource topSecurityCard = card.Owner.SecurityCards[0];
+
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: _ => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: AfterSelectCardCoroutine,
+                        message: "Return your top security card to the bottom of your deck to prevent this Digimon from leaving?",
+                        maxCount: 1,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        mode: SelectCardEffect.Mode.Custom,
+                        root: SelectCardEffect.Root.Security,
+                        customRootCardList: new List<CardSource>() { topSecurityCard },
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    selectCardEffect.SetUpCustomMessage("Return your top security card to the bottom of your deck to prevent this Digimon from leaving?", "The opponent is deciding whether to return their top security card to the bottom of their deck.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+
+                    IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                    {
+                        if (cardSources.Count >= 1)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryBottomCards(cardSources));
+
+                            thisPermanent.willBeRemoveField = false;
+
+                            thisPermanent.HideHandBounceEffect();
+                            thisPermanent.HideDeckBounceEffect();
+                            thisPermanent.HideWillRemoveFieldEffect();
+                            thisPermanent.HideDeleteEffect();
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements BT26-016 Chronomon: Holy Mode's card effect.
- Alternate digivolution requirement: Lv.5 w/[TS] trait, cost 3.
- Piercing, Engage.
- [On Play] [When Digivolving] [When Attacking] [Once Per Turn] You may delete 1 of your opponent's Digimon with as much DP as this Digimon or less. Then, by returning 3 cards in trashes to the bottom of the deck, <Recovery +1>.
- [All Turns] [Once Per Turn] When this Digimon would leave the battle area, by returning your top security card to the bottom of the deck, it doesn't leave.
- "Cards in trashes" (plural) is read as either player's trash pile combined, since no exact precedent phrasing exists elsewhere in the codebase — flagging this interpretation in case it should instead be owner-only.