### PR TITLE
Add BT26-045 GranKuwagamon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -88,9 +88,8 @@ namespace DCGO.CardEffects.BT26
                     && (cardSource.ContainsTraits("Insectoid") || cardSource.ContainsTraits("Titan"))
                     && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && CardEffectCommons.HasMatchConditionOwnersHand(card, cardSource => CanSelectHandCardCondition(cardSource, activateClass));
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionOwnersHand(card, cardSource => CanSelectHandCardCondition(cardSource, activateClass));
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -108,50 +107,18 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
-                activateClass.SetHashString("BT26_045_OP_WD_WA");
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
-                activateClass.SetHashString("BT26_045_OP_WD_WA");
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
-
-            #region When Attacking
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
-                activateClass.SetHashString("BT26_045_OP_WD_WA");
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName(),
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                maxCountPerTurn: 1,
+                hashValue: "BT26_045_OP_WD_WA",
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                onPlay: true,
+                whenDigivolving: true,
+                whenAttacking: true);
 
             #region Your Turn - Grant Alliance/Piercing/Vortex
             if (timing == EffectTiming.None)

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -23,53 +23,11 @@ namespace DCGO.CardEffects.BT26
             #endregion
 
             #region Reduce Play Cost
-            if (timing == EffectTiming.BeforePayCost)
+            if (timing == EffectTiming.None)
             {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Reduce play cost by 4", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
-                activateClass.SetHashString("BT26_045_ReducePlayCost");
-                cardEffects.Add(activateClass);
+                bool Condition() => card.Owner.HandCards.Count < card.Owner.Enemy.HandCards.Count;
 
-                string EffectDescription()
-                    => "When this card would be played, if your hand has fewer cards than your opponent's, reduce the cost by 4.";
-
-                bool CardCondition(CardSource cardSource) => cardSource == card;
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.CanTriggerWhenPermanentWouldPlay(hashtable, CardCondition);
-
-                bool CanActivateCondition(Hashtable hashtable)
-                    => card.Owner.HandCards.Count < card.Owner.Enemy.HandCards.Count
-                        && card.Owner.CanReduceCost(null, card);
-
-                IEnumerator ActivateCoroutine(Hashtable _hashtable)
-                {
-                    ChangeCostClass changeCostClass = new ChangeCostClass();
-                    changeCostClass.SetUpICardEffect("Play Cost -4", CanUseCondition1, card);
-                    changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardCondition, rootCondition: RootCondition, isUpDown: IsUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
-
-                    ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
-                    card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
-
-                    bool CanUseCondition1(Hashtable hashtable) => true;
-
-                    bool RootCondition(SelectCardEffect.Root root) => true;
-
-                    bool IsUpDown() => true;
-
-                    int ChangeCost(CardSource cardSource, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
-                    {
-                        if (CardCondition(cardSource) && card.Owner.HandCards.Count < card.Owner.Enemy.HandCards.Count)
-                        {
-                            cost -= 4;
-                        }
-
-                        return cost;
-                    }
-
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable));
-                }
+                cardEffects.Add(CardEffectFactory.MandatorySelfPlayCostReduction(4, card, Condition));
             }
             #endregion
 
@@ -127,40 +85,44 @@ namespace DCGO.CardEffects.BT26
                 whenDigivolving: true,
                 whenAttacking: true);
 
-            #region Your Turn - Grant Alliance/Piercing/Vortex
+            #region Grant Alliance/Piercing/Vortex
+
+            bool GrantPermanentCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                    && (permanent.TopCard.EqualsTraits("Insectoid") || permanent.TopCard.EqualsTraits("Titan"));
+
+            bool GrantCondition() => CardEffectCommons.IsOwnerTurn(card);
+
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                cardEffects.Add(CardEffectFactory.AllianceStaticEffect(GrantPermanentCondition, false, card, GrantCondition));
+            }
+
+            if (timing == EffectTiming.OnDetermineDoSecurityCheck)
+            {
+                foreach (Permanent permanent in card.Owner.GetBattleAreaDigimons().Filter(GrantPermanentCondition))
+                {
+                    cardEffects.Add(CardEffectFactory.PierceEffect(targetPermanent: permanent, isInheritedEffect: false, condition: GrantCondition, rootCardEffect: null, card: card));
+                }
+            }
+
             if (timing == EffectTiming.None)
             {
                 AddSkillClass addSkillClass = new AddSkillClass();
-                addSkillClass.SetUpICardEffect("Your [Insectoid]/[Titan] Digimon gain Alliance, Piercing and Vortex", CanUseCondition, card);
-                addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
+                addSkillClass.SetUpICardEffect("Your [Insectoid]/[Titan] Digimon gain Vortex", CanUseCondition, card);
+                addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects, limitTiming: EffectTiming.OnEndTurn);
                 cardEffects.Add(addSkillClass);
 
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaTrigger(card, addSkillClass);
 
