### PR TITLE
Fix Succession keyword: OPT tracking, self-poisoning identity, and parameter mismapping

### DIFF
--- a/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
@@ -102,7 +102,17 @@ public partial class CardEffectFactory
 
                     if (cardEffect is ActivateClass activateClass)
                     {
-                        getCardEffects.Add(activateClass);
+                        // Build a brand-new ActivateClass rather than mutating/reusing the source
+                        // card's own instance. The source card's copy needs its own independent
+                        // EffectSourceCard/HashString so per-turn-use tracking (ICardEffect.IsSameEffect,
+                        // which short-circuits on reference equality) doesn't treat "the original card
+                        // already used this ability this turn" as also covering "the Digimon that just
+                        // gained this ability via Succession/copy already used it" -- per game rules,
+                        // gaining another card's effects this way grants an independently-tracked copy,
+                        // not a shared use-count with the original (real bug: a [Once Per Turn] When
+                        // Digivolving effect used earlier the same turn on the source card silently
+                        // couldn't trigger again when copied onto the new top card via Succession, even
+                        // though it's a fresh instance from the new card's perspective).
 
                         List<CardSource> ValidCardSources = null;
 
@@ -123,24 +133,36 @@ public partial class CardEffectFactory
                         }
 
                         var originalUseCondition = activateClass.CanUseCondition;
-                        activateClass.SetCanUseCondition(
-                            hashtable => ValidCardSourceAtTrigger() 
-                            && (originalUseCondition is null || originalUseCondition(hashtable))
-                        );
-
                         var originalActivateCondition = activateClass.CanActivateCondition;
-                        activateClass.SetCanActivateCondition(
-                            hashtable => ValidCardSourceAtActivate()
-                            && (originalActivateCondition is null || originalActivateCondition(hashtable))
-                        );
 
