### PR TITLE
Add BT26-074 Cerberusmon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
@@ -39,8 +39,7 @@ namespace DCGO.CardEffects.BT26
             bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect activateClass)
                 => cardSource.IsOption
                     && cardSource.EqualsTraits("Titan")
-                    && !cardSource.CanNotPlayThisOption
-                    && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2);
+                    && CardEffectCommons.CanPlayOrUse(cardSource, activateClass, root: SelectCardEffect.Root.Trash, fixedCost: cardSource.GetCostItself - 2);
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
@@ -44,6 +44,8 @@ namespace DCGO.CardEffects.BT26
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
+                bool isUsed = false;
+
                 if (card.Owner.HandCards.Count >= 1)
                 {
                     CardSource selectedCardToTrash = null;
@@ -74,6 +76,8 @@ namespace DCGO.CardEffects.BT26
 
                     if (selectedCardToTrash != null)
                     {
+                        isUsed = true;
+
                         yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashHandAndProcessAccordingToResult(
                             player: card.Owner,
                             hashtable: hashtable,
@@ -155,6 +159,8 @@ namespace DCGO.CardEffects.BT26
                         }
                     }
                 }
+
+                if (!isUsed) activateClass.RemoveUse();
             }
 
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
@@ -32,9 +32,8 @@ namespace DCGO.CardEffects.BT26
             string SharedEffectDescription(string tag)
                 => $"[{tag}] [Once Per Turn] If it's your turn, by trashing 1 card in your hand, you may use 1 Option card with the [Titan] trait from your trash with the cost reduced by 2.";
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && CardEffectCommons.IsOwnerTurn(card)
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.IsOwnerTurn(card)
                     && card.Owner.HandCards.Count >= 1;
 
             bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect activateClass)
@@ -160,50 +159,18 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
-                activateClass.SetHashString(SharedHashString);
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
-                activateClass.SetHashString(SharedHashString);
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
-
-            #region When Attacking
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
-                activateClass.SetHashString(SharedHashString);
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName(),
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                maxCountPerTurn: 1,
+                hashValue: SharedHashString,
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                onPlay: true,
+                whenDigivolving: true,
+                whenAttacking: true);
 
             #region Inherit - On Deletion
             if (timing == EffectTiming.OnDestroyedAnyone)

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("TS");
+                    return targetPermanent.TopCard.EqualsTraits("TS");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 4));
@@ -38,7 +38,7 @@ namespace DCGO.CardEffects.BT26
 
             bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect activateClass)
                 => cardSource.IsOption
-                    && cardSource.ContainsTraits("Titan")
+                    && cardSource.EqualsTraits("Titan")
                     && !cardSource.CanNotPlayThisOption
                     && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2);
 

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
@@ -36,11 +36,6 @@ namespace DCGO.CardEffects.BT26
                 => CardEffectCommons.IsOwnerTurn(card)
                     && card.Owner.HandCards.Count >= 1;
 
-            bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect activateClass)
-                => cardSource.IsOption
-                    && cardSource.EqualsTraits("Titan")
-                    && CardEffectCommons.CanPlayOrUse(cardSource, activateClass, root: SelectCardEffect.Root.Trash, fixedCost: cardSource.GetCostItself - 2);
-
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
                 bool isUsed = false;
