### PR TITLE
Add BT26-098 Queen of Thorns card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
@@ -20,7 +20,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.BeforePayCost)
             {
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Reduce Play Cost -2", CanUseCondition, card);
+                activateClass.SetUpICardEffect("Reduce Use Cost -2", CanUseCondition, card);
                 activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
                 activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
@@ -128,7 +128,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.None)
             {
                 ChangeCostClass changeCostClass = new ChangeCostClass();
-                changeCostClass.SetUpICardEffect("Play Cost -2", CanUseCondition, card);
+                changeCostClass.SetUpICardEffect("Play Use -2", CanUseCondition, card);
                 changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => true, isChangePayingCost: () => true);
                 changeCostClass.SetNotShowUI(true);
                 cardEffects.Add(changeCostClass);

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// Queen of Thorns
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_098 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Reduce Use Cost
+
+            bool SharedCanSelectTamerCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
+                    && permanent.HasFaceDownDigivolutionCards;
+
+            if (timing == EffectTiming.BeforePayCost)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Reduce Use Cost -2", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "When this card would be used, by trashing the bottom face-down card from under any of your Tamers, reduce the cost by 2.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerWhenPermanentWouldPlay(hashtable, cardSource => cardSource == card)
+                        && CardEffectCommons.HasMatchConditionOwnersPermanent(card, SharedCanSelectTamerCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    if (CardEffectCommons.HasMatchConditionOwnersPermanent(card, SharedCanSelectTamerCondition))
+                    {
+                        Permanent selectedPermanent = null;
+
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: SharedCanSelectTamerCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            selectedPermanent = permanent;
+                            yield return null;
+                        }
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash the bottom face-down card from.", "The opponent is selecting 1 Tamer to trash the bottom face-down card from.");
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        if (selectedPermanent != null)
+                        {
+                            CardSource cardToTrash = selectedPermanent.DigivolutionCards.Last(x => x.IsFaceDown);
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.TrashDigivolutionCardsAndProcessAccordingToResult(
+                                targetPermanent: selectedPermanent,
+                                targetDigivolutionCards: new List<CardSource>() { cardToTrash },
+                                activateClass: activateClass,
+                                successProcess: SuccessProcess,
+                                failureProcess: null));
+
+                            IEnumerator SuccessProcess(List<CardSource> trashedCards)
+                            {
+                                ChangeCostClass changeCostClass = new ChangeCostClass();
+                                changeCostClass.SetUpICardEffect("Use Cost -2", _ => true, card);
+                                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: _ => true, isUpDown: () => true, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                                card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
+
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable));
+
+                                int ChangeCost(CardSource cardSource, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                                    => CardSourceCondition(cardSource) ? cost - 2 : cost;
+
+                                bool CardSourceCondition(CardSource cardSource) => cardSource != null && cardSource == card;
+                            }
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Main
+
+            if (timing == EffectTiming.OptionSkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("By placing 1 [Sunflowmon] and 1 [Lilamon] from trash as 1 [Lalamon]'s bottom sources, may digivolve into [Rosemon] without cost or requirements", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Main] By placing 1 [Sunflowmon] and 1 [Lilamon] from your trash as 1 of your [Lalamon]'s bottom digivolution cards, that Digimon may digivolve into [Rosemon] in the hand, ignoring digivolution requirements and without paying the cost.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+
+                bool IsLalamon(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                        && permanent.TopCard.EqualsCardName("Lalamon");
+
+                bool IsSunflowmon(CardSource cardSource) => cardSource.EqualsCardName("Sunflowmon");
+
+                bool IsLilamon(CardSource cardSource) => cardSource.EqualsCardName("Lilamon");
+
+                bool IsRosemon(CardSource cardSource) => cardSource.EqualsCardName("Rosemon");
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (!(CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsSunflowmon) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon))) yield break;
+
+                    Permanent selectedPermanent = null;
+
+                    if (CardEffectCommons.MatchConditionOwnersPermanentCount(card, IsLalamon) > 1)
+                    {
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: IsLalamon,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            selectedPermanent = permanent;
+                            yield return null;
+                        }
+
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 [Lalamon] to gain digivolution sources.", "The opponent is selecting 1 [Lalamon] to gain digivolution sources.");
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                    }
+
+                    if (CardEffectCommons.MatchConditionOwnersPermanentCount(card, IsLalamon) == 1)
+                        selectedPermanent = card.Owner.GetBattleAreaDigimons().Find(x => IsLalamon(x));
+
+                    if (selectedPermanent != null)
+                    {
+                        List<CardSource> selectedTrashCards = new List<CardSource>();
+
+                        IEnumerator SelectCardCoroutine(CardSource cardSource)
+                        {
+                            selectedTrashCards.Add(cardSource);
+                            yield return null;
+                        }
+
+                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsSunflowmon))
+                        {
+                            SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                            selectCardEffect.SetUp(
+                                canTargetCondition: IsSunflowmon,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                canNoSelect: () => true,
+                                selectCardCoroutine: SelectCardCoroutine,
+                                afterSelectCardCoroutine: null,
+                                message: "Select 1 [Sunflowmon] card.",
+                                maxCount: 1,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                mode: SelectCardEffect.Mode.Custom,
+                                root: SelectCardEffect.Root.Trash,
+                                customRootCardList: null,
+                                canLookReverseCard: true,
+                                selectPlayer: card.Owner,
+                                cardEffect: activateClass);
+
+                            selectCardEffect.SetUpCustomMessage("Select 1 [Sunflowmon] card to place under [Lalamon].", "The opponent is selecting a [Sunflowmon] card to place under [Lalamon].");
+                            yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+                        }
+
+                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon) && selectedTrashCards.Find(IsSunflowmon) != null)
+                        {
+                            SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                            selectCardEffect.SetUp(
+                                canTargetCondition: IsLilamon,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                canNoSelect: () => true,
+                                selectCardCoroutine: SelectCardCoroutine,
+                                afterSelectCardCoroutine: null,
+                                message: "Select 1 [Lilamon] card.",
+                                maxCount: 1,
+                                canEndNotMax: false,
+                                isShowOpponent: true,
+                                mode: SelectCardEffect.Mode.Custom,
+                                root: SelectCardEffect.Root.Trash,
+                                customRootCardList: null,
+                                canLookReverseCard: true,
+                                selectPlayer: card.Owner,
+                                cardEffect: activateClass);
+
+                            selectCardEffect.SetUpCustomMessage("Select 1 [Lilamon] card to place under [Lalamon].", "The opponent is selecting a [Lilamon] card to place under [Lalamon].");
+                            yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+                        }
+
+                        if (selectedTrashCards.Find(IsSunflowmon) != null && selectedTrashCards.Find(IsLilamon) != null)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(selectedPermanent.AddDigivolutionCardsBottom(
+                                addedDigivolutionCards: selectedTrashCards,
+                                cardEffect: activateClass));
+
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                                targetPermanent: selectedPermanent,
+                                cardCondition: IsRosemon,
+                                payCost: false,
+                                reduceCostTuple: null,
+                                fixedCostTuple: null,
+                                ignoreDigivolutionRequirementFixedCost: 1,
+                                isHand: true,
+                                activateClass: activateClass,
+                                successProcess: null));
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Security
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play 1 [Lalamon]/[Yoshino Fujieda] from hand or trash, then add this to hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSecurityEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Security] You may play 1 [Lalamon] or [Yoshino Fujieda] from your hand or trash without paying the cost. Then, add this card to the hand.";
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                    => (cardSource.EqualsCardName("Lalamon") || cardSource.EqualsCardName("Yoshino Fujieda"))
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
+
+                bool CanUseCondition(Hashtable hashtable) => CardEffectCommons.CanTriggerSecurityEffect(hashtable, card);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    bool canPlayFromHand = CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+                    bool canPlayFromTrash = CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
+
+                    if (canPlayFromHand || canPlayFromTrash)
+                    {
+                        List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>();
+
+                        if (canPlayFromHand) selectionElements.Add(new SelectionElement<int>("Play from hand", 1, 0));
+                        if (canPlayFromTrash) selectionElements.Add(new SelectionElement<int>("Play from trash", 2, 0));
+                        selectionElements.Add(new SelectionElement<int>("Don't play a card", 3, 1));
+
+                        GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: "Will you play a [Lalamon] or [Yoshino Fujieda]?", notSelectPlayerMessage: "The opponent is choosing whether to play a [Lalamon] or [Yoshino Fujieda].");
+                        yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+
+                        bool playFromHand = GManager.instance.userSelectionManager.SelectedIntValue == 1;
+                        bool dontPlay = GManager.instance.userSelectionManager.SelectedIntValue == 3;
+
+                        if (!dontPlay)
+                        {
+                            CardSource selectedCard = null;
+                            SelectCardEffect.Root selectedRoot = SelectCardEffect.Root.None;
+
+                            IEnumerator SelectCardCoroutine(CardSource cardSource)
+                            {
+                                selectedCard = cardSource;
+                                yield return null;
+                            }
+
+                            if (playFromHand)
+                            {
+                                SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                                selectHandEffect.SetUp(
+                                    selectPlayer: card.Owner,
+                                    canTargetCondition: CanSelectCardCondition,
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    maxCount: 1,
+                                    canNoSelect: true,
+                                    canEndNotMax: false,
+                                    isShowOpponent: true,
+                                    selectCardCoroutine: SelectCardCoroutine,
+                                    afterSelectCardCoroutine: null,
+                                    mode: SelectHandEffect.Mode.Custom,
+                                    cardEffect: activateClass);
+
+                                selectHandEffect.SetUpCustomMessage("Select 1 [Lalamon] or [Yoshino Fujieda] to play.", "The opponent is selecting 1 [Lalamon] or [Yoshino Fujieda] to play.");
+                                yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+                                selectedRoot = SelectCardEffect.Root.Hand;
+                            }
+                            else
+                            {
+                                SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                                selectCardEffect.SetUp(
+                                    canTargetCondition: CanSelectCardCondition,
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    canNoSelect: () => true,
+                                    selectCardCoroutine: SelectCardCoroutine,
+                                    afterSelectCardCoroutine: null,
+                                    message: "Select 1 [Lalamon] or [Yoshino Fujieda] to play.",
+                                    maxCount: 1,
+                                    canEndNotMax: false,
+                                    isShowOpponent: true,
+                                    mode: SelectCardEffect.Mode.Custom,
+                                    root: SelectCardEffect.Root.Trash,
+                                    customRootCardList: null,
+                                    canLookReverseCard: true,
+                                    selectPlayer: card.Owner,
+                                    cardEffect: activateClass);
+
+                                selectCardEffect.SetUpCustomMessage("Select 1 [Lalamon] or [Yoshino Fujieda] to play.", "The opponent is selecting 1 [Lalamon] or [Yoshino Fujieda] to play.");
+                                yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+                                selectedRoot = SelectCardEffect.Root.Trash;
+                            }
+
+                            if (selectedCard != null && selectedRoot != SelectCardEffect.Root.None)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                                    cardSources: new List<CardSource>() { selectedCard },
+                                    activateClass: activateClass,
+                                    payCost: false,
+                                    isTapped: false,
+                                    root: selectedRoot,
+                                    activateETB: true));
+                            }
+                        }
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.AddThisCardToHand(card, activateClass));
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
@@ -12,7 +12,7 @@ namespace DCGO.CardEffects.BT26
         {
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            #region Reduce Use Cost
+            #region Reduce Play Cost
             bool SharedCanSelectTamerCondition(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
                     && permanent.HasFaceDownDigivolutionCards;
@@ -20,7 +20,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.BeforePayCost)
             {
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Reduce Use Cost -2", CanUseCondition, card);
+                activateClass.SetUpICardEffect("Reduce Play Cost -2", CanUseCondition, card);
                 activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
                 activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
@@ -128,7 +128,7 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.None)
             {
                 ChangeCostClass changeCostClass = new ChangeCostClass();
-                changeCostClass.SetUpICardEffect("Play Use -2", CanUseCondition, card);
+                changeCostClass.SetUpICardEffect("Play Cost -2", CanUseCondition, card);
                 changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => true, isChangePayingCost: () => true);
                 changeCostClass.SetNotShowUI(true);
                 cardEffects.Add(changeCostClass);
@@ -188,25 +188,26 @@ namespace DCGO.CardEffects.BT26
                     bool IsLilamon(CardSource cardSource)
                         => cardSource.EqualsCardName("Lilamon");
 
-                    bool IsRosemon(CardSource cardSource) => cardSource.EqualsCardName("Rosemon");
+                    bool IsRosemon(CardSource cardSource)
+                        => cardSource.EqualsCardName("Rosemon");
 
                     #endregion
 
-                    if (!(CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsSunflowmon) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon))) yield break;
-                    Permanent selectedPermanent = null;
-
-                    #region Select Lalamon
-                    if (CardEffectCommons.MatchConditionOwnersPermanentCount(card, IsLalamon) > 1)
+                    if (CardEffectCommons.HasMatchConditionPermanent(IsLalamon)
+                    && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsSunflowmon)
+                    && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon))
                     {
+                        Permanent selectedPermanent = null;
+
+                        #region Select Lalamon
                         SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersPermanentCount(card, IsLalamon));
 
                         selectPermanentEffect.SetUp(
                             selectPlayer: card.Owner,
                             canTargetCondition: IsLalamon,
                             canTargetCondition_ByPreSelecetedList: null,
                             canEndSelectCondition: null,
-                            maxCount: maxCount,
+                            maxCount: 1,
                             canNoSelect: true,
                             canEndNotMax: false,
                             selectPermanentCoroutine: SelectPermanentCoroutine,
@@ -222,26 +223,20 @@ namespace DCGO.CardEffects.BT26
 
                         selectPermanentEffect.SetUpCustomMessage("Select 1 [Lalamon] to gain digivolution sources", "The opponent is selecting 1 [Lalamon] to gain digivolution sources.");
                         yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-                    }
