### PR TITLE
Add BT26-099 Training Manual card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
@@ -88,7 +88,31 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    Permanent triggeringPermanent = CardEffectCommons.GetPermanentFromHashtable(_hashtable);
+                    List<Permanent> triggeringPermanents = new List<Permanent>();
+
+                    void AddTriggeringPermanent(Permanent permanent)
+                    {
+                        if (permanent != null && !triggeringPermanents.Contains(permanent))
+                        {
+                            triggeringPermanents.Add(permanent);
+                        }
+                    }
+
+                    AddTriggeringPermanent(CardEffectCommons.GetPermanentFromHashtable(_hashtable));
+
+                    // Other Digimon that had face-down cards placed on them by the same effect, in the same
+                    // window, before this trigger got resolved (e.g. an effect that places 1 card face down under
+                    // each of 2 selected Digimon at once) — each Digimon fires its own OnAddDigivolutionCards
+                    // hashtable, so gather any still-pending sibling triggers for this same card's ability.
+                    foreach (SkillInfo skillInfo in GManager.instance.autoProcessing.StackedSkillInfos)
+                    {
+                        if (skillInfo.Timing == EffectTiming.OnAddDigivolutionCards
+                            && skillInfo.CardEffect != null
+                            && skillInfo.CardEffect.EffectSourceCard == card)
+                        {
+                            AddTriggeringPermanent(CardEffectCommons.GetPermanentFromHashtable(skillInfo.Hashtable));
+                        }
+                    }
 
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DeletePeremanentAndProcessAccordingToResult(
                         targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },
@@ -98,10 +122,12 @@ namespace DCGO.CardEffects.BT26
 
                     IEnumerator SuccessProcess(List<Permanent> permanents)
                     {
-                        if (triggeringPermanent != null && CanSelectDigivolveTargetCondition(triggeringPermanent))
+                        List<Permanent> eligiblePermanents = triggeringPermanents.Filter(CanSelectDigivolveTargetCondition);
+
+                        if (eligiblePermanents.Count == 1)
                         {
                             yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
-                                triggeringPermanent,
+                                eligiblePermanents[0],
                                 CanSelectDMCardCondition,
                                 payCost: false,
                                 reduceCostTuple: null,
@@ -111,6 +137,50 @@ namespace DCGO.CardEffects.BT26
                                 activateClass: activateClass,
                                 successProcess: null
                             ));
