### PR TITLE
Add BT26-053 Wolvermon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_053.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_053.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Glowing Dawn");
+                    return targetPermanent.TopCard.EqualsTraits("Glowing Dawn");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));
@@ -51,7 +51,7 @@ namespace DCGO.CardEffects.BT26
 
                 bool CanSelectOptionCardCondition(CardSource cardSource)
                     => cardSource.IsOption
-                        && cardSource.ContainsTraits("Glowing Dawn")
+                        && cardSource.EqualsTraits("Glowing Dawn")
                         && cardSource.HasPlayCost && cardSource.GetCostItself <= 4
                         && !cardSource.CanNotPlayThisOption;
 

--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_053.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_053.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -42,7 +41,7 @@ namespace DCGO.CardEffects.BT26
                 string EffectDescription()
                     => "[All Turns] [Once Per Turn] When attack targets change, by trashing the bottom face-down card from under any of your Tamers, you may use 1 Option card with the [Glowing Dawn] trait and a use cost of 4 or less from your hand without paying the cost.";
 
-                bool IsTamerWithFaceDownCard(ICardEffect activateClass, Permanent permanent)
+                bool IsTamerWithFaceDownCard(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
                         && permanent.HasFaceDownDigivolutionCards
                         && !permanent.ImmuneFromStackTrashing(activateClass);
@@ -61,86 +60,87 @@ namespace DCGO.CardEffects.BT26
 
                 bool CanActivateCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                        && CardEffectCommons.HasMatchConditionPermanent(permanent => IsTamerWithFaceDownCard(activateClass, permanent));
+                        && CardEffectCommons.HasMatchConditionPermanent(permanent => IsTamerWithFaceDownCard(permanent));
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    bool IsTamerWithFaceDownCardBound(Permanent permanent) => IsTamerWithFaceDownCard(activateClass, permanent);
+                    bool isUsed = false;
 
-                    if (CardEffectCommons.HasMatchConditionPermanent(IsTamerWithFaceDownCardBound))
+                    Permanent selectedTamer = null;
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: IsTamerWithFaceDownCard,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
                     {
-                        Permanent selectedTamer = null;
+                        selectedTamer = permanent;
+                        yield return null;
+                    }
 
-                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash its bottom face-down card.", "The opponent is selecting 1 Tamer to trash its bottom face-down card.");
 
-                        selectPermanentEffect.SetUp(
-                            selectPlayer: card.Owner,
-                            canTargetCondition: IsTamerWithFaceDownCardBound,
-                            canTargetCondition_ByPreSelecetedList: null,
-                            canEndSelectCondition: null,
-                            maxCount: 1,
-                            canNoSelect: true,
-                            canEndNotMax: false,
-                            selectPermanentCoroutine: SelectPermanentCoroutine,
-                            afterSelectPermanentCoroutine: null,
-                            mode: SelectPermanentEffect.Mode.Custom,
-                            cardEffect: activateClass);
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
 
-                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    if (selectedTamer != null)
+                    {
+                        isUsed = true;
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedTamer, trashCount: 1, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+
+                        if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectOptionCardCondition))
                         {
-                            selectedTamer = permanent;
-                            yield return null;
-                        }
+                            CardSource selectedCard = null;
 
-                        selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash its bottom face-down card.", "The opponent is selecting 1 Tamer to trash its bottom face-down card.");
+                            SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
 
-                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                            selectHandEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: CanSelectOptionCardCondition,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: true,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                selectCardCoroutine: SelectCardCoroutine,
+                                afterSelectCardCoroutine: null,
+                                mode: SelectHandEffect.Mode.Custom,
+                                cardEffect: activateClass);
 
-                        if (selectedTamer != null)
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedTamer, trashCount: 1, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
-
-                            if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectOptionCardCondition))
+                            IEnumerator SelectCardCoroutine(CardSource cardSource)
                             {
-                                CardSource selectedCard = null;
+                                selectedCard = cardSource;
+                                yield return null;
+                            }
 
-                                SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+                            selectHandEffect.SetUpCustomMessage("Select 1 [Glowing Dawn] Option card to use.", "The opponent is selecting 1 [Glowing Dawn] Option card to use.");
+                            selectHandEffect.SetUpCustomMessage_ShowCard("Selected Card");
+                            yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
 
-                                selectHandEffect.SetUp(
-                                    selectPlayer: card.Owner,
-                                    canTargetCondition: CanSelectOptionCardCondition,
-                                    canTargetCondition_ByPreSelecetedList: null,
-                                    canEndSelectCondition: null,
-                                    maxCount: 1,
-                                    canNoSelect: true,
-                                    canEndNotMax: false,
-                                    isShowOpponent: true,
-                                    selectCardCoroutine: SelectCardCoroutine,
-                                    afterSelectCardCoroutine: null,
-                                    mode: SelectHandEffect.Mode.Custom,
-                                    cardEffect: activateClass);
-
-                                IEnumerator SelectCardCoroutine(CardSource cardSource)
-                                {
-                                    selectedCard = cardSource;
-                                    yield return null;
-                                }
-
-                                selectHandEffect.SetUpCustomMessage("Select 1 [Glowing Dawn] Option card to use.", "The opponent is selecting 1 [Glowing Dawn] Option card to use.");
-                                selectHandEffect.SetUpCustomMessage_ShowCard("Selected Card");
-                                yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
-
-                                if (selectedCard != null)
-                                {
-                                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
-                                        cardSources: new List<CardSource>() { selectedCard },
-                                        activateClass: activateClass,
-                                        payCost: false,
-                                        root: SelectCardEffect.Root.Hand));
-                                }
+                            if (selectedCard != null)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
+                                    cardSources: new List<CardSource>() { selectedCard },
+                                    activateClass: activateClass,
+                                    payCost: false,
+                                    root: SelectCardEffect.Root.Hand));
                             }
                         }
                     }