-                    if (CardEffectCommons.MatchConditionOwnersPermanentCount(card, IsLalamon) == 1)
-                        selectedPermanent = card.Owner.GetBattleAreaDigimons().Find(IsLalamon);
-                    #endregion
+                        #endregion
 
-                    if (selectedPermanent != null)
-                    {
-                        List<CardSource> selectedTrashCards = new List<CardSource>();
-
-                        IEnumerator SelectCardCoroutine(CardSource cardSource)
+                        if (selectedPermanent != null)
                         {
-                            selectedTrashCards.Add(cardSource);
-                            yield return null;
-                        }
+                            List<CardSource> selectedTrashCards = new List<CardSource>();
 
-                        #region Select Gaogamon
-                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsSunflowmon))
-                        {
+                            IEnumerator SelectCardCoroutine(CardSource cardSource)
+                            {
+                                selectedTrashCards.Add(cardSource);
+                                yield return null;
+                            }
+
+                            #region Select Sunflowmon
                             SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
-                            int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, IsSunflowmon));
 
                             selectCardEffect.SetUp(
                                 canTargetCondition: IsSunflowmon,
@@ -251,7 +246,7 @@ namespace DCGO.CardEffects.BT26
                                 selectCardCoroutine: SelectCardCoroutine,
                                 afterSelectCardCoroutine: null,
                                 message: "Select 1 [Sunflowmon] card",
-                                maxCount: maxCount,
+                                maxCount: 1,
                                 canEndNotMax: false,
                                 isShowOpponent: true,
                                 mode: SelectCardEffect.Mode.Custom,
@@ -264,16 +259,12 @@ namespace DCGO.CardEffects.BT26
                             selectCardEffect.SetUpCustomMessage("Select 1 [Sunflowmon] card to place under [Lalamon].", "The opponent is selecting a [Sunflowmon] card to place under [Lalamon].");
                             selectCardEffect.SetUpCustomMessage_ShowCard("Selected [Sunflowmon]");
                             yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
-                        }
-                        #endregion
+                            #endregion
 