@@ -87,16 +82,20 @@ namespace DCGO.CardEffects.BT26
 
                         IEnumerator SuccessProcess(CardSource cs)
                         {
-                            bool CanSelectOptionCardConditionBound(CardSource cardSource) => CanSelectOptionCardCondition(cardSource, activateClass);
+                            bool CanSelectOptionCardCondition(CardSource cardSource)
+                                => cardSource.EqualsTraits("Titan")
+                                && cardSource.IsOption
+                                && !cardSource.CanNotPlayThisOption
+                                && cardSource.Owner.MaxMemoryCost >= cardSource.GetCostItself - 2;
 
-                            if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectOptionCardConditionBound))
+                            if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectOptionCardCondition))
                             {
                                 CardSource selectedCard = null;
 
                                 SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
 
                                 selectCardEffect.SetUp(
-                                    canTargetCondition: CanSelectOptionCardConditionBound,
+                                    canTargetCondition: CanSelectOptionCardCondition,
                                     canTargetCondition_ByPreSelecetedList: null,
                                     canEndSelectCondition: null,
                                     canNoSelect: () => true,
@@ -196,15 +195,12 @@ namespace DCGO.CardEffects.BT26
                     => CardEffectCommons.CanTriggerOnDeletion(hashtable, card, activateClass);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass)
-                        && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
+                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                     {
-                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
-
                         SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                         selectPermanentEffect.SetUp(
@@ -212,7 +208,7 @@ namespace DCGO.CardEffects.BT26
                             canTargetCondition: CanSelectPermanentCondition,
                             canTargetCondition_ByPreSelecetedList: null,
                             canEndSelectCondition: null,
-                            maxCount: maxCount,
+                            maxCount: 1,
                             canNoSelect: false,
                             canEndNotMax: false,
                             selectPermanentCoroutine: null,

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_074.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Cerberusmon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_074 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("TS");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 4));
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving / When Attacking
+
+            string SharedHashString = "BT26_074_Shared";
+
+            string SharedEffectName() => "By trashing 1 hand card, use 1 [Titan] Option from trash for 2 less";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] [Once Per Turn] If it's your turn, by trashing 1 card in your hand, you may use 1 Option card with the [Titan] trait from your trash with the cost reduced by 2.";
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && CardEffectCommons.IsOwnerTurn(card)
+                    && card.Owner.HandCards.Count >= 1;
+
+            bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect activateClass)
+                => cardSource.IsOption
+                    && cardSource.ContainsTraits("Titan")
+                    && !cardSource.CanNotPlayThisOption
+                    && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself - 2);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                if (card.Owner.HandCards.Count >= 1)
+                {
+                    CardSource selectedCardToTrash = null;
+
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: _ => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
+                    {
+                        selectedCardToTrash = cardSource;
+                        yield return null;
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                    if (selectedCardToTrash != null)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashHandAndProcessAccordingToResult(
+                            player: card.Owner,
+                            hashtable: hashtable,
+                            cardToTrash: selectedCardToTrash,
+                            activateClass: activateClass,
+                            successProcess: SuccessProcess,
+                            failureProcess: null));
+
+                        IEnumerator SuccessProcess(CardSource cs)
+                        {
+                            bool CanSelectOptionCardConditionBound(CardSource cardSource) => CanSelectOptionCardCondition(cardSource, activateClass);
+
+                            if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectOptionCardConditionBound))
+                            {
+                                CardSource selectedCard = null;
+
+                                SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                                selectCardEffect.SetUp(
+                                    canTargetCondition: CanSelectOptionCardConditionBound,
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    canNoSelect: () => true,
+                                    selectCardCoroutine: SelectCardCoroutine,
+                                    afterSelectCardCoroutine: null,
+                                    message: "Select 1 [Titan] Option card to use.",
+                                    maxCount: 1,
+                                    canEndNotMax: false,
+                                    isShowOpponent: true,
+                                    mode: SelectCardEffect.Mode.Custom,
+                                    root: SelectCardEffect.Root.Trash,
+                                    customRootCardList: null,
+                                    canLookReverseCard: true,
+                                    selectPlayer: card.Owner,
+                                    cardEffect: activateClass);
+
+                                IEnumerator SelectCardCoroutine(CardSource cardSource)
+                                {
+                                    selectedCard = cardSource;
+                                    yield return null;
+                                }
+
+                                yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+
+                                if (selectedCard != null)
+                                {
+                                    int reduceCost = 2;
+
+                                    ChangeCostClass changeCostClass = new ChangeCostClass();
+                                    changeCostClass.SetUpICardEffect($"Use Cost -{reduceCost}", _ => true, card);
+                                    changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: PlayCondition, rootCondition: _ => true, isUpDown: () => true, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                                    Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
+                                    card.Owner.UntilCalculateFixedCostEffect.Add(getCardEffect);
+
+                                    ICardEffect GetCardEffect(EffectTiming _timing)
+                                        => _timing == EffectTiming.None ? changeCostClass : null;
+
+                                    bool PlayCondition(CardSource cs2) => cs2 == selectedCard;
+
+                                    int ChangeCost(CardSource cs2, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                                    {
+                                        if (PlayCondition(cs2))
+                                        {
+                                            cost -= reduceCost;
+                                        }
+
+                                        return cost;
+                                    }
+
+                                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
+                                        cardSources: new List<CardSource>() { selectedCard },
+                                        activateClass: activateClass,
+                                        payCost: true,
+                                        root: SelectCardEffect.Root.Trash));
+
+                                    card.Owner.UntilCalculateFixedCostEffect.Remove(getCardEffect);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("On Play"));
+                activateClass.SetHashString(SharedHashString);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
+                activateClass.SetHashString(SharedHashString);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
+                activateClass.SetHashString(SharedHashString);
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+            }
+            #endregion
+
+            #region Inherit - On Deletion
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Delete 1 opponent's lowest level Digimon", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[On Deletion] Delete 1 of your opponent's Digimon with the lowest level.";
+
+                bool CanSelectPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsMinLevel(permanent, card.Owner.Enemy);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOnDeletion(hashtable, card, activateClass);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
+                    {
+                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectPermanentCondition));
+
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectPermanentCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: maxCount,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon to delete.", "The opponent is selecting 1 Digimon to delete.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
@@ -281,6 +281,18 @@ public partial class CardEffectCommons
         #endregion
     }
 
