### PR TITLE
Add BT26-056 Cerberusmon: Werewolf Mode // Inferno Divide card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_056.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_056.cs
@@ -72,7 +72,7 @@ namespace DCGO.CardEffects.BT26
                 bool CanSelectCardCondition(CardSource cardSource)
                     => cardSource.IsDigimon
                         && cardSource.HasLevel && cardSource.Level <= 4
-                        && cardSource.ContainsTraits("Titan")
+                        && cardSource.EqualsTraits("Titan")
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
 
                 bool CanUseCondition(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_056.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_056.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -12,7 +11,6 @@ namespace DCGO.CardEffects.BT26
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
             #region Digimon Effects
-
             #region Alternate Digivolution Requirement - Named
             if (timing == EffectTiming.None)
             {
@@ -64,6 +62,7 @@ namespace DCGO.CardEffects.BT26
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Play 1 level 4 or lower [Titan] Digimon from trash free", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
@@ -92,11 +91,9 @@ namespace DCGO.CardEffects.BT26
                 }
             }
             #endregion
-
             #endregion
 
             #region Option Effects
-
             #region Use Req.
             if (timing == EffectTiming.None)
             {
@@ -111,7 +108,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.OptionSkill)
             {
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Trash 1 hand card, then De-Digivolve 3 1 opponent's Digimon", CanUseCondition, card);
+                activateClass.SetUpICardEffect("Trash 1 hand card, then <De-Digivolve 3> 1 opponent's Digimon", CanUseCondition, card);
                 activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
 
@@ -119,8 +116,7 @@ namespace DCGO.CardEffects.BT26
                     => "[Main] Trash 1 card in your hand. Then, <De-Digivolve 3> 1 of your opponent's Digimon.";
 
                 bool CanSelectPermanentCondition(Permanent permanent)
-                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
-                        && permanent.DigivolutionCards.Count >= 1;
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
 
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
@@ -157,10 +153,8 @@ namespace DCGO.CardEffects.BT26
 
                         yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
 
-                        if (selectedCardToTrash != null && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
+                        if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {
-                            int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
-
                             SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                             selectPermanentEffect.SetUp(
@@ -168,7 +162,7 @@ namespace DCGO.CardEffects.BT26
                                 canTargetCondition: CanSelectPermanentCondition,
                                 canTargetCondition_ByPreSelecetedList: null,
                                 canEndSelectCondition: null,
-                                maxCount: maxCount,
+                                maxCount: 1,
                                 canNoSelect: false,
                                 canEndNotMax: false,
                                 selectPermanentCoroutine: null,
@@ -193,7 +187,6 @@ namespace DCGO.CardEffects.BT26
                 cardEffects.Add(CardEffectFactory.ArtsDigivolveEffect(card));
             }
             #endregion
-
             #endregion
 
             return cardEffects;

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_056.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_056.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Cerberusmon: Werewolf Mode // Inferno Divide
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_056 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Digimon Effects
+
+            #region Alternate Digivolution Requirement - Named
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.EqualsCardName("Cerberusmon");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 1, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Alternate Digivolution Requirement - Trait
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.HasTSTraits;
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 4));
+            }
+            #endregion
+
+            #region Jamming
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.JammingSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Reboot
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.RebootSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region On Deletion
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play 1 level 4 or lower [Titan] Digimon from trash free", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[On Deletion] You may play 1 level 4 or lower Digimon card with the [Titan] trait from your trash without paying the cost.";
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon
+                        && cardSource.HasLevel && cardSource.Level <= 4
+                        && cardSource.ContainsTraits("Titan")
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOnDeletion(hashtable, card, activateClass);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                        canTargetCondition: CanSelectCardCondition,
+                        root: SelectCardEffect.Root.Trash,
+                        cardEffect: activateClass,
+                        payCost: false));
+                }
+            }
+            #endregion
+
+            #endregion
+
+            #region Option Effects
+
+            #region Use Req.
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.UseRequirements(card, CardCondition));
+
+                bool CardCondition(CardSource cardSource)
+                    => cardSource.HasTSTraits;
+            }
+            #endregion
+
+            #region Main
+            if (timing == EffectTiming.OptionSkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Trash 1 hand card, then De-Digivolve 3 1 opponent's Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Main] Trash 1 card in your hand. Then, <De-Digivolve 3> 1 of your opponent's Digimon.";
+
+                bool CanSelectPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                        && permanent.DigivolutionCards.Count >= 1;
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (card.Owner.HandCards.Count >= 1)
+                    {
+                        CardSource selectedCardToTrash = null;
+
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: _ => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: SelectCardCoroutine,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        IEnumerator SelectCardCoroutine(CardSource cardSource)
+                        {
+                            selectedCardToTrash = cardSource;
+                            yield return null;
+                        }
+
+                        selectHandEffect.SetUpCustomMessage("Select 1 card to trash.", "The opponent is selecting 1 card to trash.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                        if (selectedCardToTrash != null && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
+                        {
+                            int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
+
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: CanSelectPermanentCondition,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: maxCount,
+                                canNoSelect: false,
+                                canEndNotMax: false,
+                                selectPermanentCoroutine: null,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Degenerate,
+                                cardEffect: activateClass);
+
+                            selectPermanentEffect.SetDegenerationCount(3);
+
+                            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to De-Digivolve.", "The opponent is selecting 1 Digimon to De-Digivolve.");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Arts Digivolution
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.ArtsDigivolveEffect(card));
+            }
+            #endregion
+
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements BT26-056 Cerberusmon: Werewolf Mode // Inferno Divide's DUAL Digimon/Option card effect.
- Digimon side: two alternate digivolution requirements — from a card named [Cerberusmon] for cost 1, or Lv.4 w/[TS] trait for cost 3. Jamming, Reboot, Blocker.
- [On Deletion] You may play 1 level 4 or lower Digimon card with the [Titan] trait from your trash without paying the cost.
- Option side (Inferno Divide): Use Req. <<[TS] trait>>, [Main] trash 1 card in your hand, then <De-Digivolve 3> 1 of your opponent's Digimon, Arts Digivolve.