### PR TITLE
Add EX13-020 Magnamon card effect

### DIFF
--- a/Assets/Scripts/CardEffect/EX13/Blue/EX13_020.cs
+++ b/Assets/Scripts/CardEffect/EX13/Blue/EX13_020.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -103,8 +102,6 @@ namespace DCGO.CardEffects.EX13
 
                 if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDebuffTargetCondition))
                 {
-                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectDebuffTargetCondition));
-
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                     selectPermanentEffect.SetUp(
@@ -112,7 +109,7 @@ namespace DCGO.CardEffects.EX13
                         canTargetCondition: CanSelectDebuffTargetCondition,
                         canTargetCondition_ByPreSelecetedList: null,
                         canEndSelectCondition: null,
-                        maxCount: maxCount,
+                        maxCount: 1,
                         canNoSelect: false,
                         canEndNotMax: false,
                         selectPermanentCoroutine: SelectPermanentCoroutine,
@@ -162,7 +159,8 @@ namespace DCGO.CardEffects.EX13
 
                 bool CanSelectPermanentCondition(Permanent permanent)
                     => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
-                        && (permanent.TopCard.ContainsTraits("Free") || permanent.TopCard.ContainsTraits("Royal Knight"));
+                        && (permanent.TopCard.ContainsTraits("Free") || permanent.TopCard.ContainsTraits("Royal Knight"))
+                        && CardEffectCommons.CanUnsuspend(permanent);
 
                 bool CanUseCondition(Hashtable hashtable)
                     => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
@@ -174,6 +172,8 @@ namespace DCGO.CardEffects.EX13
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
+                    bool isUsed = false;
+
                     SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
                     selectPermanentEffect.SetUp(
@@ -184,7 +184,7 @@ namespace DCGO.CardEffects.EX13
                         maxCount: 1,
                         canNoSelect: true,
                         canEndNotMax: false,
-                        selectPermanentCoroutine: null,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
                         afterSelectPermanentCoroutine: null,
                         mode: SelectPermanentEffect.Mode.UnTap,
                         cardEffect: activateClass);
@@ -192,6 +192,14 @@ namespace DCGO.CardEffects.EX13
                     selectPermanentEffect.SetUpCustomMessage("Select 1 [Free]/[Royal Knight] Digimon to unsuspend.", "The opponent is selecting 1 [Free]/[Royal Knight] Digimon to unsuspend.");
 
                     yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        isUsed = true;
+                        yield return null;
+                    }
+
+                    if (!isUsed) activateClass.RemoveUse();
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/EX13/Blue/EX13_020.cs
+++ b/Assets/Scripts/CardEffect/EX13/Blue/EX13_020.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+// Magnamon
+namespace DCGO.CardEffects.EX13
+{
+    public class EX13_020 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement Veemon
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                {
+                    return targetPermanent.TopCard.EqualsCardName("Veemon");
+                }
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Armor Purge
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.ArmorPurgeEffect(card: card));
+            }
+            #endregion
+
+            #region Assembly
+            if (timing == EffectTiming.None)
+            {
+                AddAssemblyConditionClass addAssemblyConditionClass = new AddAssemblyConditionClass();
+                addAssemblyConditionClass.SetUpICardEffect("Assembly", CanUseCondition, card);
+                addAssemblyConditionClass.SetUpAddAssemblyConditionClass(getAssemblyCondition: GetAssembly);
+                addAssemblyConditionClass.SetNotShowUI(true);
+                cardEffects.Add(addAssemblyConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return true;
+                }
+
+                AssemblyCondition GetAssembly(CardSource cardSource)
+                {
+                    if (cardSource == card)
+                    {
+                        AssemblyConditionElement element = new AssemblyConditionElement(CanSelectCardCondition);
+
+                        bool CanSelectCardCondition(CardSource sourceCard)
+                        {
+                            return sourceCard.EqualsCardName("Veemon");
+                        }
+
+                        AssemblyCondition assemblyCondition = new AssemblyCondition(
+                            element: element,
+                            CanTargetCondition_ByPreSelecetedList: null,
+                            selectMessage: "[Veemon]",
+                            elementCount: 1,
+                            reduceCost: 2);
+
+                        return assemblyCondition;
+                    }
+
+                    return null;
+                }
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving / When Attacking
+            string SharedHashString = "EX13_020_OP_WD_WA";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] [Once Per Turn] This Digimon gets +1000 DP until your opponent's turn ends for each color in trashes. Then, to 1 of your opponent's Digimon, give -4000 DP until their turn ends for every 5000 DP this Digimon has.";
+
+            bool CanSelectDebuffTargetCondition(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+            int TrashColorCount()
+            {
+                List<CardColor> colors = new List<CardColor>();
+                colors.AddRange(card.Owner.TrashCards.SelectMany(cardSource => cardSource.CardColors));
+                colors.AddRange(card.Owner.Enemy.TrashCards.SelectMany(cardSource => cardSource.CardColors));
+                return colors.Distinct().Count();
+            }
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                Permanent thisPermanent = card.PermanentOfThisCard();
+
+                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: thisPermanent, changeValue: 1000 * TrashColorCount(), effectDuration: EffectDuration.UntilOpponentTurnEnd, activateClass: activateClass));
+
+                if (CardEffectCommons.HasMatchConditionPermanent(CanSelectDebuffTargetCondition))
+                {
+                    int maxCount = Math.Min(1, CardEffectCommons.MatchConditionPermanentCount(CanSelectDebuffTargetCondition));
+
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectDebuffTargetCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: maxCount,
+                        canNoSelect: false,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: SelectPermanentCoroutine,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get -4000 DP for every 5000 DP this Digimon has.", "The opponent is selecting 1 Digimon that will get -4000 DP for every 5000 DP this Digimon has.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                    IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                    {
+                        int debuffCount = thisPermanent.DP / 5000;
+
+                        yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonDP(targetPermanent: permanent, changeValue: -4000 * debuffCount, effectDuration: EffectDuration.UntilOpponentTurnEnd, activateClass: activateClass));
+                    }
+                }
+            }
+            #endregion
+
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                "This Digimon gets +1000 DP per color in trashes, then -4000 DP to 1 opponent's Digimon per 5000 DP this Digimon has",
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                maxCountPerTurn: 1,
+                hashValue: SharedHashString,
+                onPlay: true,
+                whenDigivolving: true,
+                whenAttacking: true);
+
+            #region End of Your Turn / Inherit
+            if (timing == EffectTiming.OnEndTurn)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("1 of your [Free]/[Royal Knight] Digimon may unsuspend", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("EX13_020_EndOfTurn");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[End of Your Turn] [Once Per Turn] 1 of your Digimon with the [Free] or [Royal Knight] trait may unsuspend.";
+
+                bool CanSelectPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                        && (permanent.TopCard.ContainsTraits("Free") || permanent.TopCard.ContainsTraits("Royal Knight"));
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.IsOwnerTurn(card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                    selectPermanentEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectPermanentCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        selectPermanentCoroutine: null,
+                        afterSelectPermanentCoroutine: null,
+                        mode: SelectPermanentEffect.Mode.UnTap,
+                        cardEffect: activateClass);
+
+                    selectPermanentEffect.SetUpCustomMessage("Select 1 [Free]/[Royal Knight] Digimon to unsuspend.", "The opponent is selecting 1 [Free]/[Royal Knight] Digimon to unsuspend.");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
First card of the EX13 set (issue #1864). Creates the `Assets/Scripts/CardEffect/EX13/` folder and adds:

- Alternate digivolve requirement: any card named [Veemon], cost 3
- Blocker, Armor Purge
- Assembly -2 [Veemon]
- [On Play] [When Digivolving] [When Attacking] [Once Per Turn]: this Digimon gets +1000 DP until your opponent's turn ends for each distinct color across both trashes. Then, to 1 of your opponent's Digimon, give -4000 DP until their turn ends for every 5000 DP this Digimon has.
- [End of Your Turn] [Once Per Turn] (also Inherited): 1 of your Digimon with the [Free] or [Royal Knight] trait may unsuspend.

No CardBaseEntity data included, matching current convention (created in bulk closer to beta).