-                        #region Select MachGaogamon
-                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon) && selectedTrashCards.Find(IsSunflowmon))
-                        {
-                            SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
-                            int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, IsLilamon));
+                            #region Select Lilamon
+                            SelectCardEffect selectCardEffect1 = GManager.instance.GetComponent<SelectCardEffect>();
 
-                            selectCardEffect.SetUp(
+                            selectCardEffect1.SetUp(
                                 canTargetCondition: IsLilamon,
                                 canTargetCondition_ByPreSelecetedList: null,
                                 canEndSelectCondition: null,
@@ -281,7 +272,7 @@ namespace DCGO.CardEffects.BT26
                                 selectCardCoroutine: SelectCardCoroutine,
                                 afterSelectCardCoroutine: null,
                                 message: "Select 1 [Lilamon] card",
-                                maxCount: maxCount,
+                                maxCount: 1,
                                 canEndNotMax: false,
                                 isShowOpponent: true,
                                 mode: SelectCardEffect.Mode.Custom,
@@ -291,29 +282,60 @@ namespace DCGO.CardEffects.BT26
                                 selectPlayer: card.Owner,
                                 cardEffect: activateClass);
 
-                            selectCardEffect.SetUpCustomMessage("Select 1 [Lilamon] card to place under [Lalamon].", "The opponent is selecting a [Lilamon] card to place under [Lalamon].");
-                            selectCardEffect.SetUpCustomMessage_ShowCard("Selected [Lilamon]");
-                            yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
-                        }
-                        #endregion
+                            selectCardEffect1.SetUpCustomMessage("Select 1 [Lilamon] card to place under [Lalamon].", "The opponent is selecting a [Lilamon] card to place under [Lalamon].");
+                            selectCardEffect1.SetUpCustomMessage_ShowCard("Selected [Lilamon]");
+                            yield return ContinuousController.instance.StartCoroutine(selectCardEffect1.Activate());
+                            #endregion
 
