### PR TITLE
Add BT26-064 DemiDevimon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
@@ -38,7 +38,7 @@ namespace DCGO.CardEffects.BT26
                     => CardEffectCommons.CanTriggerOnPlay(hashtable, card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
 
                 bool DarkTraitCondition(CardSource cardSource)
                     => cardSource.EqualsTraits("Fallen Angel") || cardSource.EqualsTraits("Undead") || cardSource.EqualsTraits("Wizard") || cardSource.ContainsTraits("Demon Lord");

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
@@ -41,7 +41,7 @@ namespace DCGO.CardEffects.BT26
                     => CardEffectCommons.IsExistOnBattleArea(card);
 
                 bool DarkTraitCondition(CardSource cardSource)
-                    => cardSource.EqualsTraits("Fallen Angel") || cardSource.ContainsTraits("Undead") || cardSource.ContainsTraits("Wizard") || cardSource.ContainsTraits("Demon Lord");
+                    => cardSource.EqualsTraits("Fallen Angel") || cardSource.EqualsTraits("Undead") || cardSource.EqualsTraits("Wizard") || cardSource.ContainsTraits("Demon Lord");
 
                 bool TSCondition(CardSource cardSource) => cardSource.HasTSTraits;
 

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -35,13 +34,14 @@ namespace DCGO.CardEffects.BT26
                     => "[On Play] Reveal the top 3 cards of your deck. Add 1 card with the [Fallen Angel], [Undead], [Wizard] or [Demon Lord] trait and 1 card with the [TS] trait among them to the hand. Return the rest to the bottom of the deck.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+                    => CardEffectCommons.CanTriggerOnPlay(hashtable, card)
+                        && CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass);
 
                 bool CanActivateCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
 
                 bool DarkTraitCondition(CardSource cardSource)
-                    => cardSource.EqualsTraits("Fallen Angel") || cardSource.EqualsTraits("Undead") || cardSource.EqualsTraits("Wizard") || cardSource.ContainsTraits("Demon Lord");
+                    => cardSource.EqualsTraits("Fallen Angel") || cardSource.EqualsTraits("Undead") || cardSource.EqualsTraits("Wizard") || cardSource.EqualsTraits("Demon Lord");
 
                 bool TSCondition(CardSource cardSource) => cardSource.HasTSTraits;
 

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// DemiDevimon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_064 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.HasTSTraits;
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 2));
+            }
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Reveal top 3, add 1 [Fallen Angel]/[Undead]/[Wizard]/[Demon Lord] card and 1 [TS] card to hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[On Play] Reveal the top 3 cards of your deck. Add 1 card with the [Fallen Angel], [Undead], [Wizard] or [Demon Lord] trait and 1 card with the [TS] trait among them to the hand. Return the rest to the bottom of the deck.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card);
+
+                bool DarkTraitCondition(CardSource cardSource)
+                    => cardSource.ContainsTraits("Fallen Angel") || cardSource.ContainsTraits("Undead") || cardSource.ContainsTraits("Wizard") || cardSource.ContainsTraits("Demon Lord");
+
+                bool TSCondition(CardSource cardSource) => cardSource.HasTSTraits;
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SimplifiedRevealDeckTopCardsAndSelect(
+                        revealCount: 3,
+                        simplifiedSelectCardConditions: new SimplifiedSelectCardConditionClass[]
+                        {
+                            new SimplifiedSelectCardConditionClass(
+                                canTargetCondition: DarkTraitCondition,
+                                message: "Select 1 [Fallen Angel]/[Undead]/[Wizard]/[Demon Lord] card to add to your hand.",
+                                mode: SelectCardEffect.Mode.AddHand,
+                                maxCount: 1,
+                                selectCardCoroutine: null),
+                            new SimplifiedSelectCardConditionClass(
+                                canTargetCondition: TSCondition,
+                                message: "Select 1 [TS] card to add to your hand.",
+                                mode: SelectCardEffect.Mode.AddHand,
+                                maxCount: 1,
+                                selectCardCoroutine: null),
+                        },
+                        remainingCardsPlace: RemainingCardsPlace.DeckBottom,
+                        activateClass: activateClass
+                    ));
+                }
+            }
+            #endregion
+
+            #region Inherit
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Draw 1 and trash 1 card in hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("BT26_064_Inherit");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[When Attacking] [Once Per Turn] <Draw 1> and trash 1 card in your hand.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 1, activateClass).Draw());
+
+                    if (card.Owner.HandCards.Count >= 1)
+                    {
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: _ => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_064.cs
@@ -41,7 +41,7 @@ namespace DCGO.CardEffects.BT26
                     => CardEffectCommons.IsExistOnBattleArea(card);
 
                 bool DarkTraitCondition(CardSource cardSource)
-                    => cardSource.ContainsTraits("Fallen Angel") || cardSource.ContainsTraits("Undead") || cardSource.ContainsTraits("Wizard") || cardSource.ContainsTraits("Demon Lord");
+                    => cardSource.EqualsTraits("Fallen Angel") || cardSource.ContainsTraits("Undead") || cardSource.ContainsTraits("Wizard") || cardSource.ContainsTraits("Demon Lord");
 
                 bool TSCondition(CardSource cardSource) => cardSource.HasTSTraits;
 


### PR DESCRIPTION
## Summary
- Implements BT26-064 DemiDevimon's card effect.
- Alternate digivolution requirement: Lv.2 w/[TS] trait, cost 0.
- [On Play] Reveal the top 3 cards of your deck. Add 1 card with the [Fallen Angel], [Undead], [Wizard] or [Demon Lord] trait and 1 card with the [TS] trait among them to the hand. Return the rest to the bottom of the deck.
- Inherited [When Attacking] [Once Per Turn] <Draw 1> and trash 1 card in your hand.