### PR TITLE
Add BT26-049 Rosemon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
@@ -28,7 +28,7 @@ namespace DCGO.CardEffects.BT26
             {
                 bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.ContainsTraits("DATA SQUAD");
+                    return targetPermanent.TopCard.EqualsTraits("DATA SQUAD");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
@@ -45,9 +45,6 @@ namespace DCGO.CardEffects.BT26
             bool CanSelectSuspendTargetCondition(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOpponentBattleArea(permanent, card)
                     && (permanent.IsDigimon || permanent.IsTamer);
-
-            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
-                => CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendTargetCondition);
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -86,15 +83,16 @@ namespace DCGO.CardEffects.BT26
                 optional: false,
                 maxCountPerTurn: 1,
                 hashValue: "BT26_049_Shared",
-                additionalActivateCondition: SharedAdditionalActivateCondition,
                 whenDigivolving: true,
                 whenAttacking: true);
 
             #region All Turns - Reactive Play
             if (timing == EffectTiming.OnTappedAnyone || timing == EffectTiming.OnDigivolutionCardDiscarded)
             {
+                int maxCost = 3;
+
                 ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect("May play/use 1 [DATA SQUAD] card cost 3 (+1 per suspended opponent) or lower from hand", CanUseCondition, card);
+                activateClass.SetUpICardEffect("May play/use 1 [DATA SQUAD] card cost 3 (+1 per suspended Digimon/Tamer) or lower from hand", CanUseCondition, card);
                 activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
                 activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
@@ -109,8 +107,8 @@ namespace DCGO.CardEffects.BT26
                 bool OwnTamerCondition(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card);
 
-                bool IsSuspendedOpponentPermanent(Permanent permanent)
-                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleArea(permanent, card)
+                bool IsSuspendedPermanent(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnBattleArea(permanent)
                         && (permanent.IsDigimon || permanent.IsTamer)
                         && permanent.IsSuspended;
 
@@ -120,18 +118,23 @@ namespace DCGO.CardEffects.BT26
                             || CardEffectCommons.CanTriggerOnTrashDigivolutionCard(hashtable, OwnTamerCondition, null, _ => true));
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+                {
+                    maxCost = 3 + card.Owner.Enemy.GetFieldPermanents().Filter(IsSuspendedPermanent).Count;
+                    
+                    return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+                }
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                        => cardSource.EqualsTraits("DATA SQUAD")
+                            && cardSource.HasPlayCost && cardSource.GetCostItself <= maxCost
+                            && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass, isPlayOption: true);
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
+                    maxCost = 3 + card.Owner.Enemy.GetFieldPermanents().Filter(IsSuspendedPermanent).Count;
+
                     bool isUsed = false;
-
-                    int maxCost = 3 + card.Owner.Enemy.GetFieldPermanents().Filter(IsSuspendedOpponentPermanent).Count;
-
-                    bool CanSelectCardCondition(CardSource cardSource)
-                        => cardSource.ContainsTraits("DATA SQUAD")
-                            && cardSource.HasCost && cardSource.GetCostItself <= maxCost
-                            && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass, isPlayOption: true);
 
                     if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition))
                     {

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
@@ -115,7 +115,7 @@ namespace DCGO.CardEffects.BT26
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && (CardEffectCommons.CanTriggerWhenPermanentSuspends(hashtable, OpponentPermanentCondition)
-                            || CardEffectCommons.CanTriggerOnTrashDigivolutionCard(hashtable, OwnTamerCondition, null, _ => true));
+                            || CardEffectCommons.CanTriggerOnTrashDigivolutionCard(hashtable, OwnTamerCondition, cardEffect => cardEffect != null, _ => true));
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
@@ -132,10 +132,6 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
-                    maxCost = 3 + card.Owner.Enemy.GetFieldPermanents().Filter(IsSuspendedPermanent).Count;
-
-                    bool isUsed = false;
-
                     if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition))
                     {
                         yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
@@ -147,12 +143,14 @@ namespace DCGO.CardEffects.BT26
 
                         IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
                         {
-                            if (cardSources != null && cardSources.Count > 0) isUsed = true;
+                            if (cardSources == null || cardSources.Count == 0) activateClass.RemoveUse();
                             yield return null;
                         }
                     }
-
-                    if (!isUsed) activateClass.RemoveUse();
+                    else
+                    {
+                        activateClass.RemoveUse();
+                    }
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 // Rosemon
 namespace DCGO.CardEffects.BT26
