### PR TITLE
Add BT26-034 Palmon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_034.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_034.cs
@@ -40,7 +40,7 @@ namespace DCGO.CardEffects.BT26
                     => "[Start of Your Main Phase] If you have 4 or less memory, this Digimon may digivolve into a Digimon card with the [Vegetation] or [TS] trait in the hand without paying the cost.";
 
                 bool CardCondition(CardSource cardSource)
-                    => cardSource.IsDigimon && (cardSource.ContainsTraits("Vegetation") || cardSource.HasTSTraits);
+                    => cardSource.IsDigimon && (cardSource.EqualsTraits("Vegetation") || cardSource.HasTSTraits);
 
                 bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
                     => card.Owner.MemoryForPlayer <= 4;

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_034.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_034.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Palmon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_034 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.HasTSTraits;
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
+            }
+            #endregion
+
+            #region Start of Your Main Phase
+            if (timing == EffectTiming.OnStartMainPhase)
+            {
+                cardEffects.Add(CardEffectFactory.StartOfYourMainPhaseClass(
+                    card,
+                    "If 4 or less memory, may digivolve into [Vegetation]/[TS] card in hand free",
+                    ActivateCoroutine,
+                    EffectDescription(),
+                    additionalActivateCondition: AdditionalActivateCondition,
+                    optional: false,
+                    isSkippable: true
+                ));
+
+                string EffectDescription()
+                    => "[Start of Your Main Phase] If you have 4 or less memory, this Digimon may digivolve into a Digimon card with the [Vegetation] or [TS] trait in the hand without paying the cost.";
+
+                bool CardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon && (cardSource.ContainsTraits("Vegetation") || cardSource.HasTSTraits);
+
+                bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                    => card.Owner.MemoryForPlayer <= 4;
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                        targetPermanent: card.PermanentOfThisCard(),
+                        cardCondition: CardCondition,
+                        payCost: false,
+                        reduceCostTuple: null,
+                        fixedCostTuple: null,
+                        ignoreDigivolutionRequirementFixedCost: -1,
+                        isHand: true,
+                        activateClass: activateClass,
+                        successProcess: null,
+                        isOptional: true));
+                }
+            }
+            #endregion
+
+            #region Inherit
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Suspend 1 opponent's Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("BT26_034_Inherit");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[When Attacking] [Once Per Turn] You may suspend 1 of your opponent's Digimon.";
+
+                bool CanSelectPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                        && !permanent.IsSuspended && permanent.CanSuspend;
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectPermanentCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: maxCount,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Tap,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to suspend.", "The opponent is selecting 1 Digimon to suspend.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_034.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_034.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -43,7 +42,8 @@ namespace DCGO.CardEffects.BT26
                     => cardSource.IsDigimon && (cardSource.EqualsTraits("Vegetation") || cardSource.HasTSTraits);
 
                 bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
-                    => card.Owner.MemoryForPlayer <= 4;
+                    => card.Owner.MemoryForPlayer <= 4
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, CardCondition);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
                 {
@@ -67,7 +67,8 @@ namespace DCGO.CardEffects.BT26
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Suspend 1 opponent's Digimon", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsOptional(true);
                 activateClass.SetIsInheritedEffect(true);
                 activateClass.SetHashString("BT26_034_Inherit");
                 cardEffects.Add(activateClass);
@@ -89,7 +90,8 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
+                    bool isUsed = false;
+                    Permanent selectedPermanent = null;
 
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
@@ -98,10 +100,10 @@ namespace DCGO.CardEffects.BT26
                         canTargetCondition: CanSelectPermanentCondition,
                         canTargetCondition_ByPreSelecetedList: null,
                         canEndSelectCondition: null,
-                        maxCount: maxCount,
+                        maxCount: 1,
                         canNoSelect: true,
                         canEndNotMax: false,
-                        selectPermanentCoroutine: null,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
                         afterSelectPermanentCoroutine: null,
                         mode: SelectPermanentEffect.Mode.Tap,
                         cardEffect: activateClass);
@@ -109,6 +111,17 @@ namespace DCGO.CardEffects.BT26
                     selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to suspend.", "The opponent is selecting 1 Digimon to suspend.");
 
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    IEnumerator SelectPermanentCoroutine (Permanent permanent)
+                    {
+                        if (selectedPermanent == null)
+                        {
+                            isUsed = true;
+                        }
+                        yield return null;
+                    }
+
+                    if (!isUsed) activateClass.RemoveUse();
                 }
             }
             #endregion


### PR DESCRIPTION
## Summary
- Implements BT26-034 Palmon's card effect.
- Alternate digivolution requirement: Lv.2 w/[TS] trait, cost 0.
- [Start of Your Main Phase] If you have 4 or less memory, this Digimon may digivolve into a Digimon card with the [Vegetation] or [TS] trait in the hand without paying the cost.
- Inherited [When Attacking] [Once Per Turn] You may suspend 1 of your opponent's Digimon.