### PR TITLE
Add BT26-047 TyrantKabuterimon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
@@ -107,9 +107,8 @@ namespace DCGO.CardEffects.BT26
                 => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
                     && permanent.HasDP;
 
-            bool SharedCanActivateConditionA(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectBattleTargetCondition);
+            bool SharedAdditionalActivateConditionA(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionPermanent(CanSelectBattleTargetCondition);
 
             IEnumerator SharedActivateCoroutineA(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -142,33 +141,15 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region On Play A
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectNameA(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionA(hash, activateClass), (hash) => SharedActivateCoroutineA(hash, activateClass), -1, false, SharedEffectDescriptionA("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving A
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectNameA(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionA(hash, activateClass), (hash) => SharedActivateCoroutineA(hash, activateClass), -1, false, SharedEffectDescriptionA("When Digivolving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectNameA(),
+                SharedActivateCoroutineA,
+                SharedEffectDescriptionA,
+                optional: false,
+                additionalActivateCondition: SharedAdditionalActivateConditionA,
+                onPlay: true,
+                whenDigivolving: true);
 
             #region Shared Start of Your Main Phase / On Play / When Digivolving - Suspend to buff
 
@@ -187,9 +168,8 @@ namespace DCGO.CardEffects.BT26
                     && permanent.IsSuspended
                     && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.ContainsTraits("Titan"));
 
-            bool SharedCanActivateConditionB(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition);
+            bool SharedAdditionalActivateConditionB(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition);
 
             IEnumerator SharedActivateCoroutineB(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -275,43 +255,22 @@ namespace DCGO.CardEffects.BT26
                     SharedEffectNameB(),
                     (hash, activateClass) => SharedActivateCoroutineB(hash, activateClass),
                     SharedEffectDescriptionB("Start of Your Main Phase"),
-                    additionalActivateCondition: AdditionalActivateCondition,
+                    additionalActivateCondition: SharedAdditionalActivateConditionB,
                     optional: false,
                     isSkippable: true
                 ));
-
-                bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
-                    => CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition);
             }
             #endregion
 
-            #region On Play B
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectNameB(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionB(hash, activateClass), (hash) => SharedActivateCoroutineB(hash, activateClass), -1, false, SharedEffectDescriptionB("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving B
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectNameB(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionB(hash, activateClass), (hash) => SharedActivateCoroutineB(hash, activateClass), -1, false, SharedEffectDescriptionB("When Digivolving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectNameB(),
+                SharedActivateCoroutineB,
+                SharedEffectDescriptionB,
+                optional: false,
+                additionalActivateCondition: SharedAdditionalActivateConditionB,
+                onPlay: true,
+                whenDigivolving: true);
 
             return cardEffects;
         }

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
@@ -50,7 +50,7 @@ namespace DCGO.CardEffects.BT26
                                 && cardSource.Owner == card.Owner
                                 && cardSource.IsDigimon
                                 && cardSource.HasLevel
-                                && (cardSource.ContainsTraits("Larva") || cardSource.EqualsTraits("Insectoid") || cardSource.EqualsTraits("Titan"));
+                                && (cardSource.EqualsTraits("Larva") || cardSource.EqualsTraits("Insectoid") || cardSource.EqualsTraits("Titan"));
                         }
 
                         bool CanTargetCondition_ByPreSelecetedList(List<CardSource> cardSources, CardSource cardSource)

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
@@ -17,7 +17,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Insectoid") || targetPermanent.TopCard.HasTSTraits;
+                    return targetPermanent.TopCard.EqualsTraits("Insectoid") || targetPermanent.TopCard.HasTSTraits;
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
@@ -50,7 +50,7 @@ namespace DCGO.CardEffects.BT26
                                 && cardSource.Owner == card.Owner
                                 && cardSource.IsDigimon
                                 && cardSource.HasLevel
-                                && (cardSource.ContainsTraits("Larva") || cardSource.ContainsTraits("Insectoid") || cardSource.EqualsTraits("Titan"));
+                                && (cardSource.ContainsTraits("Larva") || cardSource.EqualsTraits("Insectoid") || cardSource.EqualsTraits("Titan"));
                         }
 
                         bool CanTargetCondition_ByPreSelecetedList(List<CardSource> cardSources, CardSource cardSource)
@@ -166,7 +166,7 @@ namespace DCGO.CardEffects.BT26
             bool IsSuspendedInsectoidOrTitan(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                     && permanent.IsSuspended
-                    && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.EqualsTraits("Titan"));
+                    && (permanent.TopCard.EqualsTraits("Insectoid") || permanent.TopCard.EqualsTraits("Titan"));
 
             bool SharedAdditionalActivateConditionB(Hashtable hashtable, ActivateClass activateClass)
                 => CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition);

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
@@ -50,7 +50,7 @@ namespace DCGO.CardEffects.BT26
                                 && cardSource.Owner == card.Owner
                                 && cardSource.IsDigimon
                                 && cardSource.HasLevel