@@ -67,7 +68,7 @@ namespace DCGO.CardEffects.BT26
                         mode: SelectPermanentEffect.Mode.Tap,
                         cardEffect: activateClass);
 
-                    selectPermanentEffect.SetUpCustomMessage("Select up to 2 Digimon or Tamers to suspend.", "The opponent is selecting up to 2 Digimon or Tamers to suspend.");
+                    selectPermanentEffect.SetUpCustomMessage($"Select {maxCount} Digimon or Tamers to suspend.", $"The opponent is selecting {maxCount} Digimon or Tamers to suspend.");
 
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
                 }
@@ -120,37 +121,80 @@ namespace DCGO.CardEffects.BT26
                 bool CanActivateCondition(Hashtable hashtable)
                 {
                     maxCost = 3 + card.Owner.Enemy.GetFieldPermanents().Filter(IsSuspendedPermanent).Count;
-                    
+
                     return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
                 }
 
                 bool CanSelectCardCondition(CardSource cardSource)
                         => cardSource.EqualsTraits("DATA SQUAD")
-                            && cardSource.HasPlayCost && cardSource.GetCostItself <= maxCost
-                            && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass, isPlayOption: true);
+                        && cardSource.GetCostItself <= maxCost
+                        && ((cardSource.IsOption
+                                && !cardSource.CanNotPlayThisOption)
+                            || (cardSource.HasPlayCost
+                                && CardEffectCommons.CanPlayAsNewPermanent(cardSource: cardSource, payCost: false, cardEffect: activateClass)));
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
+                    bool isUsed = false;
+
                     if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition))
                     {
-                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
-                            canTargetCondition: CanSelectCardCondition,
-                            root: SelectCardEffect.Root.Hand,
-                            cardEffect: activateClass,
-                            payCost: false,
-                            afterSelectCardCoroutine: AfterSelectCardCoroutine));
+                        CardSource selectCard = null;
 
-                        IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                        SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                        selectHandEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSelectCardCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            isShowOpponent: true,
+                            selectCardCoroutine: SelectCardCoroutine,
+                            afterSelectCardCoroutine: null,
+                            mode: SelectHandEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectHandEffect.SetUpCustomMessage("Select 1 card to play/use.", "The opponent is selecting 1 card to play/use.");
+                        selectHandEffect.SetUpCustomMessage_ShowCard("Selected Card");
+
+                        IEnumerator SelectCardCoroutine(CardSource cardSource)
                         {
-                            if (cardSources == null || cardSources.Count == 0) activateClass.RemoveUse();
+                            selectCard = cardSource;
                             yield return null;
                         }
+
+                        yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                        if (selectCard != null)
+                        {
+                            isUsed = true;
+
+                            if (selectCard.IsOption)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayOptionCards(
+                                    cardSources: new List<CardSource>() { selectCard },
+                                    activateClass: activateClass,
+                                    payCost: false,
+                                    root: SelectCardEffect.Root.Hand));
+                            }
+                            else
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                                    new List<CardSource>() { selectCard },
+                                    activateClass: activateClass,
+                                    payCost: false,
+                                    isTapped: false,
+                                    root: SelectCardEffect.Root.Hand,
+                                    activateETB: true));
+                            }
+                        }
                     }
-                    else
-                    {
-                        activateClass.RemoveUse();
-                    }
+
+                    if (!isUsed) activateClass.RemoveUse();
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
@@ -95,7 +95,8 @@ namespace DCGO.CardEffects.BT26
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("May play/use 1 [DATA SQUAD] card cost 3 (+1 per suspended opponent) or lower from hand", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
@@ -123,6 +124,8 @@ namespace DCGO.CardEffects.BT26
 
                 IEnumerator ActivateCoroutine(Hashtable _hashtable)
                 {
+                    bool isUsed = false;
+
                     int maxCost = 3 + card.Owner.Enemy.GetFieldPermanents().Filter(IsSuspendedOpponentPermanent).Count;
 
                     bool CanSelectCardCondition(CardSource cardSource)
@@ -136,8 +139,17 @@ namespace DCGO.CardEffects.BT26
                             canTargetCondition: CanSelectCardCondition,
                             root: SelectCardEffect.Root.Hand,
                             cardEffect: activateClass,
-                            payCost: false));
+                            payCost: false,
+                            afterSelectCardCoroutine: AfterSelectCardCoroutine));
+
+                        IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                        {
+                            if (cardSources != null && cardSources.Count > 0) isUsed = true;
+                            yield return null;
+                        }
                     }
