### PR TITLE
Update BT26-016

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
+++ b/Assets/Scripts/CardEffect/BT26/White/BT26_016.cs
@@ -46,7 +46,9 @@ namespace DCGO.CardEffects.BT26
 
             bool CanSelectDeleteTargetCondition(Permanent permanent, ICardEffect activateClass)
                 => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
-                    && permanent.DP <= card.Owner.MaxDP_DeleteEffect(card.PermanentOfThisCard().DP, activateClass);
+                    && permanent.HasDP
+                    && card.PermanentOfThisCard().HasDP
+                    && permanent.DP <= card.PermanentOfThisCard().DP;
 
             bool AdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
                 => CardEffectCommons.HasMatchConditionPermanent(permanent => CanSelectDeleteTargetCondition(permanent, activateClass))


### PR DESCRIPTION
MaxDP method is only for effects which delete up to a given numeric dp, not for less than or equal to this digimon's DP