### PR TITLE
Add BT26-070 NightChiropmon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
@@ -93,10 +93,10 @@ namespace DCGO.CardEffects.BT26
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2);
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card);
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && CardEffectCommons.HasMatchConditionPermanent(IsTamerWithEnoughFaceDownCards);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// NightChiropmon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_070 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("Glowing Dawn");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving - Draw & Trash
+
+            string SharedEffectNameA() => "Draw 1 and trash 1 card in hand";
+
+            string SharedEffectDescriptionA(string tag) => $"[{tag}] <Draw 1> and trash 1 card in your hand.";
+
+            bool SharedCanActivateConditionA(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+            IEnumerator SharedActivateCoroutineA(Hashtable hashtable, ActivateClass activateClass)
+            {
+                yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 1, activateClass).Draw());
+
+                if (card.Owner.HandCards.Count >= 1)
+                {
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: _ => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Discard,
+                        cardEffect: activateClass);
+
+                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                }
+            }
+
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectNameA(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionA(hash, activateClass), (hash) => SharedActivateCoroutineA(hash, activateClass), -1, false, SharedEffectDescriptionA("On Play"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectNameA(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionA(hash, activateClass), (hash) => SharedActivateCoroutineA(hash, activateClass), -1, false, SharedEffectDescriptionA("When Digivolving"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region Main - Trash 2 Facedown
+            if (timing == EffectTiming.OnDeclaration)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("By trashing 2 Tamer's bottom face-down cards, use 1 [Glowing Dawn] Option from trash for 2 less", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetHashString("BT26_070_Main");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Main] [Once Per Turn] By trashing 2 bottom face-down cards from under any of your Tamers, you may use 1 Option card with the [Glowing Dawn] trait from your trash with the cost reduced by 2.";
+
+                bool IsTamerWithEnoughFaceDownCards(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                        && permanent.DigivolutionCards.Count(cs => cs.IsFaceDown) >= 2
+                        && !permanent.ImmuneFromStackTrashing(activateClass);
+
+                bool FaceDownCards(CardSource cardSource) => cardSource.IsFaceDown;
+
+                bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect activateClass)
+                    => cardSource.IsOption
+                        && cardSource.ContainsTraits("Glowing Dawn")
+                        && !cardSource.CanNotPlayThisOption
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.HasMatchConditionPermanent(IsTamerWithEnoughFaceDownCards);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool isUsed = false;
+
+                    if (CardEffectCommons.HasMatchConditionPermanent(IsTamerWithEnoughFaceDownCards))
+                    {
+                        Permanent selectedTamer = null;
+
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsTamerWithEnoughFaceDownCards,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            selectedTamer = permanent;
+                            yield return null;
+                        }
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash 2 bottom face-down cards from.", "The opponent is selecting 1 Tamer to trash 2 bottom face-down cards from.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        if (selectedTamer != null)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedTamer, trashCount: 2, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+
+                            isUsed = true;
+
+                            bool CanSelectOptionCardConditionBound(CardSource cs) => CanSelectOptionCardCondition(cs, activateClass);
+
+                            if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectOptionCardConditionBound))
+                            {
+                                CardSource selectedCard = null;
+
+                                SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                                selectCardEffect.SetUp(
+                                    canTargetCondition: CanSelectOptionCardConditionBound,
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    canNoSelect: () => true,
+                                    selectCardCoroutine: SelectCardCoroutine,
+                                    afterSelectCardCoroutine: null,
+                                    message: "Select 1 [Glowing Dawn] Option card to use.",
+                                    maxCount: 1,
+                                    canEndNotMax: false,
+                                    isShowOpponent: true,
+                                    mode: SelectCardEffect.Mode.Custom,
+                                    root: SelectCardEffect.Root.Trash,
+                                    customRootCardList: null,
+                                    canLookReverseCard: true,
+                                    selectPlayer: card.Owner,
+                                    cardEffect: activateClass);
+
+                                IEnumerator SelectCardCoroutine(CardSource cs)
+                                {
+                                    selectedCard = cs;
+                                    yield return null;
+                                }
+
+                                selectCardEffect.SetUpCustomMessage("Select 1 [Glowing Dawn] Option card to use.", "The opponent is selecting 1 [Glowing Dawn] Option card to use.");
+                                selectCardEffect.SetUpCustomMessage_ShowCard("Selected Card");
+
+                                yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+
+                                if (selectedCard != null)
+                                {
+                                    int reduceCost = 2;
+
+                                    ChangeCostClass changeCostClass = new ChangeCostClass();
+                                    changeCostClass.SetUpICardEffect($"Use Cost -{reduceCost}", _ => true, card);
+                                    changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: PlayCondition, rootCondition: _ => true, isUpDown: () => true, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                                    Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
+                                    card.Owner.UntilCalculateFixedCostEffect.Add(getCardEffect);
+
+                                    ICardEffect GetCardEffect(EffectTiming _timing)
+                                        => _timing == EffectTiming.None ? changeCostClass : null;
+
+                                    bool PlayCondition(CardSource cs) => cs == selectedCard;
+
+                                    int ChangeCost(CardSource cs, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                                    {
+                                        if (PlayCondition(cs))
+                                        {
+                                            cost -= reduceCost;
+                                        }
+
+                                        return cost;
+                                    }
+
+                                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
+                                        cardSources: new List<CardSource>() { selectedCard },
+                                        activateClass: activateClass,
+                                        payCost: true,
+                                        root: SelectCardEffect.Root.Trash));
+
+                                    card.Owner.UntilCalculateFixedCostEffect.Remove(getCardEffect);
+                                }
+                            }
+                        }
+                    }
+
+                    if (!isUsed) activateClass.RemoveUse();
+                }
+            }
+            #endregion
+
+            #region Inherit - Retaliation
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                cardEffects.Add(CardEffectFactory.RetaliationSelfEffect(isInheritedEffect: true, card: card, condition: null));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
@@ -17,7 +17,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("Glowing Dawn");
+                    return targetPermanent.TopCard.EqualsTraits("Glowing Dawn");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));
@@ -88,7 +88,7 @@ namespace DCGO.CardEffects.BT26
 
                 bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect activateClass)
                     => cardSource.IsOption
