### PR TITLE
Fix BT26-100 (Dark Field): [Main] ability could play a Digi-Egg

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_100.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_100.cs
@@ -73,7 +73,7 @@ namespace DCGO.CardEffects.BT26
                     => CardEffectCommons.CanTriggerOptionMainEffect(hashtable, card);
 
                 bool CanSelectCardCondition(CardSource cardSource)
-                    => cardSource.HasLevel && cardSource.Level <= 4
+                    => cardSource.IsDigimon && cardSource.HasLevel && cardSource.Level <= 4
                         && cardSource.EqualsTraits("Titan")
                         && cardSource.HasPlayCost
                         && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);


### PR DESCRIPTION
## Summary
- The `[Main]` ability's card-selection filter (`CanSelectCardCondition`) was missing the `cardSource.IsDigimon` check that this card's own `[Security]` ability (`CanPlayCondition`, same file) correctly has — letting a level ≤4 Titan-trait Digi-Egg slip through and get played as a new permanent via an ability meant only for Digimon cards.
- Added the missing `IsDigimon` check, matching the `[Security]` ability's condition.

## Test plan
- [ ] Confirm a Titan-trait Digi-Egg can no longer be selected as the free-play target for the `[Main]` ability.
- [ ] Confirm a legal level ≤4 Titan Digimon card can still be played as before.