-                bool PermanentCondition(Permanent permanent)
-                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
-                        && (permanent.TopCard.EqualsTraits("Insectoid") || permanent.TopCard.EqualsTraits("Titan"));
-
                 bool CardSourceCondition(CardSource cardSource)
                     => cardSource.PermanentOfThisCard() != null
-                        && PermanentCondition(cardSource.PermanentOfThisCard())
+                        && GrantPermanentCondition(cardSource.PermanentOfThisCard())
                         && cardSource == cardSource.PermanentOfThisCard().TopCard;
-
-                bool GrantCondition() => CardEffectCommons.IsOwnerTurn(card);
 
                 List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
                 {
-                    if (_timing == EffectTiming.OnAllyAttack)
-                    {
-                        cardEffects.Add(CardEffectFactory.AllianceSelfEffect(isInheritedEffect: false, card: cardSource, condition: GrantCondition));
-                    }
-
-                    if (_timing == EffectTiming.OnDetermineDoSecurityCheck)
-                    {
-                        cardEffects.Add(CardEffectFactory.PierceSelfEffect(isInheritedEffect: false, card: cardSource, condition: GrantCondition));
-                    }
-
                     if (_timing == EffectTiming.OnEndTurn)
                     {
                         cardEffects.Add(CardEffectFactory.VortexSelfEffect(isInheritedEffect: false, card: cardSource, condition: GrantCondition));

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// GranKuwagamon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_045 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("Insectoid") || targetPermanent.TopCard.HasTSTraits;
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
+            }
+            #endregion
+
+            #region Reduce Play Cost
+            if (timing == EffectTiming.BeforePayCost)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Reduce play cost by 4", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetHashString("BT26_045_ReducePlayCost");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "When this card would be played, if your hand has fewer cards than your opponent's, reduce the cost by 4.";
+
+                bool CardCondition(CardSource cardSource) => cardSource == card;
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerWhenPermanentWouldPlay(hashtable, CardCondition);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => card.Owner.HandCards.Count < card.Owner.Enemy.HandCards.Count
+                        && card.Owner.CanReduceCost(null, card);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    ChangeCostClass changeCostClass = new ChangeCostClass();
+                    changeCostClass.SetUpICardEffect("Play Cost -4", CanUseCondition1, card);
+                    changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardCondition, rootCondition: RootCondition, isUpDown: IsUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
+
+                    ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
+                    card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
+
+                    bool CanUseCondition1(Hashtable hashtable) => true;
+
+                    bool RootCondition(SelectCardEffect.Root root) => true;
+
+                    bool IsUpDown() => true;
+
+                    int ChangeCost(CardSource cardSource, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                    {
+                        if (CardCondition(cardSource) && card.Owner.HandCards.Count < card.Owner.Enemy.HandCards.Count)
+                        {
+                            cost -= 4;
+                        }
+
+                        return cost;
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable));
+                }
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving / When Attacking
+
+            string SharedEffectName()
+                => "May play 1 level 4 or lower [Insectoid]/[Titan] Digimon from hand free";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] [Once Per Turn] You may play 1 level 4 or lower Digimon card with the [Insectoid] or [Titan] trait from your hand without paying the cost.";
+
+            bool CanSelectHandCardCondition(CardSource cardSource, ICardEffect activateClass)
+                => cardSource.IsDigimon
+                    && cardSource.HasLevel && cardSource.Level <= 4
+                    && (cardSource.ContainsTraits("Insectoid") || cardSource.ContainsTraits("Titan"))
+                    && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && CardEffectCommons.HasMatchConditionOwnersHand(card, cardSource => CanSelectHandCardCondition(cardSource, activateClass));
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                bool CanSelectHandCardConditionBound(CardSource cardSource) => CanSelectHandCardCondition(cardSource, activateClass);
+
+                if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectHandCardConditionBound))
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                        canTargetCondition: CanSelectHandCardConditionBound,
+                        root: SelectCardEffect.Root.Hand,
+                        cardEffect: activateClass,
+                        payCost: false));
+                }
+            }
+
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
+                activateClass.SetHashString("BT26_045_OP_WD_WA");
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
+                activateClass.SetHashString("BT26_045_OP_WD_WA");
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
+                activateClass.SetHashString("BT26_045_OP_WD_WA");
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+            }
+            #endregion
+
+            #region Your Turn - Grant Alliance/Piercing/Vortex
+            if (timing == EffectTiming.None)
+            {
+                AddSkillClass addSkillClass = new AddSkillClass();
+                addSkillClass.SetUpICardEffect("Your [Insectoid]/[Titan] Digimon gain Alliance, Piercing and Vortex", CanUseCondition, card);
+                addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
+                cardEffects.Add(addSkillClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card);
+
+                bool PermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                        && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.ContainsTraits("Titan"));
+
+                bool CardSourceCondition(CardSource cardSource)
+                    => cardSource.PermanentOfThisCard() != null
+                        && PermanentCondition(cardSource.PermanentOfThisCard())
+                        && cardSource == cardSource.PermanentOfThisCard().TopCard;
+
+                bool GrantCondition() => CardEffectCommons.IsOwnerTurn(card);
+
+                List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
+                {
+                    if (_timing == EffectTiming.OnAllyAttack)
+                    {
+                        cardEffects.Add(CardEffectFactory.AllianceSelfEffect(isInheritedEffect: false, card: cardSource, condition: GrantCondition));
+                    }
+
+                    if (_timing == EffectTiming.OnDetermineDoSecurityCheck)
+                    {
+                        cardEffects.Add(CardEffectFactory.PierceSelfEffect(isInheritedEffect: false, card: cardSource, condition: GrantCondition));
+                    }
+
+                    if (_timing == EffectTiming.OnEndTurn)
+                    {
+                        cardEffects.Add(CardEffectFactory.VortexSelfEffect(isInheritedEffect: false, card: cardSource, condition: GrantCondition));
+                    }
+
+                    return cardEffects;
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -93,6 +93,8 @@ namespace DCGO.CardEffects.BT26
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
+                bool isUsed = false;
+
                 bool CanSelectHandCardConditionBound(CardSource cardSource) => CanSelectHandCardCondition(cardSource, activateClass);
 
                 if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectHandCardConditionBound))
