### PR TITLE
Add BT26-088 Hiroko Sagisaka card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_088.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_088.cs
@@ -22,11 +22,11 @@ namespace DCGO.CardEffects.BT26
                     => "[Start of Your Main Phase] If your opponent has a Digimon, gain 1 memory.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && card.Owner.CanAddMemory(activateClass)
                         && card.Owner.Enemy.GetBattleAreaDigimons().Count >= 1;
 
@@ -54,12 +54,12 @@ namespace DCGO.CardEffects.BT26
                         && cardSource.Owner == card.Owner;
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.CanTriggerWhenPermanentWouldPlay(hashtable, PlayCardCondition);
 
                 bool CanActivateCondition(Hashtable hashtable)
                     => CardEffectCommons.IsOwnerTurn(card)
-                        && CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && CardEffectCommons.CanActivateSuspendCostEffect(card);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_088.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_088.cs
@@ -13,27 +13,7 @@ namespace DCGO.CardEffects.BT26
             #region Start of Your Main Phase
             if (timing == EffectTiming.OnStartMainPhase)
             {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Memory +1", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
-                cardEffects.Add(activateClass);
-
-                string EffectDescription()
-                    => "[Start of Your Main Phase] If your opponent has a Digimon, gain 1 memory.";
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.IsOwnerTurn(card);
-
-                bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                        && card.Owner.CanAddMemory(activateClass)
-                        && card.Owner.Enemy.GetBattleAreaDigimons().Count >= 1;
-
-                IEnumerator ActivateCoroutine(Hashtable _hashtable)
-                {
-                    yield return ContinuousController.instance.StartCoroutine(card.Owner.AddMemory(1, activateClass));
-                }
+                cardEffects.Add(CardEffectFactory.Gain1MemoryTamerOpponentDigimonEffect(card));
             }
             #endregion
 
@@ -49,7 +29,7 @@ namespace DCGO.CardEffects.BT26
                     => "[Your Turn] When any [Boss] or [TS] trait Digimon cards would be played, by suspending this Tamer, reduce the cost by 1. If you have no Digimon, instead reduce the cost by 2.";
 
                 bool PlayCardCondition(CardSource cardSource)
-                    => CardEffectCommons.IsExistOnHand(cardSource) && cardSource.IsDigimon
+                    => cardSource.IsDigimon
                         && (cardSource.EqualsTraits("Boss") || cardSource.HasTSTraits)
                         && cardSource.Owner == card.Owner;
 

--- a/Assets/Scripts/CardEffect/BT26/Red/BT26_088.cs
+++ b/Assets/Scripts/CardEffect/BT26/Red/BT26_088.cs
@@ -1,0 +1,105 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Hiroko Sagisaka
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_088 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Start of Your Main Phase
+            if (timing == EffectTiming.OnStartMainPhase)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Memory +1", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Start of Your Main Phase] If your opponent has a Digimon, gain 1 memory.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.IsOwnerTurn(card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && card.Owner.CanAddMemory(activateClass)
+                        && card.Owner.Enemy.GetBattleAreaDigimons().Count >= 1;
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(card.Owner.AddMemory(1, activateClass));
+                }
+            }
+            #endregion
+
+            #region Cost reduction
+            if (timing == EffectTiming.BeforePayCost)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("By suspending this Tamer, reduce a [Boss]/[TS] Digimon's play cost", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Your Turn] When any [Boss] or [TS] trait Digimon cards would be played, by suspending this Tamer, reduce the cost by 1. If you have no Digimon, instead reduce the cost by 2.";
+
+                bool PlayCardCondition(CardSource cardSource)
+                    => CardEffectCommons.IsExistOnHand(cardSource) && cardSource.IsDigimon
+                        && (cardSource.EqualsTraits("Boss") || cardSource.HasTSTraits)
+                        && cardSource.Owner == card.Owner;
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.CanTriggerWhenPermanentWouldPlay(hashtable, PlayCardCondition);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsOwnerTurn(card)
+                        && CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.CanActivateSuspendCostEffect(card);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SuspendPeremanentAndProcessAccordingToResult(
+                        targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },
+                        activateClass: activateClass,
+                        successProcess: SuccessProcess,
+                        failureProcess: null));
+
+                    IEnumerator SuccessProcess(List<Permanent> _permanents)
+                    {
+                        int reduceAmount = card.Owner.GetBattleAreaDigimons().Count == 0 ? 2 : 1;
+
+                        ChangeCostClass changeCostClass = new ChangeCostClass();
+                        changeCostClass.SetUpICardEffect($"Play Cost -{reduceAmount}", _ => true, card);
+                        changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: _ => true, isUpDown: () => true, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                        card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable));
+
+                        int ChangeCost(CardSource cardSource, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                            => CardSourceCondition(cardSource) ? cost - reduceAmount : cost;
+
+                        bool CardSourceCondition(CardSource cardSource)
+                            => cardSource != null && cardSource.Owner == card.Owner
+                                && cardSource.IsDigimon && (cardSource.EqualsTraits("Boss") || cardSource.HasTSTraits);
+                    }
+                }
+            }
+            #endregion
+
+            #region Security
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                cardEffects.Add(CardEffectFactory.PlaySelfTamerSecurityEffect(card));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements BT26-088 Hiroko Sagisaka's card effect.
- [Start of Your Main Phase] If your opponent has a Digimon, gain 1 memory.
- [Your Turn] When any [Boss] or [TS] trait Digimon cards would be played, by suspending this Tamer, reduce the cost by 1. If you have no Digimon, instead reduce the cost by 2.
- [Security] Play this card without paying the cost.