### PR TITLE
Add BT26-024 Tinkermon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
@@ -27,7 +27,8 @@ namespace DCGO.CardEffects.BT26
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Digivolve into [Vegetation]/[Fairy]/[WG] card in hand free", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -49,7 +48,8 @@ namespace DCGO.CardEffects.BT26
                         && CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, PlayedPermanentCondition);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, CardCondition);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
@@ -63,7 +63,8 @@ namespace DCGO.CardEffects.BT26
                         isHand: true,
                         activateClass: activateClass,
                         successProcess: null,
-                        isOptional: true));
+                        isOptional: true
+                    ));
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Tinkermon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_024 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("WG");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
+            }
+            #endregion
+
+            #region Your Turn
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Digivolve into [Vegetation]/[Fairy]/[WG] card in hand free", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Your Turn] When any of your other Digimon with the [Vegetation], [Fairy] or [WG] trait are played, this Digimon may digivolve into a Digimon card with the [Vegetation], [Fairy] or [WG] trait in the hand without paying the cost.";
+
+                bool PlayedPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                        && permanent != card.PermanentOfThisCard()
+                        && (permanent.TopCard.ContainsTraits("Vegetation") || permanent.TopCard.ContainsTraits("Fairy") || permanent.TopCard.ContainsTraits("WG"));
+
+                bool CardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon
+                        && (cardSource.ContainsTraits("Vegetation") || cardSource.ContainsTraits("Fairy") || cardSource.ContainsTraits("WG"));
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.IsOwnerTurn(card)
+                        && CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, PlayedPermanentCondition);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                        targetPermanent: card.PermanentOfThisCard(),
+                        cardCondition: CardCondition,
+                        payCost: false,
+                        reduceCostTuple: null,
+                        fixedCostTuple: null,
+                        ignoreDigivolutionRequirementFixedCost: -1,
+                        isHand: true,
+                        activateClass: activateClass,
+                        successProcess: null,
+                        isOptional: true));
+                }
+            }
+            #endregion
+
+            #region Inherit - Barrier
+            if (timing == EffectTiming.WhenPermanentWouldBeDeleted)
+            {
+                cardEffects.Add(CardEffectFactory.BarrierSelfEffect(isInheritedEffect: true, card: card, condition: null));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
@@ -37,11 +37,11 @@ namespace DCGO.CardEffects.BT26
                 bool PlayedPermanentCondition(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                         && permanent != card.PermanentOfThisCard()
-                        && (permanent.TopCard.ContainsTraits("Vegetation") || permanent.TopCard.ContainsTraits("Fairy") || permanent.TopCard.EqualsTraits("WG"));
+                        && (permanent.TopCard.EqualsTraits("Vegetation") || permanent.TopCard.ContainsTraits("Fairy") || permanent.TopCard.EqualsTraits("WG"));
 
                 bool CardCondition(CardSource cardSource)
                     => cardSource.IsDigimon
-                        && (cardSource.ContainsTraits("Vegetation") || cardSource.ContainsTraits("Fairy") || cardSource.EqualsTraits("WG"));
+                        && (cardSource.EqualsTraits("Vegetation") || cardSource.ContainsTraits("Fairy") || cardSource.EqualsTraits("WG"));
 
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_024.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("WG");
+                    return targetPermanent.TopCard.EqualsTraits("WG");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
@@ -37,11 +37,11 @@ namespace DCGO.CardEffects.BT26
                 bool PlayedPermanentCondition(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                         && permanent != card.PermanentOfThisCard()
-                        && (permanent.TopCard.ContainsTraits("Vegetation") || permanent.TopCard.ContainsTraits("Fairy") || permanent.TopCard.ContainsTraits("WG"));
+                        && (permanent.TopCard.ContainsTraits("Vegetation") || permanent.TopCard.ContainsTraits("Fairy") || permanent.TopCard.EqualsTraits("WG"));
 
                 bool CardCondition(CardSource cardSource)
                     => cardSource.IsDigimon
-                        && (cardSource.ContainsTraits("Vegetation") || cardSource.ContainsTraits("Fairy") || cardSource.ContainsTraits("WG"));
+                        && (cardSource.ContainsTraits("Vegetation") || cardSource.ContainsTraits("Fairy") || cardSource.EqualsTraits("WG"));
 
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)


### PR DESCRIPTION
## Summary
- Implements BT26-024 Tinkermon's card effect.
- Alternate digivolution requirement: Lv.2 w/[WG] trait, cost 0.
- [Your Turn] When any of your other Digimon with the [Vegetation], [Fairy] or [WG] trait are played, this Digimon may digivolve into a Digimon card with the [Vegetation], [Fairy] or [WG] trait in the hand without paying the cost.
- Inherited Barrier.