+                        }
+                        else if (eligiblePermanents.Count >= 2)
+                        {
+                            Permanent selectedPermanent = null;
+
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: eligiblePermanents.Contains,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: true,
+                                canEndNotMax: false,
+                                selectPermanentCoroutine: SelectPermanentCoroutine,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                            {
+                                selectedPermanent = permanent;
+                                yield return null;
+                            }
+
+                            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that may digivolve.", "The opponent is selecting 1 Digimon that may digivolve.");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                            if (selectedPermanent != null)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                                    selectedPermanent,
+                                    CanSelectDMCardCondition,
+                                    payCost: false,
+                                    reduceCostTuple: null,
+                                    fixedCostTuple: null,
+                                    ignoreDigivolutionRequirementFixedCost: -1,
+                                    isHand: true,
+                                    activateClass: activateClass,
+                                    successProcess: null
+                                ));
+                            }
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
@@ -88,31 +88,7 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    List<Permanent> triggeringPermanents = new List<Permanent>();
-
-                    void AddTriggeringPermanent(Permanent permanent)
-                    {
-                        if (permanent != null && !triggeringPermanents.Contains(permanent))
-                        {
-                            triggeringPermanents.Add(permanent);
-                        }
-                    }
-
-                    AddTriggeringPermanent(CardEffectCommons.GetPermanentFromHashtable(_hashtable));
-
-                    // Other Digimon that had face-down cards placed on them by the same effect, in the same
-                    // window, before this trigger got resolved (e.g. an effect that places 1 card face down under
-                    // each of 2 selected Digimon at once) — each Digimon fires its own OnAddDigivolutionCards
-                    // hashtable, so gather any still-pending sibling triggers for this same card's ability.
-                    foreach (SkillInfo skillInfo in GManager.instance.autoProcessing.StackedSkillInfos)
-                    {
-                        if (skillInfo.Timing == EffectTiming.OnAddDigivolutionCards
-                            && skillInfo.CardEffect != null
-                            && skillInfo.CardEffect.EffectSourceCard == card)
-                        {
-                            AddTriggeringPermanent(CardEffectCommons.GetPermanentFromHashtable(skillInfo.Hashtable));
-                        }
-                    }
+                    List<Permanent> triggeringPermanents = CardEffectCommons.GetSimultaneousPermanentsFromAddDigivolutionCardsHashtable(_hashtable);
 
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DeletePeremanentAndProcessAccordingToResult(
                         targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
@@ -15,7 +15,7 @@ namespace DCGO.CardEffects.BT26
             {
                 cardEffects.Add(CardEffectFactory.UseRequirements(card, CardCondition));
 
-                bool CardCondition(CardSource cardSource) => cardSource.ContainsTraits("DM");
+                bool CardCondition(CardSource cardSource) => cardSource.EqualsTraits("DM");
             }
             #endregion
 
@@ -33,7 +33,7 @@ namespace DCGO.CardEffects.BT26
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
 
-                bool CanSelectCardCondition(CardSource cardSource) => cardSource.ContainsTraits("DM");
+                bool CanSelectCardCondition(CardSource cardSource) => cardSource.EqualsTraits("DM");
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
@@ -77,7 +77,7 @@ namespace DCGO.CardEffects.BT26
                         && permanent.DigivolutionCards.Exists(FaceDownCardCondition);
 
                 bool CanSelectDMCardCondition(CardSource cardSource)
-                    => cardSource.IsDigimon && cardSource.HasLevel && cardSource.Level <= 6 && cardSource.ContainsTraits("DM");
+                    => cardSource.IsDigimon && cardSource.HasLevel && cardSource.Level <= 6 && cardSource.EqualsTraits("DM");
 
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleArea(card)

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
@@ -62,7 +62,8 @@ namespace DCGO.CardEffects.BT26
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("By trashing this card, 1 Digimon may digivolve into a level 6 or lower [DM] card from hand", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetEffectTargets(TargetPermanents);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
@@ -84,11 +85,18 @@ namespace DCGO.CardEffects.BT26
                         && CardEffectCommons.CanTriggerOnAddDigivolutionCard(hashtable, OwnerDigimonCondition, null, FaceDownCardCondition);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CanSelectDigivolveTargetCondition(CardEffectCommons.GetPermanentFromHashtable(hashtable));
+
+                List<Permanent> TargetPermanents(Hashtable hashtable)
+                {
+                    Permanent permanent = CardEffectCommons.GetPermanentFromHashtable(hashtable);
+                    return permanent != null ? new List<Permanent>() { permanent } : new List<Permanent>();
+                }
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    List<Permanent> triggeringPermanents = CardEffectCommons.GetSimultaneousPermanentsFromAddDigivolutionCardsHashtable(_hashtable);
+                    Permanent triggeringPermanent = CardEffectCommons.GetPermanentFromHashtable(_hashtable);
 
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DeletePeremanentAndProcessAccordingToResult(
                         targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },
@@ -98,12 +106,10 @@ namespace DCGO.CardEffects.BT26
 
                     IEnumerator SuccessProcess(List<Permanent> permanents)
                     {
-                        List<Permanent> eligiblePermanents = triggeringPermanents.Filter(CanSelectDigivolveTargetCondition);
-
-                        if (eligiblePermanents.Count == 1)
+                        if (CanSelectDigivolveTargetCondition(triggeringPermanent))
                         {
                             yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
-                                eligiblePermanents[0],
+                                triggeringPermanent,
                                 CanSelectDMCardCondition,
                                 payCost: false,
                                 reduceCostTuple: null,
@@ -113,50 +119,6 @@ namespace DCGO.CardEffects.BT26
                                 activateClass: activateClass,
                                 successProcess: null
                             ));
-                        }
-                        else if (eligiblePermanents.Count >= 2)
-                        {
-                            Permanent selectedPermanent = null;
-
-                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                            selectPermanentEffect.SetUp(
-                                selectPlayer: card.Owner,
-                                canTargetCondition: eligiblePermanents.Contains,
-                                canTargetCondition_ByPreSelecetedList: null,
-                                canEndSelectCondition: null,
-                                maxCount: 1,
-                                canNoSelect: true,
-                                canEndNotMax: false,
-                                selectPermanentCoroutine: SelectPermanentCoroutine,
-                                afterSelectPermanentCoroutine: null,
-                                mode: SelectPermanentEffect.Mode.Custom,
-                                cardEffect: activateClass);
-
-                            IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                            {
-                                selectedPermanent = permanent;
-                                yield return null;
-                            }
-
-                            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that may digivolve.", "The opponent is selecting 1 Digimon that may digivolve.");
-
-                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                            if (selectedPermanent != null)
-                            {
-                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
-                                    selectedPermanent,
-                                    CanSelectDMCardCondition,
-                                    payCost: false,
-                                    reduceCostTuple: null,
-                                    fixedCostTuple: null,
-                                    ignoreDigivolutionRequirementFixedCost: -1,
-                                    isHand: true,
-                                    activateClass: activateClass,
-                                    successProcess: null
-                                ));
-                            }
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
@@ -1,0 +1,161 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Training Manual
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_099 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Use Req.
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.UseRequirements(card, CardCondition));
+
+                bool CardCondition(CardSource cardSource) => cardSource.ContainsTraits("DM");
+            }
+            #endregion
+
+            #region Main
+            if (timing == EffectTiming.OptionSkill)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Reveal top 3, add 1 [DM] card to hand, then place this in battle area", CanUseCondition, card);
+                activateClass.SetUpActivateClass(null, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Main] Reveal the top 3 cards of your deck. Add 1 [DM] trait card among them to the hand. Return the rest to the bottom of the deck. Then, place this card in the battle area.";
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
+
+                bool CanSelectCardCondition(CardSource cardSource) => cardSource.ContainsTraits("DM");
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SimplifiedRevealDeckTopCardsAndSelect(
+                        revealCount: 3,
+                        simplifiedSelectCardConditions: new SimplifiedSelectCardConditionClass[]
+                        {
+                            new SimplifiedSelectCardConditionClass(
+                                canTargetCondition: CanSelectCardCondition,
+                                message: "Select 1 [DM] trait card to add to your hand.",
+                                mode: SelectCardEffect.Mode.AddHand,
+                                maxCount: 1,
+                                selectCardCoroutine: null),
+                        },
+                        remainingCardsPlace: RemainingCardsPlace.DeckBottom,
+                        activateClass: activateClass
+                    ));
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlaceDelayOptionCards(card: card, cardEffect: activateClass));
+                }
+            }
+            #endregion
+
+            #region All Turns - Reactive Delay
+            if (timing == EffectTiming.OnAddDigivolutionCards)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("By trashing this card, 1 Digimon may digivolve into a level 6 or lower [DM] card from hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[All Turns] When face-down cards are placed in any of your Digimon's digivolution cards, <Delay> (Trash this card in your battle area to activate the effect below.) Any of those Digimon may digivolve into a level 6 or lower [DM] trait Digimon card in the hand without paying the cost.";
+
+                bool FaceDownCardCondition(CardSource cardSource) => cardSource.IsFaceDown;
+
+                bool OwnerDigimonCondition(Permanent permanent) => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card);
+
+                bool CanSelectDigivolveTargetCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                        && permanent.DigivolutionCards.Exists(FaceDownCardCondition);
+
+                bool CanSelectDMCardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon && cardSource.HasLevel && cardSource.Level <= 6 && cardSource.ContainsTraits("DM");
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card)
+                        && CardEffectCommons.CanTriggerOnAddDigivolutionCard(hashtable, OwnerDigimonCondition, null, FaceDownCardCondition);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleArea(card);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DeletePeremanentAndProcessAccordingToResult(
+                        targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },
+                        activateClass: activateClass,
+                        successProcess: SuccessProcess,
+                        failureProcess: null));
+
+                    IEnumerator SuccessProcess(List<Permanent> permanents)
+                    {
+                        if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDigivolveTargetCondition))
+                        {
+                            Permanent selectedPermanent = null;
+
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: CanSelectDigivolveTargetCondition,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: true,
+                                canEndNotMax: false,
+                                selectPermanentCoroutine: SelectPermanentCoroutine,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                            {
+                                selectedPermanent = permanent;
+                                yield return null;
+                            }
+
+                            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that may digivolve.", "The opponent is selecting 1 Digimon that may digivolve.");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                            if (selectedPermanent != null)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                                    selectedPermanent,
+                                    CanSelectDMCardCondition,
+                                    payCost: false,
+                                    reduceCostTuple: null,
+                                    fixedCostTuple: null,
+                                    ignoreDigivolutionRequirementFixedCost: -1,
+                                    isHand: true,
+                                    activateClass: activateClass,
+                                    successProcess: null
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Security
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                CardEffectCommons.AddActivateMainOptionSecurityEffect(
+                    card: card,
+                    cardEffects: ref cardEffects,
+                    effectName: "Activate this card's [Main] effects.");
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
@@ -88,6 +88,8 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
+                    Permanent triggeringPermanent = CardEffectCommons.GetPermanentFromHashtable(_hashtable);
+
                     yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DeletePeremanentAndProcessAccordingToResult(
                         targetPermanents: new List<Permanent>() { card.PermanentOfThisCard() },
                         activateClass: activateClass,
@@ -96,49 +98,19 @@ namespace DCGO.CardEffects.BT26
 
                     IEnumerator SuccessProcess(List<Permanent> permanents)
                     {
-                        if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDigivolveTargetCondition))
+                        if (triggeringPermanent != null && CanSelectDigivolveTargetCondition(triggeringPermanent))
                         {
-                            Permanent selectedPermanent = null;
-
-                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
-
-                            selectPermanentEffect.SetUp(
-                                selectPlayer: card.Owner,
-                                canTargetCondition: CanSelectDigivolveTargetCondition,
-                                canTargetCondition_ByPreSelecetedList: null,
-                                canEndSelectCondition: null,
-                                maxCount: 1,
-                                canNoSelect: true,
-                                canEndNotMax: false,
-                                selectPermanentCoroutine: SelectPermanentCoroutine,
-                                afterSelectPermanentCoroutine: null,
-                                mode: SelectPermanentEffect.Mode.Custom,
-                                cardEffect: activateClass);
-
-                            IEnumerator SelectPermanentCoroutine(Permanent permanent)
-                            {
-                                selectedPermanent = permanent;
-                                yield return null;
-                            }
-
-                            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that may digivolve.", "The opponent is selecting 1 Digimon that may digivolve.");
-
-                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-
-                            if (selectedPermanent != null)
-                            {
-                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
-                                    selectedPermanent,
-                                    CanSelectDMCardCondition,
-                                    payCost: false,
-                                    reduceCostTuple: null,
-                                    fixedCostTuple: null,
-                                    ignoreDigivolutionRequirementFixedCost: -1,
-                                    isHand: true,
-                                    activateClass: activateClass,
-                                    successProcess: null
-                                ));
-                            }
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                                triggeringPermanent,
+                                CanSelectDMCardCondition,
+                                payCost: false,
+                                reduceCostTuple: null,
+                                fixedCostTuple: null,
+                                ignoreDigivolutionRequirementFixedCost: -1,
+                                isHand: true,
+                                activateClass: activateClass,
+                                successProcess: null
+                            ));
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_099.cs
@@ -80,11 +80,11 @@ namespace DCGO.CardEffects.BT26
                     => cardSource.IsDigimon && cardSource.HasLevel && cardSource.Level <= 6 && cardSource.EqualsTraits("DM");
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.CanTriggerOnAddDigivolutionCard(hashtable, OwnerDigimonCondition, null, FaceDownCardCondition);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {

--- a/Assets/Scripts/Script/CardEffectCommons/GetFromHashtable.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GetFromHashtable.cs
@@ -726,6 +726,44 @@ public partial class CardEffectCommons
     }
     #endregion
 