+
+                    if (!isUsed) activateClass.RemoveUse();
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_053.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_053.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Wolvermon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_053 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("Glowing Dawn");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));
+            }
+            #endregion
+
+            #region Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region All Turns
+            if (timing == EffectTiming.OnAttackTargetChanged)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("By trashing a Tamer's bottom face-down card, use 1 [Glowing Dawn] Option cost 4 or less free", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetHashString("BT26_053_AllTurns");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[All Turns] [Once Per Turn] When attack targets change, by trashing the bottom face-down card from under any of your Tamers, you may use 1 Option card with the [Glowing Dawn] trait and a use cost of 4 or less from your hand without paying the cost.";
+
+                bool IsTamerWithFaceDownCard(ICardEffect activateClass, Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                        && permanent.HasFaceDownDigivolutionCards
+                        && !permanent.ImmuneFromStackTrashing(activateClass);
+
+                bool FaceDownCards(CardSource cardSource) => cardSource.IsFaceDown;
+
+                bool CanSelectOptionCardCondition(CardSource cardSource)
+                    => cardSource.IsOption
+                        && cardSource.ContainsTraits("Glowing Dawn")
+                        && cardSource.HasPlayCost && cardSource.GetCostItself <= 4
+                        && !cardSource.CanNotPlayThisOption;
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPermanentAttackTargetSwitch(hashtable, permanent => true);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionPermanent(permanent => IsTamerWithFaceDownCard(activateClass, permanent));
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool IsTamerWithFaceDownCardBound(Permanent permanent) => IsTamerWithFaceDownCard(activateClass, permanent);
+
+                    if (CardEffectCommons.HasMatchConditionPermanent(IsTamerWithFaceDownCardBound))
+                    {
+                        Permanent selectedTamer = null;
+
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsTamerWithFaceDownCardBound,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            selectedTamer = permanent;
+                            yield return null;
+                        }
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash its bottom face-down card.", "The opponent is selecting 1 Tamer to trash its bottom face-down card.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        if (selectedTamer != null)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedTamer, trashCount: 1, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+
+                            if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectOptionCardCondition))
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                                    canTargetCondition: CanSelectOptionCardCondition,
+                                    root: SelectCardEffect.Root.Hand,
+                                    cardEffect: activateClass,
+                                    payCost: false));
+                            }
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Inherit - Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: true, card: card, condition: null));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_053.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_053.cs
@@ -52,7 +52,7 @@ namespace DCGO.CardEffects.BT26
                 bool CanSelectOptionCardCondition(CardSource cardSource)
                     => cardSource.IsOption
                         && cardSource.EqualsTraits("Glowing Dawn")
-                        && cardSource.HasPlayCost && cardSource.GetCostItself <= 4
+                        && cardSource.GetCostItself <= 4
                         && !cardSource.CanNotPlayThisOption;
 
                 bool CanUseCondition(Hashtable hashtable)
@@ -102,11 +102,42 @@ namespace DCGO.CardEffects.BT26
 
                             if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectOptionCardCondition))
                             {
-                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                                CardSource selectedCard = null;
+
+                                SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                                selectHandEffect.SetUp(
+                                    selectPlayer: card.Owner,
                                     canTargetCondition: CanSelectOptionCardCondition,
-                                    root: SelectCardEffect.Root.Hand,
-                                    cardEffect: activateClass,
-                                    payCost: false));
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    maxCount: 1,
+                                    canNoSelect: true,
+                                    canEndNotMax: false,
+                                    isShowOpponent: true,
+                                    selectCardCoroutine: SelectCardCoroutine,
+                                    afterSelectCardCoroutine: null,
+                                    mode: SelectHandEffect.Mode.Custom,
+                                    cardEffect: activateClass);
+
+                                IEnumerator SelectCardCoroutine(CardSource cardSource)
+                                {
+                                    selectedCard = cardSource;
+                                    yield return null;
+                                }
+
+                                selectHandEffect.SetUpCustomMessage("Select 1 [Glowing Dawn] Option card to use.", "The opponent is selecting 1 [Glowing Dawn] Option card to use.");
+                                selectHandEffect.SetUpCustomMessage_ShowCard("Selected Card");
+                                yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                                if (selectedCard != null)
+                                {
+                                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
+                                        cardSources: new List<CardSource>() { selectedCard },
+                                        activateClass: activateClass,
+                                        payCost: false,
+                                        root: SelectCardEffect.Root.Hand));
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Implements BT26-053 Wolvermon's card effect.
- Alternate digivolution requirement: Lv.3 w/[Glowing Dawn] trait, cost 2.
- Blocker.
- [All Turns] [Once Per Turn] When attack targets change, by trashing the bottom face-down card from under any of your Tamers, you may use 1 Option card with the [Glowing Dawn] trait and a use cost of 4 or less from your hand without paying the cost.
- Inherited Blocker.
- Note: file placed under the Black color folder based on the card art's frame color; flagging in case the color read is off.