### PR TITLE
Add BT26-061 Chiropmon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Glowing Dawn");
+                    return targetPermanent.TopCard.EqualsTraits("Glowing Dawn");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
@@ -40,9 +40,9 @@ namespace DCGO.CardEffects.BT26
                 bool CanActivateCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleArea(card);
 
-                bool GlowingDawnCondition(CardSource cardSource) => cardSource.ContainsTraits("Glowing Dawn");
+                bool GlowingDawnCondition(CardSource cardSource) => cardSource.EqualsTraits("Glowing Dawn");
 
-                bool PurpleBeatbreakCondition(CardSource cardSource) => cardSource.HasCardColor(CardColor.Purple) && cardSource.ContainsTraits("BEATBREAK");
+                bool PurpleBeatbreakCondition(CardSource cardSource) => cardSource.HasCardColor(CardColor.Purple) && cardSource.EqualsTraits("BEATBREAK");
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Chiropmon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_061 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("Glowing Dawn");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
+            }
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Reveal top 3, add 1 [Glowing Dawn] card and 1 purple [BEATBREAK] card to hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[On Play] Reveal the top 3 cards of your deck. Add 1 [Glowing Dawn] trait card and 1 purple [BEATBREAK] trait card among them to the hand. Return the rest to the bottom of the deck.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card);
+
+                bool GlowingDawnCondition(CardSource cardSource) => cardSource.ContainsTraits("Glowing Dawn");
+
+                bool PurpleBeatbreakCondition(CardSource cardSource) => cardSource.HasCardColor(CardColor.Purple) && cardSource.ContainsTraits("BEATBREAK");
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SimplifiedRevealDeckTopCardsAndSelect(
+                        revealCount: 3,
+                        simplifiedSelectCardConditions: new SimplifiedSelectCardConditionClass[]
+                        {
+                            new SimplifiedSelectCardConditionClass(
+                                canTargetCondition: GlowingDawnCondition,
+                                message: "Select 1 [Glowing Dawn] card to add to your hand.",
+                                mode: SelectCardEffect.Mode.AddHand,
+                                maxCount: 1,
+                                selectCardCoroutine: null),
+                            new SimplifiedSelectCardConditionClass(
+                                canTargetCondition: PurpleBeatbreakCondition,
+                                message: "Select 1 purple [BEATBREAK] card to add to your hand.",
+                                mode: SelectCardEffect.Mode.AddHand,
+                                maxCount: 1,
+                                selectCardCoroutine: null),
+                        },
+                        remainingCardsPlace: RemainingCardsPlace.DeckBottom,
+                        activateClass: activateClass
+                    ));
+                }
+            }
+            #endregion
+
+            #region Inherit
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Draw 1 and trash 1 card in hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("BT26_061_Inherit");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[When Attacking] [Once Per Turn] <Draw 1> and trash 1 card in your hand.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 1, activateClass).Draw());
+
+                    if (card.Owner.HandCards.Count >= 1)
+                    {
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: _ => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
@@ -38,7 +38,7 @@ namespace DCGO.CardEffects.BT26
                     => CardEffectCommons.CanTriggerOnPlay(hashtable, card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
 
                 bool GlowingDawnCondition(CardSource cardSource) => cardSource.EqualsTraits("Glowing Dawn");
 


### PR DESCRIPTION
## Summary
- Implements BT26-061 Chiropmon's card effect.
- Alternate digivolution requirement: Lv.2 w/[Glowing Dawn] trait, cost 0.
- [On Play] Reveal the top 3 cards of your deck. Add 1 [Glowing Dawn] trait card and 1 purple [BEATBREAK] trait card among them to the hand. Return the rest to the bottom of the deck.
- Inherited [When Attacking] [Once Per Turn] <Draw 1> and trash 1 card in your hand.