### PR TITLE
BT 26 030 - Pumpkinmon Fix GainAscension: watched the granter's deletion, not the recipient's

### DIFF
--- a/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Ascension.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/KeyWordEffects/Ascension.cs
@@ -72,7 +72,7 @@ public partial class CardEffectCommons
             isInheritedEffect: false,
             condition: CanUseCondition,
             rootCardEffect: activateClass,
-            card);
+            targetPermanent.TopCard);
 
         AddEffectToPermanent(
             targetPermanent: targetPermanent,


### PR DESCRIPTION
## Summary
Bug report from Discord (Fox, BT26-030 Pumpkinmon, v1.7.10): "Pumpkinmon's effect only gives execute, no ascension" — granting Execute+Ascension to a selected [Iliad] Digimon, then deleting an opponent's Digimon in battle with it, never showed the "place this card in security" Ascension prompt.

Root cause: `GainAscension` passed `card` (`activateClass.EffectSourceCard`, the card granting Ascension — e.g. Pumpkinmon itself) into `AscensionEffect(...)` as the `CardSource` whose deletion should trigger the prompt. `CanTriggerAscension` delegates to `CanTriggerOnDeletion`, which only fires for that exact card's own deletion — so whenever Ascension is granted to a *different* card than the granter (which is the whole point of `GainAscension` — granting to another target, as opposed to `AscensionSelfEffect`), the prompt could only ever appear if the granter itself died, never the actual recipient.

`GainExecute` (the sibling helper, confirmed working via other cards) already does this correctly — it passes `targetPermanent.TopCard` (the recipient), not `card`, into the equivalent slot. Fixed `GainAscension` to match.

## Test plan
- [ ] Play BT26-030 Pumpkinmon, grant Execute+Ascension to an [Iliad] Digimon, delete an opponent's Digimon in battle with it, and confirm the "place this card in security" prompt now appears.