### PR TITLE
Add BT26-025 Liollmon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
@@ -35,9 +35,8 @@ namespace DCGO.CardEffects.BT26
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
                     && permanent.TopCard.ContainsTraits("Glowing Dawn");
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && card.Owner.SecurityCards.Count >= 1
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => card.Owner.SecurityCards.Count >= 1
                     && CardEffectCommons.HasMatchConditionPermanent(CanSelectTamerCondition);
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
@@ -84,36 +83,15 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region When Moving
-            if (timing == EffectTiming.OnMove)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Moving"));
-                cardEffects.Add(activateClass);
-
-                bool PermanentCondition(Permanent permanent)
-                    => permanent == card.PermanentOfThisCard();
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnMove(hashtable, PermanentCondition);
-            }
-            #endregion
-
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName(),
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                whenMoving: true,
+                onPlay: true);
 
             #region Inherit
             if (timing == EffectTiming.OnAllyAttack)

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -41,43 +40,40 @@ namespace DCGO.CardEffects.BT26
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
-                if (card.Owner.SecurityCards.Count >= 1 && CardEffectCommons.HasMatchConditionPermanent(CanSelectTamerCondition))
+                Permanent selectedTamer = null;
+
+                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                selectPermanentEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: CanSelectTamerCondition,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: 1,
+                    canNoSelect: true,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: SelectPermanentCoroutine,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Custom,
+                    cardEffect: activateClass);
+
+                IEnumerator SelectPermanentCoroutine(Permanent permanent)
                 {
-                    Permanent selectedTamer = null;
+                    selectedTamer = permanent;
+                    yield return null;
+                }
 
-                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                selectPermanentEffect.SetUpCustomMessage("Select 1 [Glowing Dawn] Tamer to place your top security card under.", "The opponent is selecting 1 [Glowing Dawn] Tamer to place their top security card under.");
 
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanSelectTamerCondition,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: true,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Custom,
-                        cardEffect: activateClass);
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
 
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        selectedTamer = permanent;
-                        yield return null;
-                    }
+                if (selectedTamer != null)
+                {
+                    CardSource topSecurityCard = card.Owner.SecurityCards[0];
 
-                    selectPermanentEffect.SetUpCustomMessage("Select 1 [Glowing Dawn] Tamer to place your top security card under.", "The opponent is selecting 1 [Glowing Dawn] Tamer to place their top security card under.");
+                    yield return ContinuousController.instance.StartCoroutine(selectedTamer.AddDigivolutionCardsBottom(new List<CardSource>() { topSecurityCard }, activateClass, isFacedown: true));
 
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                    if (selectedTamer != null && card.Owner.SecurityCards.Count >= 1)
-                    {
-                        CardSource topSecurityCard = card.Owner.SecurityCards[0];
-
-                        yield return ContinuousController.instance.StartCoroutine(selectedTamer.AddDigivolutionCardsBottom(new List<CardSource>() { topSecurityCard }, activateClass, isFacedown: true));
-
-                        yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
-                    }
+                    yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
                 }
             }
 
@@ -89,6 +85,7 @@ namespace DCGO.CardEffects.BT26
                 SharedActivateCoroutine,
                 SharedEffectDescription,
                 optional: false,
+                isSkippable: true,
                 additionalActivateCondition: SharedAdditionalActivateCondition,
                 whenMoving: true,
                 onPlay: true);
@@ -99,7 +96,7 @@ namespace DCGO.CardEffects.BT26
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Add top security to hand, then Recovery +1 if 0 security", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
-                activateClass.SetIsSkippable(true);
+                activateClass.SetIsSkippableFunction(IsSkippable);
                 activateClass.SetIsInheritedEffect(true);
                 activateClass.SetHashString("BT26_025_Inherit");
                 cardEffects.Add(activateClass);
@@ -112,45 +109,46 @@ namespace DCGO.CardEffects.BT26
                         && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                        && card.Owner.SecurityCards.Count >= 1;
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                bool IsSkippable(Hashtable hashtable) => card.Owner.SecurityCards.Count != 0;
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
                     bool isUsed = false;
 
-                    CardSource topCard = card.Owner.SecurityCards[0];
-
-                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
-
-                    selectCardEffect.SetUp(
-                        canTargetCondition: _ => true,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        canNoSelect: () => true,
-                        selectCardCoroutine: null,
-                        afterSelectCardCoroutine: AfterSelectCardCoroutine,
-                        message: "Add your top security card to the hand?",
-                        maxCount: 1,
-                        canEndNotMax: false,
-                        isShowOpponent: false,
-                        mode: SelectCardEffect.Mode.AddHand,
-                        root: SelectCardEffect.Root.Security,
-                        customRootCardList: new List<CardSource>() { topCard },
-                        canLookReverseCard: true,
-                        selectPlayer: card.Owner,
-                        cardEffect: activateClass);
-
-                    IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                    if (card.Owner.SecurityCards.Count >= 1)
                     {
-                        if (cardSources != null && cardSources.Count > 0) isUsed = true;
-                        yield return null;
-                    }
+                        List<SelectionElement<bool>> selectionElements = new List<SelectionElement<bool>>()
+                        {
+                            new SelectionElement<bool>(message: $"Yes", value : true, spriteIndex: 0),
+                            new SelectionElement<bool>(message: $"No", value : false, spriteIndex: 1),
+                        };
 