+    #region Get simultaneous Permanents from an OnAddDigivolutionCards hashtable
+    /// <summary>
+    /// Unlike OnEnterFieldAnyone/OnDestroyedAnyone, OnAddDigivolutionCards fires from a single Permanent's own
+    /// instance method (Permanent.AddDigivolutionCards/AddDigivolutionCardsBottom), one hashtable per affected
+    /// Digimon, each pushed independently rather than pre-batched by a single caller that already knows every
+    /// affected Permanent up front. So this hashtable's own "Permanent" can't be batched at construction time —
+    /// it has to be gathered here, at check/resolution time, once any sibling pushes from the same still-pending
+    /// window have already been queued. Returns this hashtable's own Permanent plus any other Permanents with a
+    /// still-pending OnAddDigivolutionCards trigger in GManager.instance.autoProcessing.StackedSkillInfos (e.g. an
+    /// effect that places 1 face-down card under each of 2 selected Digimon in the same action) — callers should
+    /// still apply their own eligibility filter (existence/ownership/face-down checks) to the result.
+    /// </summary>
+    public static List<Permanent> GetSimultaneousPermanentsFromAddDigivolutionCardsHashtable(Hashtable hashtable)
+    {
+        List<Permanent> permanents = new List<Permanent>();
+
+        void AddPermanent(Permanent permanent)
+        {
+            if (permanent != null && !permanents.Contains(permanent))
+            {
+                permanents.Add(permanent);
+            }
+        }
+
+        AddPermanent(GetPermanentFromHashtable(hashtable));
+
+        foreach (SkillInfo skillInfo in GManager.instance.autoProcessing.StackedSkillInfos)
+        {
+            if (skillInfo.Timing == EffectTiming.OnAddDigivolutionCards && skillInfo.Hashtable != hashtable)
+            {
+                AddPermanent(GetPermanentFromHashtable(skillInfo.Hashtable));
+            }
+        }
+
+        return permanents;
+    }
+    #endregion
+
     #region Get whether to digivolve from the same level from hashtable
     public static bool IsDigivolvedFromSameLevelFromEnterFieldHashtable(Hashtable hashtable, Permanent permanent)
     {

--- a/Assets/Scripts/Script/CardEffectCommons/GetFromHashtable.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/GetFromHashtable.cs
@@ -726,44 +726,6 @@ public partial class CardEffectCommons
     }
     #endregion
 