@@ -101,8 +103,17 @@ namespace DCGO.CardEffects.BT26
                         canTargetCondition: CanSelectHandCardConditionBound,
                         root: SelectCardEffect.Root.Hand,
                         cardEffect: activateClass,
-                        payCost: false));
+                        payCost: false,
+                        afterSelectCardCoroutine: AfterSelectCardCoroutine));
+
+                    IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                    {
+                        if (cardSources != null && cardSources.Count > 0) isUsed = true;
+                        yield return null;
+                    }
                 }
+
+                if (!isUsed) activateClass.RemoveUse();
             }
 
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -114,7 +114,7 @@ namespace DCGO.CardEffects.BT26
                 cardEffects.Add(addSkillClass);
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, addSkillClass);
+                    => CardEffectCommons.IsExistOnBattleArea(card);
 
                 bool CardSourceCondition(CardSource cardSource)
                     => cardSource.PermanentOfThisCard() != null

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Insectoid") || targetPermanent.TopCard.HasTSTraits;
+                    return targetPermanent.TopCard.EqualsTraits("Insectoid") || targetPermanent.TopCard.HasTSTraits;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
@@ -85,7 +85,7 @@ namespace DCGO.CardEffects.BT26
             bool CanSelectHandCardCondition(CardSource cardSource, ICardEffect activateClass)
                 => cardSource.IsDigimon
                     && cardSource.HasLevel && cardSource.Level <= 4
-                    && (cardSource.ContainsTraits("Insectoid") || cardSource.EqualsTraits("Titan"))
+                    && (cardSource.EqualsTraits("Insectoid") || cardSource.EqualsTraits("Titan"))
                     && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
 
             bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