-                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+                        string selectPlayerMessage = "Will you add your top security card to hand?";
+                        string notSelectPlayerMessage = "The opponent is choosing whether or not to add their top security card to hand.";
+
+                        GManager.instance.userSelectionManager.SetBoolSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage, notSelectPlayerMessage: notSelectPlayerMessage);
+
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+
+                        bool willAdd = GManager.instance.userSelectionManager.SelectedBoolValue;
+
+                        if (willAdd)
+                        {
+                            isUsed = true;
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddHandCards(new List<CardSource>() { card.Owner.SecurityCards[0] }, false, activateClass));
+
+                            yield return ContinuousController.instance.StartCoroutine(new IReduceSecurity(
+                                player: card.Owner,
+                                refSkillInfos: ref ContinuousController.instance.nullSkillInfos,
+                                activateClass).ReduceSecurity());
+                        }
+                    }
 
                     if (card.Owner.SecurityCards.Count == 0)
                     {
+                        isUsed = true;
                         yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
                     }
 

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Glowing Dawn");
+                    return targetPermanent.TopCard.EqualsTraits("Glowing Dawn");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
@@ -33,7 +33,7 @@ namespace DCGO.CardEffects.BT26
 
             bool CanSelectTamerCondition(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
-                    && permanent.TopCard.ContainsTraits("Glowing Dawn");
+                    && permanent.TopCard.EqualsTraits("Glowing Dawn");
 
             bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
                 => card.Owner.SecurityCards.Count >= 1

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
@@ -98,7 +98,8 @@ namespace DCGO.CardEffects.BT26
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Add top security to hand, then Recovery +1 if 0 security", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 activateClass.SetIsInheritedEffect(true);
                 activateClass.SetHashString("BT26_025_Inherit");
                 cardEffects.Add(activateClass);
@@ -116,6 +117,8 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
+                    bool isUsed = false;
+
                     CardSource topCard = card.Owner.SecurityCards[0];
 
                     SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
@@ -126,7 +129,7 @@ namespace DCGO.CardEffects.BT26
                         canEndSelectCondition: null,
                         canNoSelect: () => true,
                         selectCardCoroutine: null,
-                        afterSelectCardCoroutine: null,
+                        afterSelectCardCoroutine: AfterSelectCardCoroutine,
                         message: "Add your top security card to the hand?",
                         maxCount: 1,
                         canEndNotMax: false,
@@ -138,12 +141,20 @@ namespace DCGO.CardEffects.BT26
                         selectPlayer: card.Owner,
                         cardEffect: activateClass);
 
+                    IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                    {
+                        if (cardSources != null && cardSources.Count > 0) isUsed = true;
+                        yield return null;
+                    }
+
                     yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
 
                     if (card.Owner.SecurityCards.Count == 0)
                     {
                         yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
                     }
+
+                    if (!isUsed) activateClass.RemoveUse();
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_025.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Liollmon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_025 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("Glowing Dawn");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
+            }
+            #endregion
+
+            #region Shared WM / OP
+
+            string SharedEffectName()
+                => "By placing top security under a [Glowing Dawn] Tamer, Recovery +1";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] By placing your top security card face down under any of your Digimon with the [Glowing Dawn] trait Tamers, <Recovery +1>.";
+
+            bool CanSelectTamerCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                    && permanent.TopCard.ContainsTraits("Glowing Dawn");
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && card.Owner.SecurityCards.Count >= 1
+                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectTamerCondition);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                if (card.Owner.SecurityCards.Count >= 1 && CardEffectCommons.HasMatchConditionPermanent(CanSelectTamerCondition))
+                {
+                    Permanent selectedTamer = null;
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectTamerCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        selectedTamer = permanent;
+                        yield return null;
+                    }
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 [Glowing Dawn] Tamer to place your top security card under.", "The opponent is selecting 1 [Glowing Dawn] Tamer to place their top security card under.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    if (selectedTamer != null && card.Owner.SecurityCards.Count >= 1)
+                    {
+                        CardSource topSecurityCard = card.Owner.SecurityCards[0];
+
+                        yield return ContinuousController.instance.StartCoroutine(selectedTamer.AddDigivolutionCardsBottom(new List<CardSource>() { topSecurityCard }, activateClass, isFacedown: true));
+
+                        yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
+                    }
+                }
+            }
+
+            #endregion
+
+            #region When Moving
+            if (timing == EffectTiming.OnMove)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Moving"));
+                cardEffects.Add(activateClass);
+
+                bool PermanentCondition(Permanent permanent)
+                    => permanent == card.PermanentOfThisCard();
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnMove(hashtable, PermanentCondition);
+            }
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region Inherit
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Add top security to hand, then Recovery +1 if 0 security", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("BT26_025_Inherit");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[When Attacking] [Once Per Turn] You may add your top security card to the hand. Then, if you have 0 security cards, <Recovery +1>.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && card.Owner.SecurityCards.Count >= 1;
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    CardSource topCard = card.Owner.SecurityCards[0];
+
+                    SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                    selectCardEffect.SetUp(
+                        canTargetCondition: _ => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        canNoSelect: () => true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: null,
+                        message: "Add your top security card to the hand?",
+                        maxCount: 1,
+                        canEndNotMax: false,
+                        isShowOpponent: false,
+                        mode: SelectCardEffect.Mode.AddHand,
+                        root: SelectCardEffect.Root.Security,
+                        customRootCardList: new List<CardSource>() { topCard },
+                        canLookReverseCard: true,
+                        selectPlayer: card.Owner,
+                        cardEffect: activateClass);
+
+                    yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+
+                    if (card.Owner.SecurityCards.Count == 0)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(new IRecovery(card.Owner, 1, activateClass).Recovery());
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements BT26-025 Liollmon's card effect.
- Alternate digivolution requirement: Lv.2 w/[Glowing Dawn] trait, cost 0.
- [When Moving] [On Play] By placing your top security card face down under any of your Digimon with the [Glowing Dawn] trait Tamers, <Recovery +1>.
- Inherited [When Attacking] [Once Per Turn] You may add your top security card to the hand. Then, if you have 0 security cards, <Recovery +1>.