### PR TITLE
BT26_089: implement missing by-effect + opponent-has-digimon check

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_089.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_089.cs
@@ -124,7 +124,7 @@ namespace DCGO.CardEffects.BT26
                     {
                         yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(new List<CardSource> { card.Owner.LibraryCards[0] }, activateClass, isFacedown: true));
 
-                        //if (by effect) && opponent has digimon
+                        if (CardEffectCommons.IsByEffect(hashtable, null) && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
                         {
                             SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 


### PR DESCRIPTION
Fixes the placeholder in #1582 per hooperk's review comment: implements the actual `by effect && opponent has digimon` gate before offering the <Security A. -1> selection.

Diff:
```diff
-//if (by effect) && opponent has digimon
+if (CardEffectCommons.IsByEffect(hashtable, null) && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
```

Opened against `x89rt2-patch-1` directly (no write access to that branch) so it can be merged into #1582.