### PR TITLE
Add BT26-089 Kyo Sawashiro card effect

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_089.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_089.cs
@@ -1,0 +1,172 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Kyo Sawashiro
+namespace DCGO.CardEffects.BT26
+{
+    public class BT26_089 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Start of Your Main Phase
+            if (timing == EffectTiming.OnStartMainPhase)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Place 1 [BEATBREAK] from hand under to <Draw 1> and gain 1 memory", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[Start of Your Main Phase] By placing 1 [BEATBREAK] trait card from your hand face down under this Tamer, <Draw 1> and gain 1 memory.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.IsOwnerTurn(card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+                }
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                {
+                    return cardSource.EqualsTraits("BEATBREAK");
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    CardSource selectedCard = null;
+
+                    SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
+
+                    selectHandEffect.SetUp(
+                        selectPlayer: card.Owner,
+                        canTargetCondition: CanSelectCardCondition,
+                        canTargetCondition_ByPreSelecetedList: null,
+                        canEndSelectCondition: null,
+                        maxCount: 1,
+                        canNoSelect: true,
+                        canEndNotMax: false,
+                        isShowOpponent: true,
+                        selectCardCoroutine: SelectCardCoroutine,
+                        afterSelectCardCoroutine: null,
+                        mode: SelectHandEffect.Mode.Custom,
+                        cardEffect: activateClass);
+
+                    selectHandEffect.SetUpCustomMessage("Select 1 card to place as the bottom digivolution card.", "The opponent is selecting 1 card to place as the bottom digivolution card.");
+                    selectHandEffect.SetUpCustomMessage_ShowCard("Selected Card");
+
+                    yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
+                    {
+                        selectedCard = cardSource;
+                        yield return null;
+                    }
+
+                    if (selectedCard != null)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(new List<CardSource>() { selectedCard }, activateClass, false, true));
+
+                        yield return ContinuousController.instance.StartCoroutine(new DrawClass(player: card.Owner, drawCount: 1, cardEffect: activateClass).Draw());
+                        yield return ContinuousController.instance.StartCoroutine(card.Owner.AddMemory(1, activateClass));
+                    }
+                }
+            }
+            #endregion
+
+            #region All Turns
+            if (timing == EffectTiming.OnLoseSecurity)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Suspend this to place top deck to bottom source facedown, then if by effect, give enemy Digimon -1 <Security A. -1> until end of their turn", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[All Turns] When your security stack is removed from, by suspending this Tamer, place the top card of your deck face down under this Tamer. After, if removed from by effects, give 1 of your opponent's Digimon <Security A. -1> until their turn ends.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.CanActivateSuspendCostEffect(card);
+                }
+
+                bool CanSelectPermanentCondition(Permanent permanent)
+                {
+                    return CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SuspendPeremanentAndProcessAccordingToResult(
+                        new List<Permanent>() { card.PermanentOfThisCard() },
+                        activateClass,
+                        SuccessProcess,
+                        null));
+
+                    IEnumerator SuccessProcess(List<Permanent> suspendedPermaments)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(card.PermanentOfThisCard().AddDigivolutionCardsBottom(new List<CardSource> { card.Owner.LibraryCards[0] }, activateClass, isFacedown: true));
+
+                        if (CardEffectCommons.IsByEffect(hashtable, null) && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition))
+                        {
+                            SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                            selectPermanentEffect.SetUp(
+                                selectPlayer: card.Owner,
+                                canTargetCondition: CanSelectPermanentCondition,
+                                canTargetCondition_ByPreSelecetedList: null,
+                                canEndSelectCondition: null,
+                                maxCount: 1,
+                                canNoSelect: false,
+                                canEndNotMax: false,
+                                selectPermanentCoroutine: SelectPermanentCoroutine,
+                                afterSelectPermanentCoroutine: null,
+                                mode: SelectPermanentEffect.Mode.Custom,
+                                cardEffect: activateClass);
+
+                            selectPermanentEffect.SetUpCustomMessage("Select 1 Digimon that will get <Security A. -1> until end of enemy turn.", "The opponent is selecting 1 Digimon that will get <Security A. -1>.");
+
+                            yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                            IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.ChangeDigimonSAttack(
+                                    targetPermanent: permanent,
+                                    changeValue: -1,
+                                    effectDuration: EffectDuration.UntilOpponentTurnEnd,
+                                    activateClass: activateClass));
+                            }
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Security Effect
+            if (timing == EffectTiming.SecuritySkill)
+            {
+                cardEffects.Add(CardEffectFactory.PlaySelfTamerSecurityEffect(card));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
Standalone PR for BT26-089 (Kyo Sawashiro), incorporating the fix from hooperk's review on #1582: the "All Turns" ability's `<Security A. -1>` grant now has its actual `by effect && opponent has digimon` condition implemented instead of a placeholder comment.

Supersedes #1582 / #1934.