### PR TITLE
Add BT26-082 Ravemon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
@@ -17,7 +17,7 @@ namespace DCGO.CardEffects.BT26
             {
                 static bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("DATA SQUAD");
+                    return targetPermanent.TopCard.EqualsTraits("DATA SQUAD");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// Ravemon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_082 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("DATA SQUAD");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
+            }
+            #endregion
+
+            #region Security - End of Opponent's Turn
+            if (timing == EffectTiming.OnEndTurn)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play this card", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Security] [End of Opponent's Turn] Play this card without paying the cost.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsOpponentTurn(card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistInSecurity(card)
+                        && CardEffectCommons.CanPlayAsNewPermanent(card, false, activateClass, SelectCardEffect.Root.Security);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(cardSources: new List<CardSource>() { card }, activateClass: activateClass, payCost: false, isTapped: false, root: SelectCardEffect.Root.Security, activateETB: true));
+                }
+            }
+            #endregion
+
+            #region Shared When Digivolving / End of Attack
+
+            string SharedEffectName() => "By deleting this Digimon or trashing 2 Tamer's bottom face-down cards, delete 1 opponent's highest DP Digimon";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] By deleting this Digimon or trashing 2 bottom face-down cards from under any of your Tamers, delete 1 of your opponent's highest DP Digimon.";
+
+            bool IsTamerWithEnoughFaceDownCards(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                    && permanent.DigivolutionCards.Count(cs => cs.IsFaceDown) >= 2;
+
+            bool FaceDownCards(CardSource cardSource) => cardSource.IsFaceDown;
+
+            bool CanSelectDeleteTargetCondition(Permanent permanent)
+                => CardEffectCommons.IsMaxDP(permanent, card.Owner.Enemy, null);
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                bool canTrashTamerCards = CardEffectCommons.HasMatchConditionPermanent(IsTamerWithEnoughFaceDownCards);
+
+                List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>()
+                {
+                    new SelectionElement<int>(message: "Delete this Digimon", value: 1, spriteIndex: 0),
+                };
+
+                if (canTrashTamerCards) selectionElements.Add(new SelectionElement<int>(message: "Trash 2 bottom face-down cards from under 1 of your Tamers", value: 2, spriteIndex: 0));
+                selectionElements.Add(new SelectionElement<int>(message: "Don't pay the cost", value: 3, spriteIndex: 1));
+
+                GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: "Will you pay the cost?", notSelectPlayerMessage: "The opponent is choosing to pay the cost.");
+                yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+                int selected = GManager.instance.userSelectionManager.SelectedIntValue;
+
+                bool hasPaidCost = false;
+
+                if (selected == 1 && CardEffectCommons.IsExistOnBattleArea(card))
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DeletePeremanentAndProcessAccordingToResult(
+                        targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },
+                        activateClass: activateClass,
+                        successProcess: SuccessProcess,
+                        failureProcess: null));
+
+                    IEnumerator SuccessProcess(List<Permanent> permanents)
+                    {
+                        hasPaidCost = true;
+                        yield return null;
+                    }
+                }
+                else if (selected == 2)
+                {
+                    Permanent selectedTamer = null;
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: IsTamerWithEnoughFaceDownCards,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        selectedTamer = permanent;
+                        yield return null;
+                    }
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash 2 bottom face-down cards from.", "The opponent is selecting 1 Tamer to trash 2 bottom face-down cards from.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    if (selectedTamer != null)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedTamer, trashCount: 2, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+
+                        hasPaidCost = true;
+                    }
+                }
+
+                if (hasPaidCost && CardEffectCommons.HasMatchConditionPermanent(CanSelectDeleteTargetCondition))
+                {
+                    SelectPermanentEffect selectDeleteEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectDeleteEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectDeleteTargetCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Destroy,
+                        cardEffect: activateClass);
+
+                    selectDeleteEffect.SetUpCustomMessage("Select 1 Digimon to delete.", "The opponent is selecting 1 Digimon to delete.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectDeleteEffect.Activate());
+                }
+            }
+
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Digivolving"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region End of Attack
+            if (timing == EffectTiming.OnEndAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("End of Attack"));
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnEndAttack(hashtable, card);
+            }
+            #endregion
+
+            #region On Deletion
+            if (timing == EffectTiming.OnDestroyedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Opponent trashes 1 hand card, then may place this as bottom security", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[On Deletion] Your opponent trashes 1 card in their hand. Then, if their hand has 7 or fewer cards, you may place this card face up as the bottom security card.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOnDeletion(hashtable, card, activateClass);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass)
+                        && card.Owner.Enemy.HandCards.Count >= 1;
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner.Enemy,
+                        canTargetCondition: _ => true,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: null,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Discard,
+                        cardEffect: activateClass);
+
+                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                    if (card.Owner.Enemy.HandCards.Count <= 7
+                        && CardEffectCommons.IsExistOnTrash(card)
+                        && card.Owner.CanAddSecurity(activateClass))
+                    {
+                        List<SelectionElement<bool>> selectionElements = new List<SelectionElement<bool>>()
+                        {
+                            new SelectionElement<bool>(message: "Yes", value: true, spriteIndex: 0),
+                            new SelectionElement<bool>(message: "No", value: false, spriteIndex: 1),
+                        };
+
+                        GManager.instance.userSelectionManager.SetBoolSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: "Place this card face up as the bottom security card?", notSelectPlayerMessage: "The opponent is choosing whether to place this card face up as the bottom security card.");
+
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+
+                        if (GManager.instance.userSelectionManager.SelectedBoolValue)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddSecurityCard(card, toTop: false, faceUp: true));
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -67,10 +68,6 @@ namespace DCGO.CardEffects.BT26
             string SharedEffectDescription(string tag)
                 => $"[{tag}] By deleting this Digimon or trashing 2 bottom face-down cards from under any of your Tamers, delete 1 of your opponent's highest DP Digimon.";
 
