### PR TITLE
Add BT26-076 Crowmon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_076.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_076.cs
@@ -17,7 +17,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("DATA SQUAD");
+                    return targetPermanent.TopCard.EqualsTraits("DATA SQUAD");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 4));
@@ -158,7 +158,7 @@ namespace DCGO.CardEffects.BT26
                             || CardEffectCommons.CanTriggerOnTrashDigivolutionCard(hashtable, OwnerTamerCondition, null, _ => true));
 
                 bool CanSelectCardCondition(CardSource cardSource)
-                    => cardSource.EqualsCardName("Ravemon") || cardSource.ContainsTraits("DATA SQUAD");
+                    => cardSource.EqualsCardName("Ravemon") || cardSource.EqualsTraits("DATA SQUAD");
 
                 bool CanActivateCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
@@ -196,7 +196,7 @@ namespace DCGO.CardEffects.BT26
                 bool CanSelectCardCondition(CardSource cardSource)
                     => cardSource.HasPlayCost
                         && cardSource.GetCostItself <= 5
-                        && (cardSource.ContainsTraits("Avian") || cardSource.ContainsTraits("Bird") || cardSource.ContainsTraits("DATA SQUAD"))
+                        && (cardSource.ContainsTraits("Avian") || cardSource.ContainsTraits("Bird") || cardSource.EqualsTraits("DATA SQUAD"))
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
 
                 bool CanUseCondition(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_076.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_076.cs
@@ -194,7 +194,7 @@ namespace DCGO.CardEffects.BT26
                     => "[On Deletion] You may play 1 play cost 5 or lower card with [Avian] or [Bird] in any of its traits or the [DATA SQUAD] trait from your trash without paying the cost.";
 
                 bool CanSelectCardCondition(CardSource cardSource)
-                    => cardSource.HasCost
+                    => cardSource.HasPlayCost
                         && cardSource.GetCostItself <= 5
                         && (cardSource.ContainsTraits("Avian") || cardSource.ContainsTraits("Bird") || cardSource.ContainsTraits("DATA SQUAD"))
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_076.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_076.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -50,15 +49,12 @@ namespace DCGO.CardEffects.BT26
                         && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                        && CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetCondition);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
                     if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetCondition))
                     {
-                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectDeleteTargetCondition));
-
                         SelectPermanentEffect selectDeleteEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                         selectDeleteEffect.SetUp(
@@ -66,7 +62,7 @@ namespace DCGO.CardEffects.BT26
                             canTargetCondition: CanSelectDeleteTargetCondition,
                             canTargetCondition_ByPreSelecetedList: null,
                             canEndSelectCondition: null,
-                            maxCount: maxCount,
+                            maxCount: 1,
                             canNoSelect: false,
                             canEndNotMax: false,
                             selectPermanentCoroutine: null,
@@ -186,7 +182,8 @@ namespace DCGO.CardEffects.BT26
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Play 1 [Avian]/[Bird]/[DATA SQUAD] card cost 5 or less from trash", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 activateClass.SetIsInheritedEffect(true);
                 cardEffects.Add(activateClass);
 

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_076.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_076.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// Crowmon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_076 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("DATA SQUAD");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 4));
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Delete 1 lvl 4 or lower. Then, by trashing 1 Tamer's bottom face-down card, opponent trashes 1 hand card", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[When Digivolving] Delete 1 of your opponent's level 4 or lower Digimon. Then, by trashing the bottom face-down card from under any of your Tamers, they trash 1 card in their hand.";
+
+                bool CanSelectDeleteTargetCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                        && permanent.TopCard.HasLevel && permanent.TopCard.Level <= 4;
+
+                bool IsTamerWithFaceDownCard(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                        && permanent.DigivolutionCards.Count(cs => cs.IsFaceDown) >= 1;
+
+                bool FaceDownCards(CardSource cardSource) => cardSource.IsFaceDown;
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetCondition))
+                    {
+                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectDeleteTargetCondition));
+
+                        SelectPermanentEffect selectDeleteEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectDeleteEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectDeleteTargetCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: maxCount,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: null,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Destroy,
+                            cardEffect: activateClass);
+
+                        selectDeleteEffect.SetUpCustomMessage("Select 1 Digimon to delete.", "The opponent is selecting 1 Digimon to delete.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectDeleteEffect.Activate());
+                    }
+
+                    if (CardEffectCommons.HasMatchConditionPermanent(IsTamerWithFaceDownCard))
+                    {
+                        Permanent selectedTamer = null;
+
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsTamerWithFaceDownCard,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            selectedTamer = permanent;
+                            yield return null;
+                        }
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash the bottom face-down card from.", "The opponent is selecting 1 Tamer to trash the bottom face-down card from.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        if (selectedTamer != null)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedTamer, trashCount: 1, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+
+                            SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                            selectHandEffect.SetUp(
+                                selectPlayer: card.Owner.Enemy,
+                                canTargetCondition: _ => true,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: false,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                selectCardCoroutine: null,
+                                afterSelectCardCoroutine: null,
+                                mode: SelectHandEffect.Mode.Discard,
+                                cardEffect: activateClass);
+
+                            yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Reactive Digivolve
+            if (timing == EffectTiming.OnDiscardHand || timing == EffectTiming.OnDigivolutionCardDiscarded)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Digivolve into [Ravemon]/[DATA SQUAD] from trash for 1 less", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetHashString("BT26_076_YT");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Your Turn] [Once Per Turn] When your opponent's hand is trashed from or effects trash cards from under your Tamers, this Digimon may digivolve into [Ravemon] or a [DATA SQUAD] trait Digimon card in the trash with the cost reduced by 1.";
+
+                bool OpponentHandCardCondition(CardSource cardSource) => cardSource.Owner == card.Owner.Enemy;
+
+                bool OwnerTamerCondition(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.IsOwnerTurn(card)
+                        && (CardEffectCommons.CanTriggerOnTrashHand(hashtable, null, OpponentHandCardCondition)
+                            || CardEffectCommons.CanTriggerOnTrashDigivolutionCard(hashtable, OwnerTamerCondition, null, _ => true));
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                    => cardSource.EqualsCardName("Ravemon") || cardSource.ContainsTraits("DATA SQUAD");
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                        card.PermanentOfThisCard(),
+                        CanSelectCardCondition,
+                        payCost: true,
+                        reduceCostTuple: (reduceCost: 1, reduceCostCardCondition: null),
+                        fixedCostTuple: null,
+                        ignoreDigivolutionRequirementFixedCost: -1,
+                        isHand: false,
+                        activateClass: activateClass,
+                        successProcess: null
+                    ));
+                }
+            }
+            #endregion
+
+            #region Inherit - On Deletion
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play 1 [Avian]/[Bird]/[DATA SQUAD] card cost 5 or less from trash", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[On Deletion] You may play 1 play cost 5 or lower card with [Avian] or [Bird] in any of its traits or the [DATA SQUAD] trait from your trash without paying the cost.";
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                    => cardSource.HasCost
+                        && cardSource.GetCostItself <= 5
+                        && (cardSource.ContainsTraits("Avian") || cardSource.ContainsTraits("Bird") || cardSource.ContainsTraits("DATA SQUAD"))
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOnDeletion(hashtable, card, activateClass);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                        canTargetCondition: CanSelectCardCondition,
+                        root: SelectCardEffect.Root.Trash,
+                        cardEffect: activateClass,
+                        payCost: false));
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements BT26-076 Crowmon's card effect.
- Alternate digivolution requirement: Lv.4 w/[DATA SQUAD] trait, cost 3.
- [When Digivolving] Delete 1 of your opponent's level 4 or lower Digimon. Then, by trashing the bottom face-down card from under any of your Tamers, they trash 1 card in their hand.
- [Your Turn] [Once Per Turn] When your opponent's hand is trashed from or effects trash cards from under your Tamers, this Digimon may digivolve into [Ravemon] or a [DATA SQUAD] trait Digimon card in the trash with the cost reduced by 1.
- Inherited [On Deletion] You may play 1 play cost 5 or lower card with [Avian] or [Bird] in any of its traits or the [DATA SQUAD] trait from your trash without paying the cost.