+
+                    if (!isUsed) activateClass.RemoveUse();
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 // Rosemon
 namespace DCGO.CardEffects.BT26
@@ -49,29 +48,26 @@ namespace DCGO.CardEffects.BT26
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
-                if (CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendTargetCondition))
-                {
-                    int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(CanSelectSuspendTargetCondition));
+                int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(CanSelectSuspendTargetCondition));
 
-                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+                SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
-                    selectPermanentEffect.SetUp(
-                        selectPlayer: card.Owner,
-                        canTargetCondition: CanSelectSuspendTargetCondition,
-                        canTargetCondition_ByPreSelecetedList: null,
-                        canEndSelectCondition: null,
-                        maxCount: maxCount,
-                        canNoSelect: false,
-                        canEndNotMax: false,
-                        selectPermanentCoroutine: null,
-                        afterSelectPermanentCoroutine: null,
-                        mode: SelectPermanentEffect.Mode.Tap,
-                        cardEffect: activateClass);
+                selectPermanentEffect.SetUp(
+                    selectPlayer: card.Owner,
+                    canTargetCondition: CanSelectSuspendTargetCondition,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    maxCount: maxCount,
+                    canNoSelect: false,
+                    canEndNotMax: false,
+                    selectPermanentCoroutine: null,
+                    afterSelectPermanentCoroutine: null,
+                    mode: SelectPermanentEffect.Mode.Tap,
+                    cardEffect: activateClass);
 
-                    selectPermanentEffect.SetUpCustomMessage($"Select {maxCount} Digimon or Tamers to suspend.", $"The opponent is selecting {maxCount} Digimon or Tamers to suspend.");
+                selectPermanentEffect.SetUpCustomMessage($"Select {maxCount} Digimon or Tamers to suspend.", $"The opponent is selecting {maxCount} Digimon or Tamers to suspend.");
 
-                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
-                }
+                yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
             }
 
             #endregion

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Rosemon
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_049 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.EqualsCardName("Lilamon")
+                        || (targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 5 && targetPermanent.TopCard.ContainsTraits("DATA SQUAD"));
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared When Digivolving / When Attacking
+
+            string SharedEffectName() => "Suspend 2 opponent's Digimon or Tamers";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] [Once Per Turn] Suspend 2 of your opponent's Digimon or Tamers.";
+
+            bool CanSelectSuspendTargetCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleArea(permanent, card)
+                    && (permanent.IsDigimon || permanent.IsTamer);
+
+            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
+                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendTargetCondition);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                if (CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendTargetCondition))
+                {
+                    int maxCount = Math.Min(2, CardEffectCommons.MatchConditionPermanentCount(CanSelectSuspendTargetCondition));
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectSuspendTargetCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: maxCount,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Tap,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select up to 2 Digimon or Tamers to suspend.", "The opponent is selecting up to 2 Digimon or Tamers to suspend.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                }
+            }
+
+            #endregion
+
+            #region When Digivolving
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
+                activateClass.SetHashString("BT26_049_Shared");
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
+                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
+                activateClass.SetHashString("BT26_049_Shared");
+                cardEffects.Add(activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+            }
+            #endregion
+
+            #region All Turns - Reactive Play
+            if (timing == EffectTiming.OnTappedAnyone || timing == EffectTiming.OnDigivolutionCardDiscarded)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("May play/use 1 [DATA SQUAD] card cost 3 (+1 per suspended opponent) or lower from hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, true, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[All Turns] [Once Per Turn] When any of your opponent's Digimon or Tamers suspend, or effects trash cards from under your Tamers, you may play or use 1 play or use cost 3 or lower [DATA SQUAD] trait card from your hand without paying the cost. For each suspended Digimon or Tamer, add 1 to the cost maximum.";
+
+                bool OpponentPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleArea(permanent, card)
+                        && (permanent.IsDigimon || permanent.IsTamer);
+
+                bool OwnTamerCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaTamer(permanent, card);
+
+                bool IsSuspendedOpponentPermanent(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOpponentBattleArea(permanent, card)
+                        && (permanent.IsDigimon || permanent.IsTamer)
+                        && permanent.IsSuspended;
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && (CardEffectCommons.CanTriggerWhenPermanentSuspends(hashtable, OpponentPermanentCondition)
+                            || CardEffectCommons.CanTriggerOnTrashDigivolutionCard(hashtable, OwnTamerCondition, null, _ => true));
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    int maxCost = 3 + card.Owner.Enemy.GetFieldPermanents().Filter(IsSuspendedOpponentPermanent).Count;
+
+                    bool CanSelectCardCondition(CardSource cardSource)
+                        => cardSource.ContainsTraits("DATA SQUAD")
+                            && cardSource.HasCost && cardSource.GetCostItself <= maxCost
+                            && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass, isPlayOption: true);
+
+                    if (CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition))
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                            canTargetCondition: CanSelectCardCondition,
+                            root: SelectCardEffect.Root.Hand,
+                            cardEffect: activateClass,
+                            payCost: false));
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
@@ -11,16 +11,27 @@ namespace DCGO.CardEffects.BT26
         {
             List<ICardEffect> cardEffects = new List<ICardEffect>();
 
-            #region Alternate Digivolution Requirement
+            #region Alternate Digivolution Requirement - [Lilamon]
             if (timing == EffectTiming.None)
             {
                 bool PermanentCondition(Permanent targetPermanent)
                 {
-                    return targetPermanent.TopCard.EqualsCardName("Lilamon")
-                        || (targetPermanent.TopCard.HasLevel && targetPermanent.TopCard.Level == 5 && targetPermanent.TopCard.ContainsTraits("DATA SQUAD"));
+                    return targetPermanent.TopCard.EqualsCardName("Lilamon");
                 }
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Alternate Digivolution Requirement - Lv.5 w/[DATA SQUAD] trait
+            if (timing == EffectTiming.None)
+            {
+                bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.ContainsTraits("DATA SQUAD");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 5));
             }
             #endregion
 

