### PR TITLE
Add BT26-096 Kosuke Misono card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_096.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_096.cs
@@ -1,0 +1,110 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Kosuke Misono
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_096 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Start of Your Turn
+            if (timing == EffectTiming.OnStartTurn)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Set memory to 3", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Start of Your Turn] If you have 2 or less memory, set it to 3.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.IsOwnerTurn(card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && card.Owner.MemoryForPlayer <= 2;
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(card.Owner.SetFixedMemory(3, activateClass));
+                }
+            }
+            #endregion
+
+            #region Main
+            if (timing == EffectTiming.OnDeclaration)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("By returning this Tamer to bottom of deck, play 1 [Chronomon]/[TS] card from hand or trash for 2 less", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Main] By returning this Tamer to the bottom of the deck, you may play 1 Digimon card with [Chronomon] in its text or 1 Tamer card with the [TS] trait from your hand or trash with the cost reduced by 2.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card);
+
+                bool CanPlayCondition(CardSource cardSource)
+                    => ((cardSource.IsDigimon && cardSource.HasText("Chronomon")) || (cardSource.IsTamer && cardSource.HasTSTraits))
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: true, cardEffect: activateClass, fixedCost: cardSource.GetCostItself - 2);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(new DeckBottomBounceClass(new List<Permanent>() { card.PermanentOfThisCard() }, CardEffectCommons.CardEffectHashtable(activateClass)).DeckBounce());
+
+                    bool canSelectHand = CardEffectCommons.HasMatchConditionOwnersHand(card, CanPlayCondition);
+                    bool canSelectTrash = CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanPlayCondition);
+
+                    if (canSelectHand || canSelectTrash)
+                    {
+                        SelectCardEffect.Root root;
+
+                        if (canSelectHand && canSelectTrash)
+                        {
+                            List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>()
+                            {
+                                new(message: "From hand", value: 1, spriteIndex: 0),
+                                new(message: "From trash", value: 2, spriteIndex: 1),
+                                new(message: "Don't play", value: 3, spriteIndex: 2),
+                            };
+
+                            GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: "From which area will you play a card?", notSelectPlayerMessage: "The opponent is choosing from which area to select a card.");
+                            yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+
+                            if (GManager.instance.userSelectionManager.SelectedIntValue == 3) yield break;
+
+                            root = GManager.instance.userSelectionManager.SelectedIntValue == 1 ? SelectCardEffect.Root.Hand : SelectCardEffect.Root.Trash;
+                        }
+                        else
+                        {
+                            root = canSelectHand ? SelectCardEffect.Root.Hand : SelectCardEffect.Root.Trash;
+                        }
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                            canTargetCondition: CanPlayCondition,
+                            root: root,
+                            cardEffect: activateClass,
+                            payCost: true,
+                            reduceCostTuple: (2, null)));
+                    }
+                }
+            }
+            #endregion
+
+            #region Security
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                cardEffects.Add(CardEffectFactory.PlaySelfTamerSecurityEffect(card));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_096.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_096.cs
@@ -22,11 +22,11 @@ namespace DCGO.CardEffects.BT26
                     => "[Start of Your Turn] If you have 2 or less memory, set it to 3.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && card.Owner.MemoryForPlayer <= 2;
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
@@ -48,7 +48,7 @@ namespace DCGO.CardEffects.BT26
                     => "[Main] By returning this Tamer to the bottom of the deck, you may play 1 Digimon card with [Chronomon] in its text or 1 Tamer card with the [TS] trait from your hand or trash with the cost reduced by 2.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card);
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass);
 
                 bool CanPlayCondition(CardSource cardSource)
                     => ((cardSource.IsDigimon && cardSource.HasText("Chronomon")) || (cardSource.IsTamer && cardSource.HasTSTraits))

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_096.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_096.cs
@@ -13,26 +13,7 @@ namespace DCGO.CardEffects.BT26
             #region Start of Your Turn
             if (timing == EffectTiming.OnStartTurn)
             {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Set memory to 3", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
-                cardEffects.Add(activateClass);
-
-                string EffectDescription()
-                    => "[Start of Your Turn] If you have 2 or less memory, set it to 3.";
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.IsOwnerTurn(card);
-
-                bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                        && card.Owner.MemoryForPlayer <= 2;
-
-                IEnumerator ActivateCoroutine(Hashtable _hashtable)
-                {
-                    yield return ContinuousController.instance.StartCoroutine(card.Owner.SetFixedMemory(3, activateClass));
-                }
+                cardEffects.Add(CardEffectFactory.SetMemoryTo3TamerEffect(card));
             }
             #endregion
 
@@ -40,7 +21,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.OnDeclaration)
             {
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("By returning this Tamer to bottom of deck, play 1 [Chronomon]/[TS] card from hand or trash for 2 less", CanUseCondition, card);
+                activateClass.SetUpICardEffect("By returning this Tamer to bottom of deck, play 1 [Chronomon] in text Digimon or [TS] Tamer from hand or trash for 2 less", CanUseCondition, card);
                 activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
 
@@ -70,8 +51,8 @@ namespace DCGO.CardEffects.BT26
                             List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>()
                             {
                                 new(message: "From hand", value: 1, spriteIndex: 0),
-                                new(message: "From trash", value: 2, spriteIndex: 1),
-                                new(message: "Don't play", value: 3, spriteIndex: 2),
+                                new(message: "From trash", value: 2, spriteIndex: 0),
+                                new(message: "Don't play", value: 3, spriteIndex: 1),
                             };
 
                             GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: "From which area will you play a card?", notSelectPlayerMessage: "The opponent is choosing from which area to select a card.");


### PR DESCRIPTION
## Summary
- Implements BT26-096 Kosuke Misono's card effect.
- [Start of Your Turn] If you have 2 or less memory, set it to 3.
- [Main] By returning this Tamer to the bottom of the deck, you may play 1 Digimon card with [Chronomon] in its text or 1 Tamer card with the [TS] trait from your hand or trash with the cost reduced by 2.
- [Security] Play this card without paying the cost.