-            bool IsTamerWithEnoughFaceDownCards(Permanent permanent)
-                => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
-                    && permanent.DigivolutionCards.Count(cs => cs.IsFaceDown) >= 2;
-
             bool FaceDownCards(CardSource cardSource) => cardSource.IsFaceDown;
 
             bool CanSelectDeleteTargetCondition(Permanent permanent)
@@ -78,14 +75,25 @@ namespace DCGO.CardEffects.BT26
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
-                bool canTrashTamerCards = CardEffectCommons.HasMatchConditionPermanent(IsTamerWithEnoughFaceDownCards);
+                bool TamerWithOneFaceDownSource(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                        && permanent.DigivolutionCards.Any(FaceDownCards)
+                        && !permanent.ImmuneFromStackTrashing(activateClass);
+
+                bool TamerWith2OrMoreFaceDownSources(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                        && permanent.DigivolutionCards.Count(FaceDownCards) >= 2
+                        && !permanent.ImmuneFromStackTrashing(activateClass);
+
+                bool canTrashTamerCards = CardEffectCommons.HasMatchConditionPermanent(TamerWith2OrMoreFaceDownSources)
+                    || CardEffectCommons.MatchConditionPermanentCount(TamerWithOneFaceDownSource) >= 2;
 
                 List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>()
                 {
                     new SelectionElement<int>(message: "Delete this Digimon", value: 1, spriteIndex: 0),
                 };
 
-                if (canTrashTamerCards) selectionElements.Add(new SelectionElement<int>(message: "Trash 2 bottom face-down cards from under 1 of your Tamers", value: 2, spriteIndex: 0));
+                if (canTrashTamerCards) selectionElements.Add(new SelectionElement<int>(message: "Trash 2 bottom face-down cards from under any of your Tamers", value: 2, spriteIndex: 0));
                 selectionElements.Add(new SelectionElement<int>(message: "Don't pay the cost", value: 3, spriteIndex: 1));
 
                 GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: "Will you pay the cost?", notSelectPlayerMessage: "The opponent is choosing to pay the cost.");
@@ -110,37 +118,51 @@ namespace DCGO.CardEffects.BT26
                 }
                 else if (selected == 2)
                 {
-                    Permanent selectedTamer = null;
+                    bool trashed = false;
 
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                    int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(TamerWithOneFaceDownSource));
 
                     selectPermanentEffect.SetUp(
                         selectPlayer: card.Owner,
-                        canTargetCondition: IsTamerWithEnoughFaceDownCards,
+                        canTargetCondition: TamerWithOneFaceDownSource,
                         canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
+                        canEndSelectCondition: CanEndSelectCondition,
+                        maxCount: maxCount,
                         canNoSelect: true,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: SelectPermanentCoroutine,
-                        afterSelectPermanentCoroutine: null,
+                        canEndNotMax: true,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: AfterSelectPermanentCoroutine,
                         mode: SelectPermanentEffect.Mode.Custom,
                         cardEffect: activateClass);
 
