### PR TITLE
Fix BT26-061 (Chiropmon) On Play never activating

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
@@ -34,10 +34,11 @@ namespace DCGO.CardEffects.BT26
                     => "[On Play] Reveal the top 3 cards of your deck. Add 1 [Glowing Dawn] trait card and 1 purple [BEATBREAK] trait card among them to the hand. Return the rest to the bottom of the deck.";
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+                    => CardEffectCommons.CanTriggerOnPlay(hashtable, card)
+                        && CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleArea(card);
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
 
                 bool GlowingDawnCondition(CardSource cardSource) => cardSource.EqualsTraits("Glowing Dawn");
 

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_061.cs
@@ -37,7 +37,7 @@ namespace DCGO.CardEffects.BT26
                     => CardEffectCommons.CanTriggerOnPlay(hashtable, card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+                    => CardEffectCommons.IsExistOnBattleArea(card);
 
                 bool GlowingDawnCondition(CardSource cardSource) => cardSource.EqualsTraits("Glowing Dawn");
 


### PR DESCRIPTION
## Summary
- Same bug as BT26-065 Falcomon: `CanUseCondition` used the plain `CanTriggerOnPlay` check, but `CanActivateCondition` used the paired `IsExistOnBattleAreaActivate`, which only returns true once the matching `...Trigger` call has populated its permanence map. Since that never happened here, `CanActivateCondition` always returned false and the On Play ability silently never activated.
- Switched `CanActivateCondition` to the plain `IsExistOnBattleArea(card)`.

## Test plan
- [ ] Play Chiropmon and confirm its On Play reveal-3 ability actually triggers.