-                        if (selectedTrashCards.Find(IsSunflowmon) && selectedTrashCards.Find(IsLilamon))
-                        {
-                            yield return ContinuousController.instance.StartCoroutine(selectedPermanent.AddDigivolutionCardsBottom(
-                                addedDigivolutionCards: selectedTrashCards,
-                                cardEffect: activateClass));
+                            if (selectedTrashCards.Count == 2)
+                            {
+                                List<CardSource> digivolutionCards = new List<CardSource>();
 
-                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
-                                targetPermanent: selectedPermanent,
-                                cardCondition: IsRosemon,
-                                payCost: false,
-                                reduceCostTuple: null,
-                                fixedCostTuple: null,
-                                ignoreDigivolutionRequirementFixedCost: 1,
-                                isHand: true,
-                                activateClass: activateClass,
-                                successProcess: null));
+                                SelectCardEffect selectCardEffect2 = GManager.instance.GetComponent<SelectCardEffect>();
 
+                                selectCardEffect2.SetUp(
+                                    canTargetCondition: (cardSource) => true,
+                                    canTargetCondition_ByPreSelecetedList: null,
+                                    canEndSelectCondition: null,
+                                    canNoSelect: () => false,
+                                    selectCardCoroutine: null,
+                                    afterSelectCardCoroutine: AfterSelectCardCoroutine1,
+                                    message: "Specify the order to place the cards in the digivolution cards\n(cards will be placed so that cards with lower numbers are on top).",
+                                    maxCount: selectedTrashCards.Count,
+                                    canEndNotMax: false,
+                                    isShowOpponent: false,
+                                    mode: SelectCardEffect.Mode.Custom,
+                                    root: SelectCardEffect.Root.Custom,
+                                    customRootCardList: selectedTrashCards,
+                                    canLookReverseCard: true,
+                                    selectPlayer: card.Owner,
+                                    cardEffect: activateClass);
+
+                                selectCardEffect2.SetUpCustomMessage_ShowCard("Digivolution Cards");
+
+                                yield return ContinuousController.instance.StartCoroutine(selectCardEffect2.Activate());
+
+                                IEnumerator AfterSelectCardCoroutine1(List<CardSource> cardSources)
+                                {
+                                    digivolutionCards = cardSources.Clone();
+
+                                    yield return null;
+                                }
+
+                                yield return ContinuousController.instance.StartCoroutine(selectedPermanent.AddDigivolutionCardsBottom(digivolutionCards, activateClass));
+
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                                    targetPermanent: selectedPermanent,
+                                    cardCondition: IsRosemon,
+                                    payCost: false,
+                                    reduceCostTuple: null,
+                                    fixedCostTuple: null,
+                                    ignoreDigivolutionRequirementFixedCost: 1,
+                                    isHand: true,
+                                    activateClass: activateClass,
+                                    successProcess: null));
+
+                            }
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
@@ -373,11 +373,11 @@ namespace DCGO.CardEffects.BT26
                         if (canSelectHand && canSelectTrash)
                         {
                             List<SelectionElement<int>> selectionElements1 = new List<SelectionElement<int>>()
-                        {
-                            new (message: $"From hand", value : 1, spriteIndex: 0),
-                            new (message: $"From trash", value : 2, spriteIndex: 1),
-                            new (message: $"Don't play", value: 3, spriteIndex: 2)
-                        };
+                            {
+                                new (message: $"From hand", value : 1, spriteIndex: 0),
+                                new (message: $"From trash", value : 2, spriteIndex: 1),
+                                new (message: $"Don't play", value: 3, spriteIndex: 2)
+                            };
 
                             string selectPlayerMessage1 = "From which area will you play a card?";
                             string notSelectPlayerMessage1 = "The opponent is choosing from which area to select a card.";

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
@@ -12,7 +12,7 @@ namespace DCGO.CardEffects.BT26
         {
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            #region Reduce Play Cost
+            #region Reduce Use Cost
             bool SharedCanSelectTamerCondition(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
                     && permanent.HasFaceDownDigivolutionCards;

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
@@ -334,7 +334,6 @@ namespace DCGO.CardEffects.BT26
                                     isHand: true,
                                     activateClass: activateClass,
                                     successProcess: null));
-
                             }
                         }
                     }

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_098.cs
@@ -12,8 +12,7 @@ namespace DCGO.CardEffects.BT26
         {
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            #region Reduce Use Cost
-
+            #region Reduce Play Cost
             bool SharedCanSelectTamerCondition(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card)
                     && permanent.HasFaceDownDigivolutionCards;
@@ -21,17 +20,21 @@ namespace DCGO.CardEffects.BT26
             if (timing == EffectTiming.BeforePayCost)
             {
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("Reduce Use Cost -2", CanUseCondition, card);
+                activateClass.SetUpICardEffect("Reduce Play Cost -2", CanUseCondition, card);
                 activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
                 activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
-                    => "When this card would be used, by trashing the bottom face-down card from under any of your Tamers, reduce the cost by 2.";
+                {
+                    return "When this card would be used, by trashing the bottom face-down card from under any of your Tamers, reduce the use cost by 2.";
+                }
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.CanTriggerWhenPermanentWouldPlay(hashtable, cardSource => cardSource == card)
+                {
+                    return CardEffectCommons.CanTriggerWhenPermanentWouldPlay(hashtable, cardSource => cardSource == card)
                         && CardEffectCommons.HasMatchConditionOwnersPermanent(card, SharedCanSelectTamerCondition);
+                }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
@@ -39,29 +42,34 @@ namespace DCGO.CardEffects.BT26
                     {
                         Permanent selectedPermanent = null;
 
-                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                        selectPermanentEffect.SetUp(
-                            selectPlayer: card.Owner,
-                            canTargetCondition: SharedCanSelectTamerCondition,
-                            canTargetCondition_ByPreSelecetedList: null,
-                            canEndSelectCondition: null,
-                            maxCount: 1,
-                            canNoSelect: true,
-                            canEndNotMax: false,
-                            selectPermanentCoroutine: SelectPermanentCoroutine,
-                            afterSelectPermanentCoroutine: null,
-                            mode: SelectPermanentEffect.Mode.Custom,
-                            cardEffect: activateClass);
-
-                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        #region Select Tamer to trash bottom face down digivolution card
+                        if (CardEffectCommons.HasMatchConditionPermanent(SharedCanSelectTamerCondition))
                         {
-                            selectedPermanent = permanent;
-                            yield return null;
-                        }
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
-                        selectPermanentEffect.SetUpCustomMessage("Select 1 Tamer to trash the bottom face-down card from.", "The opponent is selecting 1 Tamer to trash the bottom face-down card from.");
-                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: SharedCanSelectTamerCondition,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: true,
+                                canEndNotMax: false,
+                                selectPermanentCoroutine: SelectPermanentCoroutine,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                            {
+                                selectedPermanent = permanent;
+                                yield return null;
+                            }
+
+                            selectPermanentEffect.SetUpCustomMessage("Select 1 tamer to trash bottom face down digivolution card.", "The opponent is selecting 1 tamer to trash bottom face down digivolution card.");
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                        }
+                        #endregion
 
                         if (selectedPermanent != null)
                         {
@@ -75,27 +83,83 @@ namespace DCGO.CardEffects.BT26
 
                             IEnumerator SuccessProcess(List<CardSource> trashedCards)
                             {
+                                if (card.Owner.CanReduceCost(null, card)) ContinuousController.instance.PlaySE(GManager.instance.GetComponent<Effects>().BuffSE);
+
                                 ChangeCostClass changeCostClass = new ChangeCostClass();
-                                changeCostClass.SetUpICardEffect("Use Cost -2", _ => true, card);
-                                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: _ => true, isUpDown: () => true, isCheckAvailability: () => false, isChangePayingCost: () => true);
+                                changeCostClass.SetUpICardEffect("Play Cost -2", CanUseCondition1, card);
+                                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => false, isChangePayingCost: () => true);
                                 card.Owner.UntilCalculateFixedCostEffect.Add((_timing) => changeCostClass);
 
                                 yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ShowReducedCost(_hashtable));
 
-                                int ChangeCost(CardSource cardSource, int cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
-                                    => CardSourceCondition(cardSource) ? cost - 2 : cost;
+                                bool CanUseCondition1(Hashtable hashtable) => true;
 
-                                bool CardSourceCondition(CardSource cardSource) => cardSource != null && cardSource == card;
+                                int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                                {
+                                    if (CardSourceCondition(cardSource)
+                                    && RootCondition(root)
+                                    && PermanentsCondition(targetPermanents))
+                                    {
+                                        Cost -= 2;
+                                    }
+
+                                    return Cost;
+                                }
+
+                                bool PermanentsCondition(List<Permanent> targetPermanents)
+                                {
+                                    return targetPermanents == null
+                                            || targetPermanents.Count((targetPermanent) => targetPermanent != null) == 0;
+                                }
+
+                                bool CardSourceCondition(CardSource cardSource)
+                                    => cardSource != null
+                                        && cardSource == card;
+
+                                bool RootCondition(SelectCardEffect.Root root) => true;
+
+                                bool isUpDown() => true;
                             }
                         }
                     }
                 }
             }
 
