### PR TITLE
Add BT26-090 Kanan Yuki card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_090.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_090.cs
@@ -22,11 +22,11 @@ namespace DCGO.CardEffects.BT26
                     => "[Start of Your Main Phase] If you have 4 or less memory, gain 1 memory.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && card.Owner.CanAddMemory(activateClass)
                         && card.Owner.MemoryForPlayer <= 4;
 
@@ -55,11 +55,11 @@ namespace DCGO.CardEffects.BT26
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, effect, fixedCost: cardSource.GetCostItself - card.Owner.Enemy.MemoryForPlayer);
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && CardEffectCommons.CanActivateSuspendCostEffect(card);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_090.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_090.cs
@@ -1,0 +1,103 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Kanan Yuki
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_090 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Start of Your Main Phase
+            if (timing == EffectTiming.OnStartMainPhase)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Memory +1", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Start of Your Main Phase] If you have 4 or less memory, gain 1 memory.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.IsOwnerTurn(card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && card.Owner.CanAddMemory(activateClass)
+                        && card.Owner.MemoryForPlayer <= 4;
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(card.Owner.AddMemory(1, activateClass));
+                }
+            }
+            #endregion
+
+            #region End of Your Turn
+            if (timing == EffectTiming.OnEndTurn)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("By suspending this Tamer, use 1 [TS] Option card from hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[End of Your Turn] By suspending this Tamer, you may use 1 Option card with the [TS] trait from your hand. For each memory your opponent has, reduce this effect's paid cost by 1.";
+
+                bool CanSelectOptionCardCondition(CardSource cardSource, ICardEffect effect)
+                    => cardSource.IsOption
+                        && cardSource.HasTSTraits
+                        && !cardSource.CanNotPlayThisOption
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, effect, fixedCost: cardSource.GetCostItself - card.Owner.Enemy.MemoryForPlayer);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.IsOwnerTurn(card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.CanActivateSuspendCostEffect(card);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SuspendPeremanentAndProcessAccordingToResult(
+                        targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },
+                        activateClass: activateClass,
+                        successProcess: SuccessProcess,
+                        failureProcess: null));
+
+                    IEnumerator SuccessProcess(List<Permanent> _permanents)
+                    {
+                        bool CanSelectOptionCardConditionBound(CardSource cardSource) => CanSelectOptionCardCondition(cardSource, activateClass);
+
+                        if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectOptionCardConditionBound))
+                        {
+                            int reduceCost = card.Owner.Enemy.MemoryForPlayer;
+
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                                canTargetCondition: CanSelectOptionCardConditionBound,
+                                root: SelectCardEffect.Root.Hand,
+                                cardEffect: activateClass,
+                                payCost: true,
+                                reduceCostTuple: (reduceCost, null)));
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Security
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                cardEffects.Add(CardEffectFactory.PlaySelfTamerSecurityEffect(card));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_090.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_090.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -78,12 +79,65 @@ namespace DCGO.CardEffects.BT26
                         {
                             int reduceCost = card.Owner.Enemy.MemoryForPlayer;
 
-                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                            CardSource selectedCard = null;
+
+                            SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                            selectHandEffect.SetUp(
+                                selectPlayer: card.Owner,
                                 canTargetCondition: CanSelectOptionCardConditionBound,
-                                root: SelectCardEffect.Root.Hand,
-                                cardEffect: activateClass,
-                                payCost: true,
-                                reduceCostTuple: (reduceCost, null)));
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: true,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                selectCardCoroutine: SelectCardCoroutine,
+                                afterSelectCardCoroutine: null,
+                                mode: SelectHandEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            IEnumerator SelectCardCoroutine(CardSource cardSource)
+                            {
+                                selectedCard = cardSource;
+                                yield return null;
+                            }
+
+                            selectHandEffect.SetUpCustomMessage("Select 1 [TS] Option card to use.", "The opponent is selecting 1 [TS] Option card to use.");
+                            selectHandEffect.SetUpCustomMessage_ShowCard("Selected Card");
+                            yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                            if (selectedCard != null)
+                            {
+                                ChangeCostClass changeCostClass = new ChangeCostClass();
+                                changeCostClass.SetUpICardEffect($"Use Cost -{reduceCost}", _ => true, card);
+                                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: PlayCondition, rootCondition: _ => true, isUpDown: () => true, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                                Func<EffectTiming, ICardEffect> getCardEffect = GetCardEffect;
+                                card.Owner.UntilCalculateFixedCostEffect.Add(getCardEffect);
+
+                                ICardEffect GetCardEffect(EffectTiming _timing)
+                                    => _timing == EffectTiming.None ? changeCostClass : null;
+
+                                bool PlayCondition(CardSource cs) => cs == selectedCard;
+
+                                int ChangeCost(CardSource cs, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                                {
+                                    if (PlayCondition(cs))
+                                    {
+                                        cost -= reduceCost;
+                                    }
+
+                                    return cost;
+                                }
+
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
+                                    cardSources: new List<CardSource>() { selectedCard },
+                                    activateClass: activateClass,
+                                    payCost: true,
+                                    root: SelectCardEffect.Root.Hand));
+
+                                card.Owner.UntilCalculateFixedCostEffect.Remove(getCardEffect);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Implements BT26-090 Kanan Yuki's card effect.
- [Start of Your Main Phase] If you have 4 or less memory, gain 1 memory.
- [End of Your Turn] By suspending this Tamer, you may use 1 Option card with the [TS] trait from your hand. For each memory your opponent has, reduce this effect's paid cost by 1.
- [Security] Play this card without paying the cost.