@@ -144,7 +144,7 @@ namespace DCGO.CardEffects.BT26
 
                 bool PermanentCondition(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
-                        && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.EqualsTraits("Titan"));
+                        && (permanent.TopCard.EqualsTraits("Insectoid") || permanent.TopCard.EqualsTraits("Titan"));
 
                 bool CardSourceCondition(CardSource cardSource)
                     => cardSource.PermanentOfThisCard() != null

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -140,7 +140,7 @@ namespace DCGO.CardEffects.BT26
                 cardEffects.Add(addSkillClass);
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card);
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass);
 
                 bool PermanentCondition(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -140,7 +140,7 @@ namespace DCGO.CardEffects.BT26
                 cardEffects.Add(addSkillClass);
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass);
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, addSkillClass);
 
                 bool PermanentCondition(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -85,7 +85,7 @@ namespace DCGO.CardEffects.BT26
             bool CanSelectHandCardCondition(CardSource cardSource, ICardEffect activateClass)
                 => cardSource.IsDigimon
                     && cardSource.HasLevel && cardSource.Level <= 4
-                    && (cardSource.ContainsTraits("Insectoid") || cardSource.ContainsTraits("Titan"))
+                    && (cardSource.ContainsTraits("Insectoid") || cardSource.EqualsTraits("Titan"))
                     && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
 
             bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
@@ -144,7 +144,7 @@ namespace DCGO.CardEffects.BT26
 
                 bool PermanentCondition(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
-                        && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.ContainsTraits("Titan"));
+                        && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.EqualsTraits("Titan"));
 
                 bool CardSourceCondition(CardSource cardSource)
                     => cardSource.PermanentOfThisCard() != null

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -75,7 +74,6 @@ namespace DCGO.CardEffects.BT26
             #endregion
 
             #region Shared On Play / When Digivolving / When Attacking
-
             string SharedEffectName()
                 => "May play 1 level 4 or lower [Insectoid]/[Titan] Digimon from hand free";
 
@@ -97,20 +95,17 @@ namespace DCGO.CardEffects.BT26
 
                 bool CanSelectHandCardConditionBound(CardSource cardSource) => CanSelectHandCardCondition(cardSource, activateClass);
 
-                if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectHandCardConditionBound))
-                {
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
-                        canTargetCondition: CanSelectHandCardConditionBound,
-                        root: SelectCardEffect.Root.Hand,
-                        cardEffect: activateClass,
-                        payCost: false,
-                        afterSelectCardCoroutine: AfterSelectCardCoroutine));
+                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                    canTargetCondition: CanSelectHandCardConditionBound,
+                    root: SelectCardEffect.Root.Hand,
+                    cardEffect: activateClass,
+                    payCost: false,
+                    afterSelectCardCoroutine: AfterSelectCardCoroutine));
 
-                    IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
-                    {
-                        if (cardSources != null && cardSources.Count > 0) isUsed = true;
-                        yield return null;
-                    }
+                IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                {
+                    if (cardSources != null && cardSources.Count > 0) isUsed = true;
+                    yield return null;
                 }
 
                 if (!isUsed) activateClass.RemoveUse();
@@ -124,6 +119,7 @@ namespace DCGO.CardEffects.BT26
                 SharedActivateCoroutine,
                 SharedEffectDescription,
                 optional: false,
+                isSkippable: true,
                 maxCountPerTurn: 1,
                 hashValue: "BT26_045_OP_WD_WA",
                 additionalActivateCondition: SharedAdditionalActivateCondition,


### PR DESCRIPTION
## Summary
- Implements BT26-045 GranKuwagamon's card effect.
- Alternate digivolution requirement: Lv.5 w/[Insectoid]/[TS] trait, cost 3.
- When this card would be played, if your hand has fewer cards than your opponent's, reduce the cost by 4.
- [On Play] [When Digivolving] [When Attacking] [Once Per Turn] You may play 1 level 4 or lower Digimon card with the [Insectoid] or [Titan] trait from your hand without paying the cost.
- [Your Turn] All of your Digimon with the [Insectoid] or [Titan] trait gain <Alliance>, <Piercing> and <Vortex>.