-                                && (cardSource.ContainsTraits("Larva") || cardSource.ContainsTraits("Insectoid") || cardSource.ContainsTraits("Titan"));
+                                && (cardSource.ContainsTraits("Larva") || cardSource.ContainsTraits("Insectoid") || cardSource.EqualsTraits("Titan"));
                         }
 
                         bool CanTargetCondition_ByPreSelecetedList(List<CardSource> cardSources, CardSource cardSource)
@@ -166,7 +166,7 @@ namespace DCGO.CardEffects.BT26
             bool IsSuspendedInsectoidOrTitan(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                     && permanent.IsSuspended
-                    && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.ContainsTraits("Titan"));
+                    && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.EqualsTraits("Titan"));
 
             bool SharedAdditionalActivateConditionB(Hashtable hashtable, ActivateClass activateClass)
                 => CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition);

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// TyrantKabuterimon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_047 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("Insectoid") || targetPermanent.TopCard.HasTSTraits;
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
+            }
+            #endregion
+
+            #region Assembly
+            if (timing == EffectTiming.None)
+            {
+                AddAssemblyConditionClass addAssemblyConditionClass = new AddAssemblyConditionClass();
+                addAssemblyConditionClass.SetUpICardEffect($"Assembly", CanUseCondition, card);
+                addAssemblyConditionClass.SetUpAddAssemblyConditionClass(getAssemblyCondition: GetAssembly);
+                addAssemblyConditionClass.SetNotShowUI(true);
+                cardEffects.Add(addAssemblyConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return true;
+                }
+
+                AssemblyCondition GetAssembly(CardSource cardSource)
+                {
+                    if (cardSource == card)
+                    {
+                        AssemblyConditionElement element = new AssemblyConditionElement(CanSelectCardCondition);
+
+                        bool CanSelectCardCondition(CardSource cardSource)
+                        {
+                            return cardSource != null
+                                && cardSource.Owner == card.Owner
+                                && cardSource.IsDigimon
+                                && cardSource.HasLevel
+                                && (cardSource.ContainsTraits("Larva") || cardSource.ContainsTraits("Insectoid") || cardSource.ContainsTraits("Titan"));
+                        }
+
+                        bool CanTargetCondition_ByPreSelecetedList(List<CardSource> cardSources, CardSource cardSource)
+                        {
+                            List<int> cardLevels = new List<int>();
+
+                            foreach (CardSource cardSource1 in cardSources)
+                            {
+                                if (!cardLevels.Contains(cardSource1.Level))
+                                {
+                                    cardLevels.Add(cardSource1.Level);
+                                }
+                                foreach (int level in cardSource1.Level_Assembly)
+                                {
+                                    if (!cardLevels.Contains(level))
+                                    {
+                                        cardLevels.Add(level);
+                                    }
+                                }
+                            }
+
+                            if (cardSource.Level_Assembly.Count((level) => cardLevels.Contains(level)) >= 1 || cardLevels.Contains(cardSource.Level))
+                            {
+                                return false;
+                            }
+
+                            return true;
+                        }
+
+                        AssemblyCondition assemblyCondition = new AssemblyCondition(
+                            element: element,
+                            CanTargetCondition_ByPreSelecetedList: CanTargetCondition_ByPreSelecetedList,
+                            selectMessage: "4 [Larva]/[Insectoid]/[Titan] trait Digimon cards w/different levels",
+                            elementCount: 4,
+                            reduceCost: 6);
+
+                        return assemblyCondition;
+                    }
+
+                    return null;
+                }
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving - May Battle
+
+            string SharedEffectNameA()
+                => "This Digimon may battle 1 of your opponent's Digimon";
+
+            string SharedEffectDescriptionA(string tag)
+                => $"[{tag}] This Digimon may battle 1 of your opponent's Digimon.";
+
+            bool CanSelectBattleTargetCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                    && permanent.HasDP;
+
+            bool SharedCanActivateConditionA(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectBattleTargetCondition);
+
+            IEnumerator SharedActivateCoroutineA(Hashtable hashtable, ActivateClass activateClass)
+            {
+                int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectBattleTargetCondition));
+
+                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                selectPermanentEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: CanSelectBattleTargetCondition,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: maxCount,
+                    canNoSelect: true,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: SelectPermanentCoroutine,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Custom,
+                    cardEffect: activateClass);
+
+                selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to battle.", "The opponent is selecting 1 Digimon to battle.");
+
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new IBattle(card.PermanentOfThisCard(), permanent, null, true).Battle());
+                }
+            }
+
+            #endregion
+
+            #region On Play A
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectNameA(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionA(hash, activateClass), (hash) => SharedActivateCoroutineA(hash, activateClass), -1, false, SharedEffectDescriptionA("On Play"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving A
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectNameA(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionA(hash, activateClass), (hash) => SharedActivateCoroutineA(hash, activateClass), -1, false, SharedEffectDescriptionA("When Digivolving"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region Shared Start of Your Main Phase / On Play / When Digivolving - Suspend to buff
+
+            string SharedEffectNameB()
+                => "By suspending 1 Digimon, suspended [Insectoid]/[Titan] Digimon get +3000 DP and immune to opponent's Options";
+
+            string SharedEffectDescriptionB(string tag)
+                => $"[{tag}] By suspending 1 Digimon, until your opponent's turn ends, none of your suspended Digimon with the [Insectoid] or [Titan] trait are affected by your opponent's Option effects, and they get +3000 DP.";
+
+            bool CanSelectSuspendCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnBattleAreaDigimon(permanent)
+                    && !permanent.IsSuspended && permanent.CanSuspend;
+
+            bool IsSuspendedInsectoidOrTitan(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                    && permanent.IsSuspended
+                    && (permanent.TopCard.ContainsTraits("Insectoid") || permanent.TopCard.ContainsTraits("Titan"));
+
+            bool SharedCanActivateConditionB(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition);
+
+            IEnumerator SharedActivateCoroutineB(Hashtable hashtable, ActivateClass activateClass)
+            {
+                if (CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition))
+                {
+                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectSuspendCondition));
+
+                    SelectPermanentEffect selectSuspendEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectSuspendEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectSuspendCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: maxCount,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Tap,
+                        cardEffect: activateClass);
+
+                    selectSuspendEffect.SetUpCustomMessage("Select 1 Digimon to suspend.", "The opponent is selecting 1 Digimon to suspend.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectSuspendEffect.Activate());
+
+                    // +3000 DP dynamically re-applies to whichever of your [Insectoid]/[Titan] Digimon are
+                    // suspended for the rest of the duration (ChangeDigimonDPPlayerEffect re-checks
+                    // permanentCondition continuously, it's not a one-time snapshot).
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDPPlayerEffect(
+                        permanentCondition: IsSuspendedInsectoidOrTitan,
+                        changeValue: 3000,
+                        effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                        activateClass: activateClass));
+
+                    // No player-wide "isn't affected by opponent's Option effects" helper exists (only
+                    // self-targeted CanNotAffected-based keywords like Progress), so this is built here via
+                    // AddSkillClass mirroring how other player-wide dynamic grants (e.g. Progress) work.
+                    AddSkillClass addSkillClass = new AddSkillClass();
+                    addSkillClass.SetUpICardEffect("Isn't affected by opponent's Option effects", CanUseSkillCondition, card);
+                    addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
+                    CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilOpponentTurnEnd, card: card, cardEffect: addSkillClass, timing: EffectTiming.None);
+
+                    bool CanUseSkillCondition(Hashtable _hashtable) => true;
+
+                    bool CardSourceCondition(CardSource cardSource)
+                        => cardSource.PermanentOfThisCard() != null
+                            && IsSuspendedInsectoidOrTitan(cardSource.PermanentOfThisCard())
+                            && cardSource == cardSource.PermanentOfThisCard().TopCard;
+
+                    List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> effects, EffectTiming _timing)
+                    {
+                        if (_timing == EffectTiming.None)
+                        {
+                            CanNotAffectedClass canNotAffectedClass = new CanNotAffectedClass();
+                            canNotAffectedClass.SetUpICardEffect("Isn't affected by opponent's Option effects", CanUseInner, cardSource);
+                            canNotAffectedClass.SetUpCanNotAffectedClass(CardCondition: SelfCardCondition, SkillCondition: SkillCondition);
+                            effects.Add(canNotAffectedClass);
+
+                            bool CanUseInner(Hashtable _hashtable) => true;
+
+                            bool SelfCardCondition(CardSource cs) => cs == cardSource;
+
+                            bool SkillCondition(ICardEffect cardEffect)
+                                => cardEffect != null
+                                    && cardEffect.EffectSourceCard != null
+                                    && cardEffect.EffectSourceCard.Owner == card.Owner.Enemy
+                                    && cardEffect.EffectSourceCard.IsOption;
+                        }
+
+                        return effects;
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Start of Your Main Phase B
+            if (timing == EffectTiming.OnStartMainPhase)
+            {
+                cardEffects.Add(CardEffectFactory.StartOfYourMainPhaseClass(
+                    card,
+                    SharedEffectNameB(),
+                    (hash, activateClass) => SharedActivateCoroutineB(hash, activateClass),
+                    SharedEffectDescriptionB("Start of Your Main Phase"),
+                    additionalActivateCondition: AdditionalActivateCondition,
+                    optional: false,
+                    isSkippable: true
+                ));
+
+                bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                    => CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition);
+            }
+            #endregion
+
+            #region On Play B
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectNameB(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionB(hash, activateClass), (hash) => SharedActivateCoroutineB(hash, activateClass), -1, false, SharedEffectDescriptionB("On Play"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving B
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectNameB(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionB(hash, activateClass), (hash) => SharedActivateCoroutineB(hash, activateClass), -1, false, SharedEffectDescriptionB("When Digivolving"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_047.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -96,7 +95,6 @@ namespace DCGO.CardEffects.BT26
             #endregion
 
             #region Shared On Play / When Digivolving - May Battle
-
             string SharedEffectNameA()
                 => "This Digimon may battle 1 of your opponent's Digimon";
 
@@ -112,8 +110,6 @@ namespace DCGO.CardEffects.BT26
 
             IEnumerator SharedActivateCoroutineA(Hashtable hashtable, ActivateClass activateClass)
             {
-                int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectBattleTargetCondition));
-
                 SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                 selectPermanentEffect.SetUp(
@@ -121,7 +117,7 @@ namespace DCGO.CardEffects.BT26
                     canTargetCondition: CanSelectBattleTargetCondition,
                     canTargetCondition_ByPreSelecetedList: null,
                     canEndSelectCondition: null,
-                    maxCount: maxCount,
+                    maxCount: 1,
                     canNoSelect: true,
                     canEndNotMax: false,
                     selectPermanentCoroutine: SelectPermanentCoroutine,
@@ -138,7 +134,6 @@ namespace DCGO.CardEffects.BT26
                     yield return ContinuousController.instance.StartCoroutine(new IBattle(card.PermanentOfThisCard(), permanent, null, true).Battle());
                 }
             }
-
             #endregion
 
             CardEffectFactory.ActivateClassesForSharedEffects(
@@ -147,12 +142,12 @@ namespace DCGO.CardEffects.BT26
                 SharedActivateCoroutineA,
                 SharedEffectDescriptionA,
                 optional: false,
+                isSkippable: true,
                 additionalActivateCondition: SharedAdditionalActivateConditionA,
                 onPlay: true,
                 whenDigivolving: true);
 
             #region Shared Start of Your Main Phase / On Play / When Digivolving - Suspend to buff
-
             string SharedEffectNameB()
                 => "By suspending 1 Digimon, suspended [Insectoid]/[Titan] Digimon get +3000 DP and immune to opponent's Options";
 
@@ -173,92 +168,65 @@ namespace DCGO.CardEffects.BT26
 
             IEnumerator SharedActivateCoroutineB(Hashtable hashtable, ActivateClass activateClass)
             {
-                if (CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendCondition))
+                SelectPermanentEffect selectSuspendEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                selectSuspendEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: CanSelectSuspendCondition,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: 1,
+                    canNoSelect: false,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: null,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Tap,
+                    cardEffect: activateClass);
+
+                selectSuspendEffect.SetUpCustomMessage("Select 1 Digimon to suspend.", "The opponent is selecting 1 Digimon to suspend.");
+
+                yield return ContinuousController.instance.StartCoroutine(selectSuspendEffect.Activate());
+
+                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDPPlayerEffect(
+                    permanentCondition: IsSuspendedInsectoidOrTitan,
+                    changeValue: 3000,
+                    effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                    activateClass: activateClass));
+
+                AddSkillClass addSkillClass = new AddSkillClass();
+                addSkillClass.SetUpICardEffect("Isn't affected by opponent's Option effects", CanUseSkillCondition, card);
+                addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
+                CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilOpponentTurnEnd, card: card, cardEffect: addSkillClass, timing: EffectTiming.None);
+
+                bool CanUseSkillCondition(Hashtable _hashtable) => true;
+
+                bool CardSourceCondition(CardSource cardSource)
+                    => cardSource.PermanentOfThisCard() != null
+                        && IsSuspendedInsectoidOrTitan(cardSource.PermanentOfThisCard())
+                        && cardSource == cardSource.PermanentOfThisCard().TopCard;
+
+                List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> effects, EffectTiming _timing)
                 {
-                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectSuspendCondition));
-
-                    SelectPermanentEffect selectSuspendEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                    selectSuspendEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanSelectSuspendCondition,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: maxCount,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: null,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Tap,
-                        cardEffect: activateClass);
-
-                    selectSuspendEffect.SetUpCustomMessage("Select 1 Digimon to suspend.", "The opponent is selecting 1 Digimon to suspend.");
-
-                    yield return ContinuousController.instance.StartCoroutine(selectSuspendEffect.Activate());
-
-                    // +3000 DP dynamically re-applies to whichever of your [Insectoid]/[Titan] Digimon are
-                    // suspended for the rest of the duration (ChangeDigimonDPPlayerEffect re-checks
-                    // permanentCondition continuously, it's not a one-time snapshot).
-                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDPPlayerEffect(
-                        permanentCondition: IsSuspendedInsectoidOrTitan,
-                        changeValue: 3000,
-                        effectDuration: EffectDuration.UntilOpponentTurnEnd,
-                        activateClass: activateClass));
-
-                    // No player-wide "isn't affected by opponent's Option effects" helper exists (only
-                    // self-targeted CanNotAffected-based keywords like Progress), so this is built here via
-                    // AddSkillClass mirroring how other player-wide dynamic grants (e.g. Progress) work.
-                    AddSkillClass addSkillClass = new AddSkillClass();
-                    addSkillClass.SetUpICardEffect("Isn't affected by opponent's Option effects", CanUseSkillCondition, card);
-                    addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
-                    CardEffectCommons.AddEffectToPlayer(effectDuration: EffectDuration.UntilOpponentTurnEnd, card: card, cardEffect: addSkillClass, timing: EffectTiming.None);
-
-                    bool CanUseSkillCondition(Hashtable _hashtable) => true;
-
-                    bool CardSourceCondition(CardSource cardSource)
-                        => cardSource.PermanentOfThisCard() != null
-                            && IsSuspendedInsectoidOrTitan(cardSource.PermanentOfThisCard())
-                            && cardSource == cardSource.PermanentOfThisCard().TopCard;
-
-                    List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> effects, EffectTiming _timing)
+                    if (_timing == EffectTiming.None)
                     {
-                        if (_timing == EffectTiming.None)
-                        {
-                            CanNotAffectedClass canNotAffectedClass = new CanNotAffectedClass();
-                            canNotAffectedClass.SetUpICardEffect("Isn't affected by opponent's Option effects", CanUseInner, cardSource);
-                            canNotAffectedClass.SetUpCanNotAffectedClass(CardCondition: SelfCardCondition, SkillCondition: SkillCondition);
-                            effects.Add(canNotAffectedClass);
+                        CanNotAffectedClass canNotAffectedClass = new CanNotAffectedClass();
+                        canNotAffectedClass.SetUpICardEffect("Isn't affected by opponent's Option effects", CanUseInner, cardSource);
+                        canNotAffectedClass.SetUpCanNotAffectedClass(CardCondition: SelfCardCondition, SkillCondition: SkillCondition);
+                        effects.Add(canNotAffectedClass);
 
-                            bool CanUseInner(Hashtable _hashtable) => true;
+                        bool CanUseInner(Hashtable _hashtable) => true;
 
-                            bool SelfCardCondition(CardSource cs) => cs == cardSource;
+                        bool SelfCardCondition(CardSource cs) => cs == cardSource;
 
-                            bool SkillCondition(ICardEffect cardEffect)
-                                => cardEffect != null
-                                    && cardEffect.EffectSourceCard != null
-                                    && cardEffect.EffectSourceCard.Owner == card.Owner.Enemy
-                                    && cardEffect.EffectSourceCard.IsOption;
-                        }
-
-                        return effects;
+                        bool SkillCondition(ICardEffect cardEffect)
+                            => cardEffect != null
+                                && cardEffect.EffectSourceCard != null
+                                && cardEffect.EffectSourceCard.Owner == card.Owner.Enemy
+                                && cardEffect.EffectSourceCard.IsOption;
                     }
