### PR TITLE
Fix stack overflow crash when Zanbamon (BT26-017) grants Progress

### DIFF
--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Progress.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Progress.cs
@@ -18,25 +18,14 @@ public partial class CardEffectCommons
 
         bool CanUseCondition()
         {
-            if (IsPermanentExistsOnBattleArea(targetPermanent))
-            {
-                if (!targetPermanent.TopCard.CanNotBeAffected(activateClass))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return IsPermanentExistsOnBattleArea(targetPermanent) && CanActivateProgress(targetPermanent.TopCard);
         }
 
-        CanNotAffectedClass progress = CardEffectFactory.ProgressStaticEffect(isInheritedEffect: false, card: card, condition: CanUseCondition);
+        CanNotAffectedClass progress = CardEffectFactory.ProgressStaticEffect(isInheritedEffect: false, card: targetPermanent.TopCard, condition: CanUseCondition);
 
         AddEffectToPermanent(targetPermanent: targetPermanent, effectDuration: effectDuration, card: card, cardEffect: progress, timing: EffectTiming.None);
 
-        if (!targetPermanent.TopCard.CanNotBeAffected(activateClass))
-        {
-            yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateBuffEffect(targetPermanent));
-        }
+        yield return ContinuousController.instance.StartCoroutine(GManager.instance.GetComponent<Effects>().CreateBuffEffect(targetPermanent));
     }
     #endregion
 


### PR DESCRIPTION
## Summary
- `GainProgress` attached the Progress `CanNotAffectedClass` to the target permanent, then immediately called `targetPermanent.TopCard.CanNotBeAffected(activateClass)` to decide whether to play the buff visual. `CanNotBeAffected` scans every permanent's `EffectTiming.None` effects and calls `CanUse()` on each `ICanNotAffectedEffect` it finds — including the one just attached, whose own `CanUseCondition` called back into `CanNotBeAffected` on the same permanent. That's unbounded recursion, ending in a stack overflow that crashes the whole process the moment Zanbamon's ability resolves.
- BT26_017 (Zanbamon) is the only card that calls `GainProgress`, so this path was never exercised before.
- Fix mirrors `ProgressSelfStaticEffect`'s existing, non-recursive condition — `CanActivateProgress(targetPermanent.TopCard)` — instead of checking `CanNotBeAffected` against the very effect being granted. Also passes `card: targetPermanent.TopCard` (not the ability's source card) to `ProgressStaticEffect`, since its internal `CardCondition` needs to match whichever Digimon the player actually selected as the target, which may not be Zanbamon itself.

## Test plan
- [ ] Play Zanbamon (BT26-017), trigger its On Play/When Digivolving ability, select a valid [Shambala] target, confirm it gains Security Attack +1 and Progress without crashing.
- [ ] Confirm the Progress-granted Digimon is correctly protected while attacking (not while Zanbamon itself is attacking, if a different target was chosen).