-                        activateClass.SetHashString(GenerateHashString(card, activateClass.OriginalEffectSourceCard, activateClass.HashString, isInheritedEffect, isLinkedEffect));
+                        ActivateClass copiedActivateClass = new ActivateClass();
+
+                        copiedActivateClass.SetUpICardEffect(
+                            activateClass.EffectName,
+                            hashtable => ValidCardSourceAtTrigger()
+                                && (originalUseCondition is null || originalUseCondition(hashtable)),
+                            card);
+
+                        copiedActivateClass.SetUpActivateClass(
+                            hashtable => ValidCardSourceAtActivate()
+                                && (originalActivateCondition is null || originalActivateCondition(hashtable)),
+                            hashtable => activateClass.Activate(hashtable),
+                            activateClass.MaxCountPerTurn,
+                            activateClass.IsOptional,
+                            activateClass.EffectDescription);
+
+                        copiedActivateClass.SetOriginalEffectSourceCard(activateClass.OriginalEffectSourceCard);
+                        copiedActivateClass.SetHashString(GenerateHashString(card, activateClass.OriginalEffectSourceCard, activateClass.HashString, isInheritedEffect, isLinkedEffect));
+                        copiedActivateClass.SetIsInheritedEffect(isInheritedEffect);
+                        copiedActivateClass.SetIsLinkedEffect(isLinkedEffect);
+
+                        getCardEffects.Add(copiedActivateClass);
 
                         getCardEffects.Add(PermanentEffectFactory.AddDetailClass(
                             thisPermanent,
-                            activateClass.EffectDescription,
+                            copiedActivateClass.EffectDescription,
                             true,
-                            activateClass));
+                            copiedActivateClass));
                     }
                     else if (!isSuccession || cardEffect.EffectName != "Succession") // Succession can never copy another succession skill
                     {

--- a/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
@@ -34,19 +34,24 @@ public partial class CardEffectFactory
 
         bool DefaultCardSourceCondition(CardSource cardSource)
         {
-            if (cardSource == null) return false;
+            // This wrapper only ever grants its copy to its own host (card) -- never to
+            // whatever else happens to be the probed candidate. Without this identity check,
+            // a completely unrelated card could satisfy "permanentCondition(permanent) &&
+            // cardSource == permanent.TopCard" purely by being the top card of card's own
+            // permanent, and get treated as if it were the intended recipient.
+            if (cardSource == null || cardSource != card) return false;
 
             Permanent permanent = cardSource.PermanentOfThisCard();
             if (permanent == null) return false;
 
-            if (permanentCondition(permanent))
-            {
-                if (cardSource == permanent.TopCard)
-                {
-                    return true;
-                }
-            }
-            return false;
+            if (!permanentCondition(permanent)) return false;
+
+            // A non-inherited/non-linked copy only applies while card is still the actual
+            // active top card of its permanent. An inherited/linked copy is specifically meant
+            // to keep applying once card is buried/attached -- requiring cardSource ==
+            // permanent.TopCard here would make that impossible, since a buried/linked card is
+            // by definition never the top card.
+            return isInheritedEffect || isLinkedEffect || cardSource == permanent.TopCard;
         }
 
         List<CardSource> validSources(List<CardSource> availableSources) => availableSources.Filter(

--- a/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
@@ -85,6 +85,7 @@ public partial class CardEffectFactory
             foreach (CardSource cardSource in validSources(targetSources(sourceCard.PermanentOfThisCard().DigivolutionCards)))
             {
                 List<ICardEffect> toCopyEffects = cardSource.cEntity_EffectController.GetCardEffects_ExceptAddedEffects(_timing, sourceCard);
+
                 toCopyEffects.ForEach(eff =>
                     {
                         eff.SetOriginalEffectSourceCard(cardSource);

--- a/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
@@ -149,10 +149,24 @@ public partial class CardEffectFactory
                                 && (originalUseCondition is null || originalUseCondition(hashtable)),
                             card);
 
+                        // activateClass's own coroutine body may self-reference activateClass to
+                        // adjust its own OPT usage mid-effect (e.g. "if (!isUsed) activateClass.
+                        // RemoveUse();" -- real precedent: BT26_016 Chronomon: Holy Mode). Since
+                        // that closure still targets activateClass (the source), redirect
+                        // RemoveUse()/AddUse() to affect copiedActivateClass instead for the
+                        // duration of this one call, so the source card's own OPT tracking isn't
+                        // touched by a copy's activation.
+                        IEnumerator ActivateWithRedirectedUseTracking(Hashtable hashtable)
+                        {
+                            activateClass.SetUseTrackingRedirectTarget(copiedActivateClass);
+                            yield return ContinuousController.instance.StartCoroutine(activateClass.Activate(hashtable));
+                            activateClass.SetUseTrackingRedirectTarget(null);
+                        }
+
                         copiedActivateClass.SetUpActivateClass(
                             hashtable => ValidCardSourceAtActivate()
                                 && (originalActivateCondition is null || originalActivateCondition(hashtable)),
-                            hashtable => activateClass.Activate(hashtable),
+                            ActivateWithRedirectedUseTracking,
                             activateClass.MaxCountPerTurn,
                             activateClass.IsOptional,
                             activateClass.EffectDescription);

--- a/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/CopiedEffects.cs
@@ -155,12 +155,22 @@ public partial class CardEffectFactory
                         // that closure still targets activateClass (the source), redirect
                         // RemoveUse()/AddUse() to affect copiedActivateClass instead for the
                         // duration of this one call, so the source card's own OPT tracking isn't
-                        // touched by a copy's activation.
+                        // touched by a copy's activation. Push/pop (not set/clear) and a finally
+                        // block: activateClass may already be mid-activation for a different copy
+                        // (e.g. awaiting player input) when this one starts, and the underlying
+                        // coroutine could throw or be stopped externally -- both must not leave a
+                        // stale redirect in place for the source's own later activations.
                         IEnumerator ActivateWithRedirectedUseTracking(Hashtable hashtable)
                         {
-                            activateClass.SetUseTrackingRedirectTarget(copiedActivateClass);
-                            yield return ContinuousController.instance.StartCoroutine(activateClass.Activate(hashtable));
-                            activateClass.SetUseTrackingRedirectTarget(null);
+                            activateClass.PushUseTrackingRedirectTarget(copiedActivateClass);
+                            try
+                            {
+                                yield return ContinuousController.instance.StartCoroutine(activateClass.Activate(hashtable));
+                            }
+                            finally
+                            {
+                                activateClass.PopUseTrackingRedirectTarget();
+                            }
                         }
 
                         copiedActivateClass.SetUpActivateClass(

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Succession.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/Succession.cs
@@ -15,7 +15,7 @@ public partial class CardEffectFactory
                 isInheritedEffect,
                 isLinkedEffect,
                 canUseCondition: CanUseCondition,
-                cardSourceCondition: cardCondition,
+                cardCondition: cardCondition,
                 isSuccession: true);
     }
     #endregion

--- a/Assets/Scripts/Script/CardEffects/AddSkillClass.cs
+++ b/Assets/Scripts/Script/CardEffects/AddSkillClass.cs
@@ -24,12 +24,17 @@ public class AddSkillClass : ICardEffect, IAddSkillEffect
     }
     public List<ICardEffect> GetCardEffect(CardSource card, List<ICardEffect> getCardEffect, EffectTiming timing)
     {
+        // Callers probe this wrapper against every card being evaluated on the field (e.g. "would
+        // this granted-effect apply to card X?"), not just the card it actually applies to. Only
+        // adopt `card` as our own identity when we actually matched it -- otherwise a probe against
+        // an unrelated card (that fails _cardSourceCondition) would permanently overwrite this
+        // wrapper's real EffectSourceCard with that unrelated card, and since later probes read
+        // EffectSourceCard back to decide what to pass in next, the corruption never self-heals.
         if (_cardSourceCondition(card))
         {
             getCardEffect = _getEffects(card, getCardEffect, timing);
+            SetEffectSourceCard(card);
         }
-
-        SetEffectSourceCard(card);
 
         return getCardEffect;
     }

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -79,6 +79,32 @@ public abstract class ICardEffect
 
     #endregion
 
+    #region Redirect target for RemoveUse()/AddUse() self-calls (Succession/copied-effect support)
+
+    // A card's own ActivateCoroutine body sometimes self-references its own ActivateClass
+    // instance to adjust its own OPT usage mid-effect (e.g. "if (!isUsed) activateClass.
+    // RemoveUse();" for an ability that may end up doing nothing). When that coroutine is
+    // reused verbatim by CardEffectFactory.CopyDigivolutionCardEffects (Succession and similar)
+    // via a wrapping copiedActivateClass that just delegates to the original's Activate(), the
+    // closure still targets the ORIGINAL instance -- so RemoveUse()/AddUse() would touch the
+    // source card's own OPT tracking instead of the copy's, even though the copy's own
+    // EffectSourceCard/tracking is otherwise correctly independent. This field lets a caller
+    // (CopyDigivolutionCardEffects) temporarily redirect RemoveUse()/AddUse() calls made on
+    // this instance to affect a different ICardEffect (the copy) instead, for the duration of
+    // one Activate() call.
+    ICardEffect _useTrackingRedirectTarget = null;
+    public ICardEffect UseTrackingRedirectTarget
+    {
+        get { return _useTrackingRedirectTarget; }
+        private set { _useTrackingRedirectTarget = value; }
+    }
+    public void SetUseTrackingRedirectTarget(ICardEffect useTrackingRedirectTarget)
+    {
+        UseTrackingRedirectTarget = useTrackingRedirectTarget;
+    }
+
+    #endregion
+
     #region The source permanent of this effect
 
     private Permanent _effectSourcePermanent = null;
@@ -1254,14 +1280,18 @@ public static class ActivateICardEffectExtensionClass
     #region remove a usage of an X Per Turn
     public static void RemoveUse(this ActivateICardEffect activateICardEffect)
     {
-        ((ICardEffect)activateICardEffect).EffectSourceCard.cEntity_EffectController.RemoveUseEffectThisTurn((ICardEffect)activateICardEffect);
+        ICardEffect effect = (ICardEffect)activateICardEffect;
+        ICardEffect trackedEffect = effect.UseTrackingRedirectTarget ?? effect;
+        trackedEffect.EffectSourceCard.cEntity_EffectController.RemoveUseEffectThisTurn(trackedEffect);
     }
     #endregion
 
     #region add a usage of an X Per Turn
     public static void AddUse(this ActivateICardEffect activateICardEffect)
     {
-        ((ICardEffect)activateICardEffect).EffectSourceCard.cEntity_EffectController.RegisterUseEffectThisTurn((ICardEffect)activateICardEffect);
+        ICardEffect effect = (ICardEffect)activateICardEffect;
+        ICardEffect trackedEffect = effect.UseTrackingRedirectTarget ?? effect;
+        trackedEffect.EffectSourceCard.cEntity_EffectController.RegisterUseEffectThisTurn(trackedEffect);
     }
     #endregion
 

--- a/Assets/Scripts/Script/ICardEffect.cs
+++ b/Assets/Scripts/Script/ICardEffect.cs
@@ -88,19 +88,28 @@ public abstract class ICardEffect
     // via a wrapping copiedActivateClass that just delegates to the original's Activate(), the
     // closure still targets the ORIGINAL instance -- so RemoveUse()/AddUse() would touch the
     // source card's own OPT tracking instead of the copy's, even though the copy's own
-    // EffectSourceCard/tracking is otherwise correctly independent. This field lets a caller
+    // EffectSourceCard/tracking is otherwise correctly independent. This lets a caller
     // (CopyDigivolutionCardEffects) temporarily redirect RemoveUse()/AddUse() calls made on
     // this instance to affect a different ICardEffect (the copy) instead, for the duration of
-    // one Activate() call.
-    ICardEffect _useTrackingRedirectTarget = null;
+    // one Activate() call. A stack (not a single field) because the source ability could in
+    // principle be mid-activation for one copy (e.g. awaiting player input) when a second,
+    // unrelated activation for a different copy starts -- pushing/popping keeps each
+    // invocation's redirect correctly scoped instead of the second overwriting the first's.
+    readonly Stack<ICardEffect> _useTrackingRedirectStack = new Stack<ICardEffect>();
     public ICardEffect UseTrackingRedirectTarget
     {
-        get { return _useTrackingRedirectTarget; }
-        private set { _useTrackingRedirectTarget = value; }
+        get { return _useTrackingRedirectStack.Count > 0 ? _useTrackingRedirectStack.Peek() : null; }
     }
-    public void SetUseTrackingRedirectTarget(ICardEffect useTrackingRedirectTarget)
+    public void PushUseTrackingRedirectTarget(ICardEffect useTrackingRedirectTarget)
     {
-        UseTrackingRedirectTarget = useTrackingRedirectTarget;
+        _useTrackingRedirectStack.Push(useTrackingRedirectTarget);
+    }
+    public void PopUseTrackingRedirectTarget()
+    {
+        if (_useTrackingRedirectStack.Count > 0)
+        {
+            _useTrackingRedirectStack.Pop();
+        }
     }
 
     #endregion


### PR DESCRIPTION
## Summary
Three real bugs found while testing the [Succession] keyword (Chronomon: Destroy Mode digivolving onto Chronomon: Holy Mode, same-turn), all in shared `CopyDigivolutionCardEffects`/`AddSkillClass` infrastructure used by every Succession card (and by 9 other cards that call `CopyDigivolutionCardEffects` directly):

1. **Once-per-turn tracking was shared with the source card.** `CopyDigivolutionCardEffects` reused the source card's own `ActivateClass` object reference (only mutating its conditions/hash in place), and `ICardEffect.IsSameEffect` short-circuits on reference equality — so a `[Once Per Turn]` effect used on the source card earlier the same turn silently couldn't trigger again when copied onto a new card via Succession, even though it should be an independently-tracked copy. Fixed by building a genuinely new `ActivateClass` with its own `EffectSourceCard`/hash, delegating activation behavior to the original.
2. **`AddSkillClass.GetCardEffect` self-poisoning.** The engine's cross-permanent scan probes every `AddSkillClass` wrapper on the field against whatever card is currently being evaluated for an event — most such probes are expected to fail the wrapper's own condition. `GetCardEffect` called `SetEffectSourceCard(card)` unconditionally regardless of that result, so a single failed probe against an unrelated card permanently overwrote the wrapper's real identity (self-reinforcing, since later calls read that same field back to decide what to probe next). Fixed to only adopt the probed card's identity when the wrapper actually matched it.
3. **Succession parameter mismapping.** `SuccessionSelfEffect` passed its own `cardCondition` parameter (the printed keyword's material filter, e.g. "Lv.6 with Chronomon in name") into `CopyDigivolutionCardEffects`'s `cardSourceCondition` slot instead of its `cardCondition` slot — silently replacing the real self-check ("am I still my own permanent's top card") with the material filter, and leaving the actual buried-card filter unapplied. Fixed the parameter mapping.

## Test plan
- [ ] Use a Once-Per-Turn When-Digivolving effect on a card, then digivolve a Succession card matching its name onto it the same turn, and confirm the Succession copy can also trigger.
- [ ] Confirm Succession only copies from the correct (topmost matching) buried card, not an unrelated one.