+            if (timing == EffectTiming.None)
+            {
+                ChangeCostClass changeCostClass = new ChangeCostClass();
+                changeCostClass.SetUpICardEffect("Play Cost -2", CanUseCondition, card);
+                changeCostClass.SetUpChangeCostClass(changeCostFunc: ChangeCost, cardSourceCondition: CardSourceCondition, rootCondition: RootCondition, isUpDown: isUpDown, isCheckAvailability: () => true, isChangePayingCost: () => true);
+                changeCostClass.SetNotShowUI(true);
+                cardEffects.Add(changeCostClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnHand(card)
+                        && CardEffectCommons.HasMatchConditionOwnersPermanent(card, SharedCanSelectTamerCondition);
+                }
+
+                int ChangeCost(CardSource cardSource, int Cost, SelectCardEffect.Root root, List<Permanent> targetPermanents)
+                {
+                    if (CardSourceCondition(cardSource)
+                    && RootCondition(root))
+                    {
+                        Cost -= 2;
+                    }
+
+                    return Cost;
+                }
+
+                bool CardSourceCondition(CardSource cardSource)
+                    => cardSource != null && cardSource == card;
+
+                bool RootCondition(SelectCardEffect.Root root) => true;
+
+                bool isUpDown() => true;
+            }
             #endregion
 
             #region Main