+    #region CanPlayOrUse
+    public static bool CanPlayOrUse(CardSource cardSource, ICardEffect activateClass, SelectCardEffect.Root root = SelectCardEffect.Root.Hand, int fixedCost = -1)
+    {
+        return cardSource != null
+            && (cardSource.IsOption
+                && !cardSource.CanNotPlayThisOption
+                && cardSource.Owner.MaxMemoryCost >= fixedCost)
+            || (cardSource.HasPlayCost
+                && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: fixedCost > 0, cardEffect: activateClass, root: root, fixedCost: fixedCost));
+    }
+    #endregion
+
     //TODO: UseByEffect
 
     //TODO: PlayOrUseByEffect

--- a/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/PlayEffects.cs
@@ -294,18 +294,6 @@ public partial class CardEffectCommons
     }
     #endregion
 
-    #region CanPlayOrUse
-    public static bool CanPlayOrUse(CardSource cardSource, ICardEffect activateClass, SelectCardEffect.Root root = SelectCardEffect.Root.Hand, int fixedCost = -1)
-    {
-        return cardSource != null
-            && (cardSource.IsOption
-                && !cardSource.CanNotPlayThisOption
-                && cardSource.Owner.MaxMemoryCost >= fixedCost)
-            || (cardSource.HasPlayCost
-                && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: fixedCost > 0, cardEffect: activateClass, root: root, fixedCost: fixedCost));
-    }
-    #endregion
-
     //TODO: UseByEffect
 
     //TODO: PlayOrUseByEffect


### PR DESCRIPTION
## Summary
- Implements BT26-074 Cerberusmon's card effect.
- Alternate digivolution requirement: Lv.4 w/[TS] trait, cost 3.
- [On Play] [When Digivolving] [When Attacking] [Once Per Turn] If it's your turn, by trashing 1 card in your hand, you may use 1 Option card with the [Titan] trait from your trash with the cost reduced by 2.
- Inherited [On Deletion] Delete 1 of your opponent's Digimon with the lowest level.