-                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                    {
-                        selectedTamer = permanent;
-                        yield return null;
-                    }
-
-                    selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash 2 bottom face-down cards from.", "The opponent is selecting 1 Tamer to trash 2 bottom face-down cards from.");
+                    selectPermanentEffect.SetUpCustomMessage("Select all Tamer(s) to trash bottom face-down cards from.", "The opponent is selecting Tamer(s) to trash bottom face-down cards from.");
 
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
 
-                    if (selectedTamer != null)
+                    bool CanEndSelectCondition(List<Permanent> permanents)
                     {
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedTamer, trashCount: 2, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+                        return permanents.Count == 2
+                            || (permanents.Count > 0 && permanents[0].DigivolutionCards.Count(FaceDownCards) >= 2);
+                    }
 
+                    IEnumerator AfterSelectPermanentCoroutine(List<Permanent> permanents)
+                    {
+                        if (permanents.Count == 1)
+                        {
+                            trashed = true;
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: permanents[0], trashCount: 2, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+                        }
+                        else if (permanents.Count == 2)
+                        {
+                            trashed = true;
+                            foreach (Permanent selectedPermanent in permanents)
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedPermanent, trashCount: 1, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
+                        }
+                    }
+
+                    if (trashed)
+                    {
                         hasPaidCost = true;
                     }
                 }

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
@@ -102,7 +102,7 @@ namespace DCGO.CardEffects.BT26
 
                 bool hasPaidCost = false;
 
-                if (selected == 1 && CardEffectCommons.IsExistOnBattleArea(card))
+                if (selected == 1)
                 {
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DeletePeremanentAndProcessAccordingToResult(
                         targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },
@@ -118,8 +118,6 @@ namespace DCGO.CardEffects.BT26
                 }
                 else if (selected == 2)
                 {
-                    bool trashed = false;
-
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
                     int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(TamerWithOneFaceDownSource));
 
@@ -150,20 +148,15 @@ namespace DCGO.CardEffects.BT26
                     {
                         if (permanents.Count == 1)
                         {
-                            trashed = true;
+                            hasPaidCost = true;
                             yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: permanents[0], trashCount: 2, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
                         }
                         else if (permanents.Count == 2)
                         {
-                            trashed = true;
+                            hasPaidCost = true;
                             foreach (Permanent selectedPermanent in permanents)
                                 yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsFromTopOrBottom(targetPermanent: selectedPermanent, trashCount: 1, isFromTop: false, activateClass: activateClass, cardCondition: FaceDownCards));
                         }
-                    }
-
-                    if (trashed)
-                    {
-                        hasPaidCost = true;
                     }
                 }
 
@@ -189,7 +182,6 @@ namespace DCGO.CardEffects.BT26
                     yield return ContinuousController.instance.StartCoroutine(selectDeleteEffect.Activate());
                 }
             }