-
             if (timing == EffectTiming.OptionSkill)
             {
                 ActivateClass activateClass = new ActivateClass();
@@ -107,34 +171,42 @@ namespace DCGO.CardEffects.BT26
                     => "[Main] By placing 1 [Sunflowmon] and 1 [Lilamon] from your trash as 1 of your [Lalamon]'s bottom digivolution cards, that Digimon may digivolve into [Rosemon] in the hand, ignoring digivolution requirements and without paying the cost.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
-
-                bool IsLalamon(Permanent permanent)
-                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
-                        && permanent.TopCard.EqualsCardName("Lalamon");
-
-                bool IsSunflowmon(CardSource cardSource) => cardSource.EqualsCardName("Sunflowmon");
-
-                bool IsLilamon(CardSource cardSource) => cardSource.EqualsCardName("Lilamon");
-
-                bool IsRosemon(CardSource cardSource) => cardSource.EqualsCardName("Rosemon");
+                {
+                    return CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+                }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    if (!(CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsSunflowmon) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon))) yield break;
+                    #region Conditions
+                    bool IsLalamon(Permanent permanent)
+                        => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                            && permanent.TopCard.EqualsCardName("Lalamon");
 
+                    bool IsSunflowmon(CardSource cardSource)
+                        => cardSource.EqualsCardName("Sunflowmon");
+
+                    bool IsLilamon(CardSource cardSource)
+                        => cardSource.EqualsCardName("Lilamon");
+
+                    bool IsRosemon(CardSource cardSource) => cardSource.EqualsCardName("Rosemon");
+
+                    #endregion
+
+                    if (!(CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsSunflowmon) && CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon))) yield break;
                     Permanent selectedPermanent = null;
 
+                    #region Select Lalamon
                     if (CardEffectCommons.MatchConditionOwnersPermanentCount(card, IsLalamon) > 1)
                     {
                         SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                        int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersPermanentCount(card, IsLalamon));
 
                         selectPermanentEffect.SetUp(
                             selectPlayer: card.Owner,
                             canTargetCondition: IsLalamon,
                             canTargetCondition_ByPreSelecetedList: null,
                             canEndSelectCondition: null,
-                            maxCount: 1,
+                            maxCount: maxCount,
                             canNoSelect: true,
                             canEndNotMax: false,
                             selectPermanentCoroutine: SelectPermanentCoroutine,
@@ -148,12 +220,12 @@ namespace DCGO.CardEffects.BT26
                             yield return null;
                         }
 
-                        selectPermanentEffect.SetUpCustomMessage("Select 1 [Lalamon] to gain digivolution sources.", "The opponent is selecting 1 [Lalamon] to gain digivolution sources.");
+                        selectPermanentEffect.SetUpCustomMessage("Select 1 [Lalamon] to gain digivolution sources", "The opponent is selecting 1 [Lalamon] to gain digivolution sources.");
                         yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
                     }
-
                     if (CardEffectCommons.MatchConditionOwnersPermanentCount(card, IsLalamon) == 1)
-                        selectedPermanent = card.Owner.GetBattleAreaDigimons().Find(x => IsLalamon(x));
+                        selectedPermanent = card.Owner.GetBattleAreaDigimons().Find(IsLalamon);
+                    #endregion
 
                     if (selectedPermanent != null)
                     {
@@ -165,9 +237,11 @@ namespace DCGO.CardEffects.BT26
                             yield return null;
                         }
 