--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_049.cs
@@ -46,9 +46,8 @@ namespace DCGO.CardEffects.BT26
                 => CardEffectCommons.IsPermanentExistsOnOpponentBattleArea(permanent, card)
                     && (permanent.IsDigimon || permanent.IsTamer);
 
-            bool SharedCanActivateCondition(Hashtable hashtable, ICardEffect activateClass)
-                => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
-                    && CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendTargetCondition);
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionPermanent(CanSelectSuspendTargetCondition);
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -79,35 +78,17 @@ namespace DCGO.CardEffects.BT26
 
             #endregion
 
-            #region When Digivolving
-            if (timing == EffectTiming.OnEnterFieldAnyone)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Digivolving"));
-                activateClass.SetHashString("BT26_049_Shared");
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerWhenDigivolving(hashtable, card);
-            }
-            #endregion
-
-            #region When Attacking
-            if (timing == EffectTiming.OnAllyAttack)
-            {
-                ActivateClass activateClass = new ActivateClass();
-                activateClass.SetUpICardEffect(SharedEffectName(), CanUseCondition, card);
-                activateClass.SetUpActivateClass((hash) => SharedCanActivateCondition(hash, activateClass), (hash) => SharedActivateCoroutine(hash, activateClass), 1, false, SharedEffectDescription("When Attacking"));
-                activateClass.SetHashString("BT26_049_Shared");
-                cardEffects.Add(activateClass);
-
-                bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
-                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
-            }
-            #endregion
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName(),
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                maxCountPerTurn: 1,
+                hashValue: "BT26_049_Shared",
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                whenDigivolving: true,
+                whenAttacking: true);
 
             #region All Turns - Reactive Play
             if (timing == EffectTiming.OnTappedAnyone || timing == EffectTiming.OnDigivolutionCardDiscarded)


### PR DESCRIPTION
## Summary
- Implements BT26-049 Rosemon's card effect (text supplied directly; the card was already revealed but this repo's issue still shows "Not revealed").
- Alternate digivolution requirement: [Lilamon] or Lv.5 w/[DATA SQUAD] trait, cost 3.
- [When Digivolving] [When Attacking] [Once Per Turn] Suspend 2 of your opponent's Digimon or Tamers.
- [All Turns] [Once Per Turn] When any of your opponent's Digimon or Tamers suspend, or effects trash cards from under your Tamers, you may play or use 1 play or use cost 3 or lower [DATA SQUAD] trait card from your hand without paying the cost. For each suspended Digimon or Tamer, add 1 to the cost maximum.