### PR TITLE
Add BT26-079 ZombiePlutomon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_079.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_079.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// ZombiePlutomon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_079 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("TS");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
+            }
+            #endregion
+
+            #region Trash Main
+            if (timing == EffectTiming.OnDeclaration)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play this card from trash with reduced cost", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsDigimonEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Trash] [Main] If your hand has 5 or fewer cards, play this card with the cost reduced by 4.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsOwnerTurn(card)
+                        && CardEffectCommons.IsExistOnTrash(card)
+                        && card.Owner.HandCards.Count <= 5;
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    int reduceCost = 4;
+
+                    ChangeCostClass changeCostClass = new ChangeCostClass();
+                    changeCostClass.SetUpICardEffect($"Play Cost -{reduceCost}", _ => true, card);
+                    changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: _ => true, isUpDown: () => true, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                    Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
+                    card.Owner.UntilCalculateFixedCostEffect.Add(getCardEffect);
+
+                    ICardEffect GetCardEffect(EffectTiming _timing)
+                        => _timing == EffectTiming.None ? changeCostClass : null;
+
+                    int ChangeCost(CardSource cardSource, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                        => CardSourceCondition(cardSource) ? cost - reduceCost : cost;
+
+                    bool CardSourceCondition(CardSource cardSource) => cardSource == card;
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                        cardSources: new List<CardSource> { card },
+                        activateClass: activateClass,
+                        payCost: true,
+                        isTapped: false,
+                        root: SelectCardEffect.Root.Trash,
+                        activateETB: true));
+
+                    card.Owner.UntilCalculateFixedCostEffect.Remove(getCardEffect);
+                }
+            }
+            #endregion
+
+            #region Security A. +1
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.ChangeSelfSAttackStaticEffect(changeValue: 1, isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Decode
+            if (timing == EffectTiming.WhenRemoveField)
+            {
+                bool SourceCondition(CardSource cardSource)
+                    => cardSource.IsDigimon && cardSource.EqualsCardName("Plutomon");
+
+                string[] decodeStrings = { "(w/[Plutomon] in name)", "Digimon card with [Plutomon] in its name" };
+                cardEffects.Add(CardEffectFactory.DecodeSelfEffect(card: card, isInheritedEffect: false, decodeStrings: decodeStrings, sourceCondition: SourceCondition, condition: null));
+            }
+            #endregion
+
+            #region Retaliation
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                cardEffects.Add(CardEffectFactory.RetaliationSelfEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving / When Attacking
+
+            string SharedEffectName() => "By trashing 1 hand card, delete 1 opponent's level 6 or lower Digimon";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] By trashing 1 card in your hand, delete 1 of your opponent's level 6 or lower Digimon.";
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && card.Owner.HandCards.Count >= 1;
+
+            bool CanSelectDeleteTargetCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                    && permanent.TopCard.HasLevel && permanent.TopCard.Level <= 6;
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                if (card.Owner.HandCards.Count >= 1)
+                {
+                    CardSource selectedCardToTrash = null;
+
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: _ => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
+                    {
+                        selectedCardToTrash = cardSource;
+                        yield return null;
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                    if (selectedCardToTrash != null)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashHandAndProcessAccordingToResult(
+                            player: card.Owner,
+                            hashtable: hashtable,
+                            cardToTrash: selectedCardToTrash,
+                            activateClass: activateClass,
+                            successProcess: SuccessProcess,
+                            failureProcess: null));
+
+                        IEnumerator SuccessProcess(CardSource cs)
+                        {
+                            if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetCondition))
+                            {
+                                int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectDeleteTargetCondition));
+
+                                SelectPermanentEffect selectDeleteEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                                selectDeleteEffect.SetUp(
+                                    selectPlayer: card.Owner,
+                                    canTargetCondition: CanSelectDeleteTargetCondition,
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    maxCount: maxCount,
+                                    canNoSelect: false,
+                                    canEndNotMax: false,
+                                    selectPermanentCoroutine: null,
+                                    afterSelectPermanentCoroutine: null,
+                                    mode: SelectPermanentEffect.Mode.Destroy,
+                                    cardEffect: activateClass);
+
+                                selectDeleteEffect.SetUpCustomMessage("Select 1 Digimon to delete.", "The opponent is selecting 1 Digimon to delete.");
+
+                                yield return ContinuousController.instance.StartCoroutine(selectDeleteEffect.Activate());
+                            }
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+            }
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Digivolving"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Attacking"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+            }
+            #endregion
+
+            #region All Turns - Both players trash hand to 4
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Both players trash hand cards until 4 left", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetHashString("BT26_079_AT");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[All Turns] [Once Per Turn] When any of your opponent's Digimon are played or digivolve, both players trash cards in their hand so that they have 4 left.";
+
+                bool OpponentDigimonCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && (CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, OpponentDigimonCondition)
+                            || CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, OpponentDigimonCondition));
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    foreach (Player player in GManager.instance.turnStateMachine.gameContext.Players)
+                    {
+                        if (player.HandCards.Count > 4)
+                        {
+                            int discardCount = player.HandCards.Count - 4;
+
+                            SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                            selectHandEffect.SetUp(
+                                selectPlayer: player,
+                                canTargetCondition: _ => true,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: discardCount,
+                                canNoSelect: false,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                selectCardCoroutine: null,
+                                afterSelectCardCoroutine: null,
+                                mode: SelectHandEffect.Mode.Discard,
+                                cardEffect: activateClass);
+
+                            yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Assembly
+            if (timing == EffectTiming.None)
+            {
+                AddAssemblyConditionClass addAssemblyConditionClass = new AddAssemblyConditionClass();
+                addAssemblyConditionClass.SetUpICardEffect("Assembly", CanUseCondition, card);
+                addAssemblyConditionClass.SetUpAddAssemblyConditionClass(getAssemblyCondition: GetAssembly);
+                addAssemblyConditionClass.SetNotShowUI(true);
+                cardEffects.Add(addAssemblyConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable) => true;
+
+                AssemblyCondition GetAssembly(CardSource cardSource)
+                {
+                    if (cardSource == card)
+                    {
+                        AssemblyConditionElement element = new AssemblyConditionElement(CanSelectCardCondition);
+
+                        bool CanSelectCardCondition(CardSource cs)
+                            => cs.EqualsCardName("Plutomon");
+
+                        AssemblyCondition assemblyCondition = new AssemblyCondition(
+                            element: element,
+                            CanTargetCondition_ByPreSelecetedList: null,
+                            selectMessage: "w/[Plutomon] in name",
+                            elementCount: 1,
+                            reduceCost: 2);
+
+                        return assemblyCondition;
+                    }
+
+                    return null;
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_079.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_079.cs
@@ -103,9 +103,8 @@ namespace DCGO.CardEffects.BT26
             string SharedEffectDescription(string tag)
                 => $"[{tag}] By trashing 1 card in your hand, delete 1 of your opponent's level 6 or lower Digimon.";
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && card.Owner.HandCards.Count >= 1;
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => card.Owner.HandCards.Count >= 1;
 
             bool CanSelectDeleteTargetCondition(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
@@ -183,47 +182,16 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region On Play
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("On Play"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
-            }
-            #endregion
-
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Digivolving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
-
-            #region When Attacking
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Attacking"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName(),
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                onPlay: true,
+                whenDigivolving: true,
+                whenAttacking: true);
 
             #region All Turns - Both players trash hand to 4
             if (timing == EffectTiming.OnEnterFieldAnyone)

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_079.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_079.cs
@@ -11,7 +11,19 @@ namespace DCGO.CardEffects.BT26
         {
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            #region Alternate Digivolution Requirement
+            #region Alternate Digivolution Requirement Plutomon
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.EqualsCardName("Plutomon");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 1, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Alternate Digivolution Requirement TS
             if (timing == EffectTiming.None)
             {
                 static bool PermanentCondition(Permanent targetPermanent)
@@ -29,7 +41,6 @@ namespace DCGO.CardEffects.BT26
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Play this card from trash with reduced cost", CanUseCondition, card);
                 activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
-                activateClass.SetIsDigimonEffect(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
@@ -84,7 +95,7 @@ namespace DCGO.CardEffects.BT26
                 bool SourceCondition(CardSource cardSource)
                     => cardSource.IsDigimon && cardSource.EqualsCardName("Plutomon");
 
-                string[] decodeStrings = { "(w/[Plutomon] in name)", "Digimon card with [Plutomon] in its name" };
+                string[] decodeStrings = { "(Plutomon)", "Plutomon" };
                 cardEffects.Add(CardEffectFactory.DecodeSelfEffect(card: card, isInheritedEffect: false, decodeStrings: decodeStrings, sourceCondition: SourceCondition, condition: null));
             }
             #endregion
@@ -97,7 +108,6 @@ namespace DCGO.CardEffects.BT26
             #endregion
 
             #region Shared On Play / When Digivolving / When Attacking
-
             string SharedEffectName() => "By trashing 1 hand card, delete 1 opponent's level 6 or lower Digimon";
 
             string SharedEffectDescription(string tag)
@@ -154,8 +164,6 @@ namespace DCGO.CardEffects.BT26
                         {
                             if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetCondition))
                             {
-                                int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectDeleteTargetCondition));
-
                                 SelectPermanentEffect selectDeleteEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                                 selectDeleteEffect.SetUp(
@@ -163,7 +171,7 @@ namespace DCGO.CardEffects.BT26
                                     canTargetCondition: CanSelectDeleteTargetCondition,
                                     canTargetCondition_ByPreSelecetedList: null,
                                     canEndSelectCondition: null,
-                                    maxCount: maxCount,
+                                    maxCount: 1,
                                     canNoSelect: false,
                                     canEndNotMax: false,
                                     selectPermanentCoroutine: null,
@@ -179,7 +187,6 @@ namespace DCGO.CardEffects.BT26
                     }
                 }
             }
-
             #endregion
 
             CardEffectFactory.ActivateClassesForSharedEffects(
@@ -188,6 +195,7 @@ namespace DCGO.CardEffects.BT26
                 SharedActivateCoroutine,
                 SharedEffectDescription,
                 optional: false,
+                isSkippable: true,
                 additionalActivateCondition: SharedAdditionalActivateCondition,
                 onPlay: true,
                 whenDigivolving: true,
@@ -214,7 +222,9 @@ namespace DCGO.CardEffects.BT26
                             || CardEffectCommons.CanTriggerWhenPermanentDigivolving(hashtable, OpponentDigimonCondition));
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && (card.Owner.HandCards.Count > 4
+                            || card.Owner.Enemy.HandCards.Count > 4);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_079.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_079.cs
@@ -16,7 +16,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("TS");
+                    return targetPermanent.TopCard.EqualsTraits("TS");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));


### PR DESCRIPTION
## Summary
- Implements BT26-079 ZombiePlutomon's card effect.
- Alternate digivolution requirement: Lv.5 w/[TS] trait, cost 3.
- [Trash] [Main] If your hand has 5 or fewer cards, play this card with the cost reduced by 4.
- Security A. +1.
- Decode (Digimon card with [Plutomon] in its name).
- Retaliation.
- [On Play] [When Digivolving] [When Attacking] By trashing 1 card in your hand, delete 1 of your opponent's level 6 or lower Digimon.
- [All Turns] [Once Per Turn] When any of your opponent's Digimon are played or digivolve, both players trash cards in their hand so that they have 4 left.
- Assembly -2 (Digimon card with [Plutomon] in its name).