+                        #region Select Gaogamon
                         if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsSunflowmon))
                         {
                             SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+                            int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, IsSunflowmon));
 
                             selectCardEffect.SetUp(
                                 canTargetCondition: IsSunflowmon,
@@ -176,8 +250,8 @@ namespace DCGO.CardEffects.BT26
                                 canNoSelect: () => true,
                                 selectCardCoroutine: SelectCardCoroutine,
                                 afterSelectCardCoroutine: null,
-                                message: "Select 1 [Sunflowmon] card.",
-                                maxCount: 1,
+                                message: "Select 1 [Sunflowmon] card",
+                                maxCount: maxCount,
                                 canEndNotMax: false,
                                 isShowOpponent: true,
                                 mode: SelectCardEffect.Mode.Custom,
@@ -188,12 +262,16 @@ namespace DCGO.CardEffects.BT26
                                 cardEffect: activateClass);
 
                             selectCardEffect.SetUpCustomMessage("Select 1 [Sunflowmon] card to place under [Lalamon].", "The opponent is selecting a [Sunflowmon] card to place under [Lalamon].");
+                            selectCardEffect.SetUpCustomMessage_ShowCard("Selected [Sunflowmon]");
                             yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
                         }
+                        #endregion
 
-                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon) && selectedTrashCards.Find(IsSunflowmon) != null)
+                        #region Select MachGaogamon
+                        if (CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, IsLilamon) && selectedTrashCards.Find(IsSunflowmon))
                         {
                             SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+                            int maxCount = Math.Min(1, CardEffectCommons.MatchConditionOwnersCardCountInTrash(card, IsLilamon));
 
                             selectCardEffect.SetUp(
                                 canTargetCondition: IsLilamon,
@@ -202,8 +280,8 @@ namespace DCGO.CardEffects.BT26
                                 canNoSelect: () => true,
                                 selectCardCoroutine: SelectCardCoroutine,
                                 afterSelectCardCoroutine: null,
-                                message: "Select 1 [Lilamon] card.",
-                                maxCount: 1,
+                                message: "Select 1 [Lilamon] card",
+                                maxCount: maxCount,
                                 canEndNotMax: false,
                                 isShowOpponent: true,
                                 mode: SelectCardEffect.Mode.Custom,
@@ -214,10 +292,12 @@ namespace DCGO.CardEffects.BT26
                                 cardEffect: activateClass);
 
                             selectCardEffect.SetUpCustomMessage("Select 1 [Lilamon] card to place under [Lalamon].", "The opponent is selecting a [Lilamon] card to place under [Lalamon].");
+                            selectCardEffect.SetUpCustomMessage_ShowCard("Selected [Lilamon]");
                             yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
                         }
+                        #endregion
 
-                        if (selectedTrashCards.Find(IsSunflowmon) != null && selectedTrashCards.Find(IsLilamon) != null)
+                        if (selectedTrashCards.Find(IsSunflowmon) && selectedTrashCards.Find(IsLilamon))
                         {
                             yield return ContinuousController.instance.StartCoroutine(selectedPermanent.AddDigivolutionCardsBottom(
                                 addedDigivolutionCards: selectedTrashCards,
@@ -233,11 +313,11 @@ namespace DCGO.CardEffects.BT26
                                 isHand: true,
                                 activateClass: activateClass,
                                 successProcess: null));
+
                         }
                     }
                 }
             }
-
             #endregion
 
             #region Security
@@ -250,103 +330,58 @@ namespace DCGO.CardEffects.BT26
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
-                    => "[Security] You may play 1 [Lalamon] or [Yoshino Fujieda] from your hand or trash without paying the cost. Then, add this card to the hand.";
+                {
+                    return "[Security] You may play 1 [Lalamon] or [Yoshino Fujieda] from your hand or trash without paying the cost. Then, add this card to the hand.";
+                }
 
                 bool CanSelectCardCondition(CardSource cardSource)
-                    => (cardSource.EqualsCardName("Lalamon") || cardSource.EqualsCardName("Yoshino Fujieda"))
+                {
+                    return (cardSource.EqualsCardName("Lalamon") || cardSource.EqualsCardName("Yoshino Fujieda"))
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
+                }
 
                 bool CanUseCondition(Hashtable hashtable) => CardEffectCommons.CanTriggerSecurityEffect(hashtable, card);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    bool canPlayFromHand = CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
-                    bool canPlayFromTrash = CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
+                    bool canSelectHand = CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+                    bool canSelectTrash = CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectCardCondition);
 