-
             #endregion
 
             CardEffectFactory.ActivateClassesForSharedEffects(
@@ -198,6 +190,7 @@ namespace DCGO.CardEffects.BT26
                 SharedActivateCoroutine,
                 SharedEffectDescription,
                 optional: false,
+                isSkippable: true,
                 whenDigivolving: true,
                 endOfAttack: true);
 

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,7 +11,19 @@ namespace DCGO.CardEffects.BT26
         {
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            #region Alternate Digivolution Requirement
+            #region Alternate Digivolution Requirement Crowmon
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.EqualsCardName("Crowmon");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Alternate Digivolution Requirement DATA SQUAD
             if (timing == EffectTiming.None)
             {
                 static bool PermanentCondition(Permanent targetPermanent)
@@ -36,10 +47,11 @@ namespace DCGO.CardEffects.BT26
                     => "[Security] [End of Opponent's Turn] Play this card without paying the cost.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsOpponentTurn(card);
+                    => CardEffectCommons.IsOpponentTurn(card)
+                        && CardEffectCommons.IsExistInSecurityTrigger(card, activateClass);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistInSecurity(card)
+                    => CardEffectCommons.IsExistInSecurityActivate(card, activateClass)
                         && CardEffectCommons.CanPlayAsNewPermanent(card, false, activateClass, SelectCardEffect.Root.Security);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
@@ -50,7 +62,6 @@ namespace DCGO.CardEffects.BT26
             #endregion
 
             #region Shared When Digivolving / End of Attack
-
             string SharedEffectName() => "By deleting this Digimon or trashing 2 Tamer's bottom face-down cards, delete 1 opponent's highest DP Digimon";
 
             string SharedEffectDescription(string tag)
@@ -183,28 +194,30 @@ namespace DCGO.CardEffects.BT26
                     => CardEffectCommons.CanTriggerOnDeletion(hashtable, card, activateClass);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass)
-                        && card.Owner.Enemy.HandCards.Count >= 1;
+                    => CardEffectCommons.CanActivateOnDeletion(card, activateClass);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+                    if (card.Owner.Enemy.HandCards.Count >= 1)
+                    {
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
 
-                    selectHandEffect.SetUp(
-                        selectPlayer: card.Owner.Enemy,
-                        canTargetCondition: _ => true,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: 1,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        isShowOpponent: true,
-                        selectCardCoroutine: null,
-                        afterSelectCardCoroutine: null,
-                        mode: SelectHandEffect.Mode.Discard,
-                        cardEffect: activateClass);
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner.Enemy,
+                            canTargetCondition: _ => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: false,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Discard,
+                            cardEffect: activateClass);
 
-                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                        yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                    }
 
                     if (card.Owner.Enemy.HandCards.Count <= 7
                         && CardEffectCommons.IsExistOnTrash(card)

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_082.cs
@@ -65,9 +65,6 @@ namespace DCGO.CardEffects.BT26
             bool CanSelectDeleteTargetCondition(Permanent permanent)
                 => CardEffectCommons.IsMaxDP(permanent, card.Owner.Enemy, null);
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
-
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
                 bool canTrashTamerCards = CardEffectCommons.HasMatchConditionPermanent(IsTamerWithEnoughFaceDownCards);
@@ -162,33 +159,14 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("When Digivolving"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
-
-            #region End of Attack
-            if (timing == EffectTiming.OnEndAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), -1, false, SharedEffectDescription("End of Attack"));
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnEndAttack(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName(),
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                whenDigivolving: true,
+                endOfAttack: true);
 
             #region On Deletion
             if (timing == EffectTiming.OnDestroyedAnyone)


### PR DESCRIPTION
## Summary
- Implements BT26-082 Ravemon's card effect.
- Alternate digivolution requirement: Lv.5 w/[DATA SQUAD] trait, cost 3.
- [Security] [End of Opponent's Turn] Play this card without paying the cost.
- [When Digivolving] [End of Attack] By deleting this Digimon or trashing 2 bottom face-down cards from under any of your Tamers, delete 1 of your opponent's highest DP Digimon.
- [On Deletion] Your opponent trashes 1 card in their hand. Then, if their hand has 7 or fewer cards, you may place this card face up as the bottom security card.