### PR TITLE
Fix 3M 'when trashed from digivolution cards' triggers firing after leaving and re-entering trash

### DIFF
--- a/Assets/Scripts/CardEffect/EX7/Black/EX7_070.cs
+++ b/Assets/Scripts/CardEffect/EX7/Black/EX7_070.cs
@@ -28,7 +28,8 @@ namespace DCGO.CardEffects.EX7
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanTriggerOnTrashSelfDigivolutionCard(hashtable, cardEffect => cardEffect != null, card);
+                    return CardEffectCommons.CanTriggerOnTrashSelfDigivolutionCard(hashtable, cardEffect => cardEffect != null, card)
+                        && CardEffectCommons.IsExistOnTrashTrigger(card, activateClass);
                 }
 
                 bool CanSelectPermanentCondition(Permanent permanent)
@@ -38,7 +39,7 @@ namespace DCGO.CardEffects.EX7
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnTrash(card)
+                    return CardEffectCommons.IsExistOnTrashActivate(card, activateClass)
                         && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/EX7/Purple/EX7_071.cs
+++ b/Assets/Scripts/CardEffect/EX7/Purple/EX7_071.cs
@@ -28,12 +28,13 @@ namespace DCGO.CardEffects.EX7
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanTriggerOnTrashSelfDigivolutionCard(hashtable, cardEffect => cardEffect != null, card);
+                    return CardEffectCommons.CanTriggerOnTrashSelfDigivolutionCard(hashtable, cardEffect => cardEffect != null, card)
+                        && CardEffectCommons.IsExistOnTrashTrigger(card, activateClass);
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnTrash(card)
+                    return CardEffectCommons.IsExistOnTrashActivate(card, activateClass)
                         && card.Owner.CanAddMemory(activateClass);
                 }
 

--- a/Assets/Scripts/CardEffect/EX7/Red/EX7_066.cs
+++ b/Assets/Scripts/CardEffect/EX7/Red/EX7_066.cs
@@ -33,12 +33,13 @@ namespace DCGO.CardEffects.EX7
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanTriggerOnTrashSelfDigivolutionCard(hashtable, cardEffect => cardEffect != null, card);
+                    return CardEffectCommons.CanTriggerOnTrashSelfDigivolutionCard(hashtable, cardEffect => cardEffect != null, card)
+                        && CardEffectCommons.IsExistOnTrashTrigger(card, activateClass);
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnTrash(card)
+                    return CardEffectCommons.IsExistOnTrashActivate(card, activateClass)
                         && CardEffectCommons.HasMatchConditionPermanent(CanSelectPermanentCondition);
                 }
 

--- a/Assets/Scripts/CardEffect/P/Red/P_180.cs
+++ b/Assets/Scripts/CardEffect/P/Red/P_180.cs
@@ -54,12 +54,13 @@ namespace DCGO.CardEffects.P
 
                 bool CanUseCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.CanTriggerOnTrashSelfDigivolutionCard(hashtable, cardEffect => cardEffect != null, card);
+                    return CardEffectCommons.CanTriggerOnTrashSelfDigivolutionCard(hashtable, cardEffect => cardEffect != null, card)
+                        && CardEffectCommons.IsExistOnTrashTrigger(card, activateClass);
                 }
 
                 bool CanActivateCondition(Hashtable hashtable)
                 {
-                    return CardEffectCommons.IsExistOnTrash(card)
+                    return CardEffectCommons.IsExistOnTrashActivate(card, activateClass)
                         && CardEffectCommons.HasMatchConditionPermanent(CanSelectOpponentsDigimon);
                 }
 


### PR DESCRIPTION
## Summary
x89rt2's original fix (45ee3dc9a, "Fix 3M leaving trash issues") paired `CanUseCondition` with `IsExistOnTrashTrigger` and `CanActivateCondition` with `IsExistOnTrashActivate` on 4 [Three Musketeers] cards' "when trashed from digivolution cards" abilities: P_180 (Bind Red Trigger), EX7_070, EX7_071 (Hurricane Screw Shot), EX7_066. Somewhere in `develop`'s later history this regressed back to the plain, unpaired `IsExistOnTrash(card)` check on all 4 (confirmed by diffing the current tip against that commit).

Root cause of what this pairing actually fixes, confirmed via a real bug report and Player.log trace: these "when trashed" triggers queue asynchronously and only get re-validated right before they actually resolve. If, in between, the same card leaves the trash (e.g. played back out via an effect like BT25_083's "trash 1 option from digivolution cards, then use a [Three Musketeers] option from trash at -3 cost") and then legitimately re-enters the trash on its own later (e.g. an Option card with no valid target for its own placement effect simply returning to trash after resolving), the plain `IsExistOnTrash(card)` check can't tell "still the same trashing this trigger reacted to" apart from "coincidentally back in trash from an unrelated, later event" — so the stale trigger fires again on the second, unrelated re-entry. The paired `...Trigger`/`...Activate` check is specifically for this: it validates the card is still in the *same zone instance* as when the trigger fired, not just currently-in-that-zone.

Restored the pairing on all 4 affected cards.

## Test plan
- [ ] Trash a Bind Red Trigger / Hurricane Screw Shot / etc. from digivolution material with a legal target, confirm the "when trashed" effect still fires normally.
- [ ] Reproduce the BT25_083-style sequence (trash the card, then immediately play it back from trash at reduced cost with no valid placement target so it returns to trash) and confirm the "when trashed" effect does *not* fire a second time.