-                    if (canPlayFromHand || canPlayFromTrash)
+                    if (canSelectHand || canSelectTrash)
                     {
-                        List<SelectionElement<int>> selectionElements = new List<SelectionElement<int>>();
+                        if (canSelectHand && canSelectTrash)
+                        {
+                            List<SelectionElement<int>> selectionElements1 = new List<SelectionElement<int>>()
+                        {
+                            new (message: $"From hand", value : 1, spriteIndex: 0),
+                            new (message: $"From trash", value : 2, spriteIndex: 1),
+                            new (message: $"Don't play", value: 3, spriteIndex: 2)
+                        };
 
-                        if (canPlayFromHand) selectionElements.Add(new SelectionElement<int>("Play from hand", 1, 0));
-                        if (canPlayFromTrash) selectionElements.Add(new SelectionElement<int>("Play from trash", 2, 0));
-                        selectionElements.Add(new SelectionElement<int>("Don't play a card", 3, 1));
+                            string selectPlayerMessage1 = "From which area will you play a card?";
+                            string notSelectPlayerMessage1 = "The opponent is choosing from which area to select a card.";
 
-                        GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements, selectPlayer: card.Owner, selectPlayerMessage: "Will you play a [Lalamon] or [Yoshino Fujieda]?", notSelectPlayerMessage: "The opponent is choosing whether to play a [Lalamon] or [Yoshino Fujieda].");
+                            GManager.instance.userSelectionManager.SetIntSelection(selectionElements: selectionElements1, selectPlayer: card.Owner, selectPlayerMessage: selectPlayerMessage1, notSelectPlayerMessage: notSelectPlayerMessage1);
+                        }
+                        else
+                        {
+                            GManager.instance.userSelectionManager.SetInt(canSelectHand ? 1 : 2);
+                        }
                         yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
 
-                        bool playFromHand = GManager.instance.userSelectionManager.SelectedIntValue == 1;
-                        bool dontPlay = GManager.instance.userSelectionManager.SelectedIntValue == 3;
+                        bool doPlay = GManager.instance.userSelectionManager.SelectedIntValue != 3;
+                        SelectCardEffect.Root root = GManager.instance.userSelectionManager.SelectedIntValue == 1 ? SelectCardEffect.Root.Hand : SelectCardEffect.Root.Trash;
 
-                        if (!dontPlay)
+                        if (doPlay)
                         {
-                            CardSource selectedCard = null;
-                            SelectCardEffect.Root selectedRoot = SelectCardEffect.Root.None;
-
-                            IEnumerator SelectCardCoroutine(CardSource cardSource)
-                            {
-                                selectedCard = cardSource;
-                                yield return null;
-                            }
-
-                            if (playFromHand)
-                            {
-                                SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
-
-                                selectHandEffect.SetUp(
-                                    selectPlayer: card.Owner,
-                                    canTargetCondition: CanSelectCardCondition,
-                                    canTargetCondition_ByPreSelecetedList: null,
-                                    canEndSelectCondition: null,
-                                    maxCount: 1,
-                                    canNoSelect: true,
-                                    canEndNotMax: false,
-                                    isShowOpponent: true,
-                                    selectCardCoroutine: SelectCardCoroutine,
-                                    afterSelectCardCoroutine: null,
-                                    mode: SelectHandEffect.Mode.Custom,
-                                    cardEffect: activateClass);
-
-                                selectHandEffect.SetUpCustomMessage("Select 1 [Lalamon] or [Yoshino Fujieda] to play.", "The opponent is selecting 1 [Lalamon] or [Yoshino Fujieda] to play.");
-                                yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
-                                selectedRoot = SelectCardEffect.Root.Hand;
-                            }
-                            else
-                            {
-                                SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
-
-                                selectCardEffect.SetUp(
-                                    canTargetCondition: CanSelectCardCondition,
-                                    canTargetCondition_ByPreSelecetedList: null,
-                                    canEndSelectCondition: null,
-                                    canNoSelect: () => true,
-                                    selectCardCoroutine: SelectCardCoroutine,
-                                    afterSelectCardCoroutine: null,
-                                    message: "Select 1 [Lalamon] or [Yoshino Fujieda] to play.",
-                                    maxCount: 1,
-                                    canEndNotMax: false,
-                                    isShowOpponent: true,
-                                    mode: SelectCardEffect.Mode.Custom,
-                                    root: SelectCardEffect.Root.Trash,
-                                    customRootCardList: null,
-                                    canLookReverseCard: true,
-                                    selectPlayer: card.Owner,
-                                    cardEffect: activateClass);
-
-                                selectCardEffect.SetUpCustomMessage("Select 1 [Lalamon] or [Yoshino Fujieda] to play.", "The opponent is selecting 1 [Lalamon] or [Yoshino Fujieda] to play.");
-                                yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
-                                selectedRoot = SelectCardEffect.Root.Trash;
-                            }
-
-                            if (selectedCard != null && selectedRoot != SelectCardEffect.Root.None)
-                            {
-                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
-                                    cardSources: new List<CardSource>() { selectedCard },
-                                    activateClass: activateClass,
-                                    payCost: false,
-                                    isTapped: false,
-                                    root: selectedRoot,
-                                    activateETB: true));
-                            }
+                            #region Hand/Trash Card Selection & Play
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                                canTargetCondition: CanSelectCardCondition,
+                                root,
+                                activateClass,
+                                payCost: false
+                            ));
+                            #endregion
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Implements BT26-098 Queen of Thorns' card effect.
- When this card would be used, by trashing the bottom face-down card from under any of your Tamers, reduce the cost by 2.
- [Main] By placing 1 [Sunflowmon] and 1 [Lilamon] from your trash as 1 of your [Lalamon]'s bottom digivolution cards, that Digimon may digivolve into [Rosemon] in the hand, ignoring digivolution requirements and without paying the cost.
- [Security] You may play 1 [Lalamon] or [Yoshino Fujieda] from your hand or trash without paying the cost. Then, add this card to the hand.