+
+                    return effects;
                 }
-            }
-
-            #endregion
-
-            #region Start of Your Main Phase B
-            if (timing == EffectTiming.OnStartMainPhase)
-            {
-                cardEffects.Add(CardEffectFactory.StartOfYourMainPhaseClass(
-                    card,
-                    SharedEffectNameB(),
-                    (hash, activateClass) => SharedActivateCoroutineB(hash, activateClass),
-                    SharedEffectDescriptionB("Start of Your Main Phase"),
-                    additionalActivateCondition: SharedAdditionalActivateConditionB,
-                    optional: false,
-                    isSkippable: true
-                ));
             }
             #endregion
 
@@ -268,7 +236,9 @@ namespace DCGO.CardEffects.BT26
                 SharedActivateCoroutineB,
                 SharedEffectDescriptionB,
                 optional: false,
+                isSkippable: true,
                 additionalActivateCondition: SharedAdditionalActivateConditionB,
+                startOfYourMainPhase: true,
                 onPlay: true,
                 whenDigivolving: true);
 


### PR DESCRIPTION
## Summary
- Implements BT26-047 TyrantKabuterimon's card effect.
- Alternate digivolution requirement: Lv.5 w/[Insectoid]/[TS] trait, cost 3.
- Assembly -6: 4 [Larva]/[Insectoid]/[Titan] trait Digimon cards w/different levels.
- [On Play] [When Digivolving] This Digimon may battle 1 of your opponent's Digimon.
- [Start of Your Main Phase] [On Play] [When Digivolving] By suspending 1 Digimon, until your opponent's turn ends, none of your suspended Digimon with the [Insectoid] or [Titan] trait are affected by your opponent's Option effects, and they get +3000 DP.
- No player-wide "isn't affected by opponent's Option effects" helper exists in the codebase (only self-targeted Progress-style keywords), so that part is built inline via `AddSkillClass`, dynamically re-evaluating which of your Insectoid/Titan Digimon are currently suspended (mirrors how `ChangeDigimonDPPlayerEffect` already handles the DP half). Flagging as a novel composition for review.