-    #region Get simultaneous Permanents from an OnAddDigivolutionCards hashtable
-    /// <summary>
-    /// Unlike OnEnterFieldAnyone/OnDestroyedAnyone, OnAddDigivolutionCards fires from a single Permanent's own
-    /// instance method (Permanent.AddDigivolutionCards/AddDigivolutionCardsBottom), one hashtable per affected
-    /// Digimon, each pushed independently rather than pre-batched by a single caller that already knows every
-    /// affected Permanent up front. So this hashtable's own "Permanent" can't be batched at construction time —
-    /// it has to be gathered here, at check/resolution time, once any sibling pushes from the same still-pending
-    /// window have already been queued. Returns this hashtable's own Permanent plus any other Permanents with a
-    /// still-pending OnAddDigivolutionCards trigger in GManager.instance.autoProcessing.StackedSkillInfos (e.g. an
-    /// effect that places 1 face-down card under each of 2 selected Digimon in the same action) — callers should
-    /// still apply their own eligibility filter (existence/ownership/face-down checks) to the result.
-    /// </summary>
-    public static List<Permanent> GetSimultaneousPermanentsFromAddDigivolutionCardsHashtable(Hashtable hashtable)
-    {
-        List<Permanent> permanents = new List<Permanent>();
-
-        void AddPermanent(Permanent permanent)
-        {
-            if (permanent != null && !permanents.Contains(permanent))
-            {
-                permanents.Add(permanent);
-            }
-        }
-
-        AddPermanent(GetPermanentFromHashtable(hashtable));
-
-        foreach (SkillInfo skillInfo in GManager.instance.autoProcessing.StackedSkillInfos)
-        {
-            if (skillInfo.Timing == EffectTiming.OnAddDigivolutionCards && skillInfo.Hashtable != hashtable)
-            {
-                AddPermanent(GetPermanentFromHashtable(skillInfo.Hashtable));
-            }
-        }
-
-        return permanents;
-    }
-    #endregion
-
     #region Get whether to digivolve from the same level from hashtable
     public static bool IsDigivolvedFromSameLevelFromEnterFieldHashtable(Hashtable hashtable, Permanent permanent)
     {


### PR DESCRIPTION
## Summary
- Implements BT26-099 Training Manual's card effect.
- Use Req. [DM] trait.
- [Main] Reveal the top 3 cards of your deck. Add 1 [DM] trait card among them to the hand. Return the rest to the bottom of the deck. Then, place this card in the battle area.
- [All Turns] When face-down cards are placed in any of your Digimon's digivolution cards, <Delay>. Any of those Digimon may digivolve into a level 6 or lower [DM] trait Digimon card in the hand without paying the cost.
- [Security] Activate this card's [Main] effects.