### PR TITLE
Fix BT26-103 (Jupitermon: Wrath Mode) Succession never triggering

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Yellow/BT26_103.cs
+++ b/Assets/Scripts/CardEffect/BT26/Yellow/BT26_103.cs
@@ -48,7 +48,7 @@ namespace DCGO.CardEffects.BT26
             #region Succession
             if (timing == EffectTiming.None)
             {
-                bool CardCondition(CardSource cardSource) => cardSource.EqualsCardName("Jupitermon");
+                bool CardCondition(CardSource cardSource) => cardSource.ContainsCardName("Jupitermon");
 
                 cardEffects.Add(CardEffectFactory.SuccessionSelfEffect(isInheritedEffect: false, card: card, condition: null, cardCondition: CardCondition));
             }


### PR DESCRIPTION
## Summary
- Wrath Mode's Succession self-check used `EqualsCardName("Jupitermon")`, but this card's own printed name is `"Jupitermon: Wrath Mode"` (same colon-joined display-name convention as other dual/mode cards), so the exact-match check could never succeed and Succession never activated.
- Switched to `ContainsCardName("Jupitermon")`, matching the same pattern already used by other Succession cards (e.g. BT26_060 checks `ContainsCardName("Chronomon")` against its own name `"Chronomon: Destroy Mode"`).

## Test plan
- [ ] Digivolve Wrath Mode onto a Digimon named "Jupitermon" and confirm Succession grants that card's effects.