-                        && cardSource.ContainsTraits("Glowing Dawn")
+                        && cardSource.EqualsTraits("Glowing Dawn")
                         && !cardSource.CanNotPlayThisOption
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2);
 

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
@@ -89,8 +89,7 @@ namespace DCGO.CardEffects.BT26
                 bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect activateClass)
                     => cardSource.IsOption
                         && cardSource.EqualsTraits("Glowing Dawn")
-                        && !cardSource.CanNotPlayThisOption
-                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2);
+                        && CardEffectCommons.CanPlayOrUse(cardSource, activateClass, root: SelectCardEffect.Root.Trash, fixedCost: cardSource.GetCostItself - 2);
 
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass);

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
@@ -30,9 +30,6 @@ namespace DCGO.CardEffects.BT26
 
             string SharedEffectDescriptionA(string tag) => $"[{tag}] <Draw 1> and trash 1 card in your hand.";
 
-            bool SharedCanActivateConditionA(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
-
             IEnumerator SharedActivateCoroutineA(Hashtable hashtable, ActivateClass activateClass)
             {
                 yield return ContinuousController.instance.StartCoroutine(new DrawClass(card.Owner, 1, activateClass).Draw());
@@ -61,33 +58,14 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectNameA(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionA(hash, activateClass), (hash) => SharedActivateCoroutineA(hash, activateClass), -1, false, SharedEffectDescriptionA("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectNameA(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateConditionA(hash, activateClass), (hash) => SharedActivateCoroutineA(hash, activateClass), -1, false, SharedEffectDescriptionA("When Digivolving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectNameA(),
+                SharedActivateCoroutineA,
+                SharedEffectDescriptionA,
+                optional: false,
+                onPlay: true,
+                whenDigivolving: true);
 
             #region Main - Trash 2 Facedown
             if (timing == EffectTiming.OnDeclaration)

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_070.cs
@@ -79,9 +79,14 @@ namespace DCGO.CardEffects.BT26
                 string EffectDescription()
                     => "[Main] [Once Per Turn] By trashing 2 bottom face-down cards from under any of your Tamers, you may use 1 Option card with the [Glowing Dawn] trait from your trash with the cost reduced by 2.";
 
-                bool IsTamerWithEnoughFaceDownCards(Permanent permanent)
+                bool TamerWithOneFaceDownSource(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
-                        && permanent.DigivolutionCards.Count(cs => cs.IsFaceDown) >= 2
+                        && permanent.DigivolutionCards.Any(FaceDownCards)
+                        && !permanent.ImmuneFromStackTrashing(activateClass);
+
+                bool TamerWith2OrMoreFaceDownSources(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                        && permanent.DigivolutionCards.Count(FaceDownCards) >= 2
                         && !permanent.ImmuneFromStackTrashing(activateClass);
 
                 bool FaceDownCards(CardSource cardSource) => cardSource.IsFaceDown;
@@ -96,45 +101,61 @@ namespace DCGO.CardEffects.BT26
 
                 bool CanActivateCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                        && CardEffectCommons.HasMatchConditionPermanent(IsTamerWithEnoughFaceDownCards);
+                        && (CardEffectCommons.HasMatchConditionPermanent(TamerWith2OrMoreFaceDownSources)
+                            || CardEffectCommons.MatchConditionPermanentCount(TamerWithOneFaceDownSource) >= 2);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
                     bool isUsed = false;
 
-                    if (CardEffectCommons.HasMatchConditionPermanent(IsTamerWithEnoughFaceDownCards))
+                    if (CardEffectCommons.HasMatchConditionPermanent(TamerWith2OrMoreFaceDownSources)
+                        || CardEffectCommons.MatchConditionPermanentCount(TamerWithOneFaceDownSource) >= 2)
                     {
-                        Permanent selectedTamer = null;
+                        bool trashed = false;
 
                         SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                        int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(TamerWithOneFaceDownSource));
 
                         selectPermanentEffect.SetUp(
                             selectPlayer: card.Owner,
-                            canTargetCondition: IsTamerWithEnoughFaceDownCards,
+                            canTargetCondition: TamerWithOneFaceDownSource,
                             canTargetCondition_ByPreSelecetedList: null,
-                            canEndSelectCondition: null,
-                            maxCount: 1,
+                            canEndSelectCondition: CanEndSelectCondition,
+                            maxCount: maxCount,
                             canNoSelect: true,
-                            canEndNotMax: false,
-                            selectPermanentCoroutine: SelectPermanentCoroutine,
-                            afterSelectPermanentCoroutine: null,
+                            canEndNotMax: true,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: AfterSelectPermanentCoroutine,
                             mode: SelectPermanentEffect.Mode.Custom,
                             cardEffect: activateClass);
 
-                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                        {
-                            selectedTamer = permanent;
-                            yield return null;
-                        }
-
-                        selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash 2 bottom face-down cards from.", "The opponent is selecting 1 Tamer to trash 2 bottom face-down cards from.");
+                        selectPermanentEffect.SetUpCustomMessage("Select all Tamer(s) to trash bottom face-down cards from.", "The opponent is selecting Tamer(s) to trash bottom face-down cards from.");
 
                         yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
 
-                        if (selectedTamer != null)
+                        bool CanEndSelectCondition(List<Permanent> permanents)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedTamer, trashCount: 2, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+                            return permanents.Count == 2
+                                || (permanents.Count > 0 && permanents[0].DigivolutionCards.Count(FaceDownCards) >= 2);
+                        }
 
+                        IEnumerator AfterSelectPermanentCoroutine(List<Permanent> permanents)
+                        {
+                            if (permanents.Count == 1)
+                            {
+                                trashed = true;
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: permanents[0], trashCount: 2, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+                            }
+                            else if (permanents.Count == 2)
+                            {
+                                trashed = true;
+                                foreach (Permanent selectedPermanent in permanents)
+                                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedPermanent, trashCount: 1, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+                            }
+                        }
+
+                        if (trashed)
+                        {
                             isUsed = true;
 
                             bool CanSelectOptionCardConditionBound(CardSource cs) => CanSelectOptionCardCondition(cs, activateClass);

--- a/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
@@ -281,6 +281,18 @@ public partial class CardEffectCommons
         #endregion
     }
 
+    #region CanPlayOrUse
+    public static bool CanPlayOrUse(CardSource cardSource, ICardEffect activateClass, SelectCardEffect.Root root = SelectCardEffect.Root.Hand, int fixedCost = -1)
+    {
+        return cardSource != null
+            && (cardSource.IsOption
+                && !cardSource.CanNotPlayThisOption
+                && cardSource.Owner.MaxMemoryCost >= fixedCost)
+            || (cardSource.HasPlayCost
+                && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: fixedCost > 0, cardEffect: activateClass, root: root, fixedCost: fixedCost));
+    }
+    #endregion
+
     //TODO: UseByEffect
 
     //TODO: PlayOrUseByEffect

--- a/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
@@ -294,18 +294,6 @@ public partial class CardEffectCommons
     }
     #endregion
 
-    #region CanPlayOrUse
-    public static bool CanPlayOrUse(CardSource cardSource, ICardEffect activateClass, SelectCardEffect.Root root = SelectCardEffect.Root.Hand, int fixedCost = -1)
-    {
-        return cardSource != null
-            && (cardSource.IsOption
-                && !cardSource.CanNotPlayThisOption
-                && cardSource.Owner.MaxMemoryCost >= fixedCost)
-            || (cardSource.HasPlayCost
-                && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: fixedCost > 0, cardEffect: activateClass, root: root, fixedCost: fixedCost));
-    }
-    #endregion
-
     //TODO: UseByEffect
 
     //TODO: PlayOrUseByEffect


### PR DESCRIPTION
## Summary
- Implements BT26-070 NightChiropmon's card effect.
- Alternate digivolution requirement: Lv.3 w/[Glowing Dawn] trait, cost 2.
- [On Play] [When Digivolving] <Draw 1> and trash 1 card in your hand.
- [Main] [Once Per Turn] By trashing 2 bottom face-down cards from under any of your Tamers, you may use 1 Option card with the [Glowing Dawn] trait from your trash with the cost reduced by 2.
- Inherited Retaliation.