### PR TITLE
Corrected BT24-050 effect text

### DIFF
--- a/Assets/Scripts/CardEffect/BT24/Green/BT24_050.cs
+++ b/Assets/Scripts/CardEffect/BT24/Green/BT24_050.cs
@@ -103,7 +103,7 @@ namespace DCGO.CardEffects.BT24
                             mode: SelectPermanentEffect.Mode.Custom,
                             cardEffect: activateClass);
 
-                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon or Tamer that will get unable to suspend.", "The opponent is selecting 1 Digimon or Tamer that will get unable to suspend.");
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon or Tamer that will be unable to unsuspend.", "The opponent is selecting 1 Digimon or Tamer that will be unable to unsuspend.");
 
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
 


### PR DESCRIPTION
BT24-050 (WereGaruru)'s effect string was incorrectly written as "Unable to suspend" when it is actually "Unable to unsuspend". Actual effect works fine.