### PR TITLE
BT26-060 (Chronomon: Destroy Mode): return-order picker + return-count fixes

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
@@ -112,6 +112,7 @@ namespace DCGO.CardEffects.BT26
                     foreach (Permanent selectedPermanent in selectedPermanents)
                     {
                         if (selectedPermanent == null) continue;
+                        if (!CardEffectCommons.IsPermanentExistsOnBattleArea(selectedPermanent)) continue;
                         if (selectedPermanent.TopCard == null) continue;
                         if (selectedPermanent.ImmuneFromStackReturnToLibrary(activateClass)) continue;
                         if (selectedPermanent.TopCard.CanNotBeAffected(activateClass)) continue;

--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
@@ -74,8 +74,7 @@ namespace DCGO.CardEffects.BT26
                 => $"[{tag}] Return the top 5 stacked cards of 3 of your opponent's Digimon to the top of the deck.";
 
             bool CanSelectTargetCondition(Permanent permanent)
-                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
-                    && !permanent.HasNoDigivolutionCards;
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {

--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
@@ -74,7 +74,8 @@ namespace DCGO.CardEffects.BT26
                 => $"[{tag}] Return the top 5 stacked cards of 3 of your opponent's Digimon to the top of the deck.";
 
             bool CanSelectTargetCondition(Permanent permanent)
-                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card)
+                    && !permanent.HasNoDigivolutionCards;
 
             IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
             {
@@ -117,11 +118,11 @@ namespace DCGO.CardEffects.BT26
                         if (selectedPermanent.ImmuneFromStackReturnToLibrary(activateClass)) continue;
                         if (selectedPermanent.TopCard.CanNotBeAffected(activateClass)) continue;
 
-                        int returnCount = Math.Min(selectedPermanent.StackCards.Count, 5);
+                        int returnCount = Math.Min(selectedPermanent.DigivolutionCards.Count, 5);
 
                         if (returnCount <= 0) continue;
 
-                        List<CardSource> cardsToReturn = selectedPermanent.StackCards.GetRange(0, returnCount);
+                        List<CardSource> cardsToReturn = selectedPermanent.DigivolutionCards.GetRange(0, returnCount);
 
                         if (returnCount == 1)
                         {

--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
@@ -111,7 +111,58 @@ namespace DCGO.CardEffects.BT26
 
                     foreach (Permanent selectedPermanent in selectedPermanents)
                     {
-                        yield return ContinuousController.instance.StartCoroutine(new IReturnStackToLibrary(selectedPermanent, 5, activateClass).ReturnStackToLibrary());
+                        if (selectedPermanent == null) continue;
+                        if (selectedPermanent.TopCard == null) continue;
+                        if (selectedPermanent.ImmuneFromStackReturnToLibrary(activateClass)) continue;
+                        if (selectedPermanent.TopCard.CanNotBeAffected(activateClass)) continue;
+
+                        int returnCount = Math.Min(selectedPermanent.StackCards.Count, 5);
+
+                        if (returnCount <= 0) continue;
+
+                        List<CardSource> cardsToReturn = selectedPermanent.StackCards.GetRange(0, returnCount);
+
+                        if (returnCount == 1)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(cardsToReturn, cardEffect: activateClass));
+                            continue;
+                        }
+
+                        List<CardSource> drawOrderedCards = new List<CardSource>();
+
+                        SelectCardEffect selectOrderEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                        selectOrderEffect.SetUp(
+                            canTargetCondition: (cardSource) => true,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            canNoSelect: () => false,
+                            selectCardCoroutine: null,
+                            afterSelectCardCoroutine: AfterSelectOrderCoroutine,
+                            message: $"Select the order to return these {returnCount} cards to the top of the opponent's deck (card #1 is the one they'll draw first, #2 second, and so on).",
+                            maxCount: returnCount,
+                            canEndNotMax: false,
+                            isShowOpponent: false,
+                            mode: SelectCardEffect.Mode.Custom,
+                            root: SelectCardEffect.Root.Custom,
+                            customRootCardList: cardsToReturn,
+                            canLookReverseCard: true,
+                            selectPlayer: card.Owner,
+                            cardEffect: activateClass);
+
+                        selectOrderEffect.SetUpCustomMessage_ShowCard("Returned Cards");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectOrderEffect.Activate());
+
+                        IEnumerator AfterSelectOrderCoroutine(List<CardSource> cardSources)
+                        {
+                            drawOrderedCards = cardSources.Clone();
+                            yield return null;
+                        }
+
+                        drawOrderedCards.Reverse();
+
+                        yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddLibraryTopCards(drawOrderedCards, cardEffect: activateClass));
                     }
                 }
             }

--- a/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
+++ b/Assets/Scripts/CardEffect/BT26/Black/BT26_060.cs
@@ -118,11 +118,13 @@ namespace DCGO.CardEffects.BT26
                         if (selectedPermanent.ImmuneFromStackReturnToLibrary(activateClass)) continue;
                         if (selectedPermanent.TopCard.CanNotBeAffected(activateClass)) continue;
 
-                        int returnCount = Math.Min(selectedPermanent.DigivolutionCards.Count, 5);
+                        // Return from the top of the stack (TopCard included) but always leave at least 1
+                        // card behind -- this ability returns cards, it doesn't remove the whole permanent.
+                        int returnCount = Math.Min(selectedPermanent.StackCards.Count - 1, 5);
 
                         if (returnCount <= 0) continue;
 
-                        List<CardSource> cardsToReturn = selectedPermanent.DigivolutionCards.GetRange(0, returnCount);
+                        List<CardSource> cardsToReturn = selectedPermanent.StackCards.GetRange(0, returnCount);
 
                         if (returnCount == 1)
                         {


### PR DESCRIPTION
## Summary
- The "Return the top 5 stacked cards" ability returned cards without letting the player choose the order the opponent will draw them back in. Added an order-choice selection so the player controls which card the opponent draws first vs. second, etc.
- Fixed an `InvalidOperationException` crash (`Permanent.ImmuneFromStackReturnToLibrary`'s cross-board scan) that could occur mid-loop if a previously-processed permanent's board state changed the availability of a later one — added a defensive existence re-check per permanent in the return-order loop.
- Fixed the return-count/slice logic: it originally computed the return count from `Permanent.StackCards` (which includes the target's own active top card, not just digivolution material), so a Digimon with zero digivolution cards could have its own card returned to the deck, wiping it off the field entirely. Fixed to return from the top of the stack (top card included, matching "top 5 stacked cards") while always leaving at least 1 card behind so the permanent is never fully removed, and excluded zero-material Digimon from being selectable as a target at all (since returning from them would always be a no-op).

## Test plan
- [ ] Activate the ability against an opponent's Digimon with 3+ stacked cards and confirm the order-choice prompt lets you pick which cards return, and in what order.
- [ ] Confirm a target with zero digivolution cards is not offered as a selectable target.
- [ ] Confirm returning from a 3-card stack (e.g. top + 2 material) can return the top 2 cards, leaving 1 behind, without crashing.