### PR TITLE
Blast DNA obeys DNA requirements

### DIFF
--- a/Assets/Scripts/Script/CardEffectCommons/DNADigivolveEffects.cs
+++ b/Assets/Scripts/Script/CardEffectCommons/DNADigivolveEffects.cs
@@ -156,21 +156,23 @@ public partial class CardEffectCommons
     /// <param name="permanentCondition">Condition to filter which permaments may be used for this effect</param>
     /// <param name="cardCondition">Condition to filter which cards may be used for this effect</param>
     /// <returns></returns>
-    private static bool PermanentFulfillsRequirement(Player owner, Permanent permanent, CardSource jogressTarget, Permanent firstCondition, bool isWithHandCard, Func<Permanent, bool> permanentCondition = null, Func<CardSource, bool> cardCondition = null)
+    private static bool PermanentFulfillsRequirement(Player owner, Permanent permanent, CardSource jogressTarget, Permanent firstCondition, bool isWithHandCard, Func<Permanent, bool> permanentCondition = null, Func<CardSource, bool> cardCondition = null, bool isBlast = false)
     {
-        if (jogressTarget.jogressCondition.Count <= 0 || jogressTarget.CanNotEvolve(permanent))
-            return false;
-        if(permanentCondition == null || permanentCondition(permanent))
+        var fulfilled = !(jogressTarget.jogressCondition.Count <= 0 || jogressTarget.CanNotEvolve(permanent));
+        if (fulfilled is not true) return false;
+        else fulfilled = false;
+        if (permanentCondition == null || permanentCondition(permanent))
         {
             if (firstCondition == null)
             {
+                if (isBlast) return false;
                 foreach (JogressCondition DNACondition in jogressTarget.jogressCondition)
                 {
                     if (DNACondition.elements[0].EvoRootCondition(permanent))
                     {
                         List<CardSource> sources = isWithHandCard ? owner.HandCards : owner.TrashCards;
 
-                        foreach(CardSource cardSource in sources.Filter(cardSource => cardCondition == null || cardCondition(cardSource)))
+                        foreach (CardSource cardSource in sources.Filter(cardSource => cardCondition == null || cardCondition(cardSource)))
                         {
                             Permanent tempPermanent = PlayTempPermanent(cardSource);
                             if (tempPermanent == null)
@@ -178,7 +180,7 @@ public partial class CardEffectCommons
                             bool isValid = DNACondition.elements[1].EvoRootCondition(tempPermanent);
                             owner.FieldPermanents[tempPermanent.PermanentFrame.FrameID] = null;
 
-                            if(isValid)
+                            if (isValid)
                                 return true;
 
                         }
@@ -193,15 +195,47 @@ public partial class CardEffectCommons
                 }
                 foreach (JogressCondition DNACondition in jogressTarget.jogressCondition)
                 {
-                    if (DNACondition.elements[0].EvoRootCondition(firstCondition) && DNACondition.elements[1].EvoRootCondition(permanent))
+                    var ownerHand = owner.HandCards;
+                    bool testedCardOnHand = ownerHand.Contains(permanent.TopCard),
+                    firstOnHand = ownerHand.Contains(firstCondition.TopCard);
+                    Permanent truePermanentTest = permanent,
+                    trueFirstCondition = firstCondition;
+                    if (isBlast)
                     {
-                        return true;
+                        if (firstOnHand && testedCardOnHand) return false;
+                        if (testedCardOnHand)
+                        {
+                            truePermanentTest = PlayTempPermanent(permanent.TopCard);
+                            if (truePermanentTest == null)
+                                continue;
+                        }
+                        else if (firstOnHand)
+                        {
+                            trueFirstCondition = PlayTempPermanent(firstCondition.TopCard);
+                            if (trueFirstCondition == null)
+                                continue;
+                        }
                     }
+                    fulfilled = DNACondition.elements[0].EvoRootCondition(trueFirstCondition) &&
+                        DNACondition.elements[1].EvoRootCondition(truePermanentTest);
+                    {
+                        if (testedCardOnHand)
+                            owner.FieldPermanents[truePermanentTest.PermanentFrame.FrameID] = null;
+                        else if (firstOnHand)
+                            owner.FieldPermanents[trueFirstCondition.PermanentFrame.FrameID] = null;
+                    }
+                    if (fulfilled) break;
+
                 }
             }
         }
 
-        return false;
+        return fulfilled;
+    }
+
+    public static bool BlastDNAFulfillsRequirement(Player owner, Permanent permanent, CardSource jogressTarget, Permanent firstCondition, bool isWithHandCard, Func<Permanent, bool> permanentCondition = null, Func<CardSource, bool> cardCondition = null)
+    {
+        return PermanentFulfillsRequirement(owner, permanent, jogressTarget, firstCondition, isWithHandCard, permanentCondition, cardCondition, true);
     }
 
     private static IEnumerator SelectPermanent(Player owner, CardSource jogressTarget, Permanent firstCondition, bool isOptional, ICardEffect activateClass, bool isWithHand, Func<Permanent, IEnumerator> SelectPermanentCoroutine, Func<Permanent, bool> permanentCondition = null, Func<CardSource, bool> digivolutionCardCondition = null)

--- a/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/BlastDNADigivolution.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/KeyWordEffects/BlastDNADigivolution.cs
@@ -2,8 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System;
 using System.Linq;
-using UnityEngine;
-using Photon.Pun;
 
 public class BlastDNACondition
 {
@@ -32,40 +30,118 @@ public partial class CardEffectFactory
         List<Permanent> fieldPermanents = new List<Permanent>();
         List<Permanent> permanentSources = new List<Permanent>();
         List<CardSource> handSources = new List<CardSource>();
+        Player owner = card.Owner;
 
         void FilterDNAPermanents()
         {
-            if (blastDNAConditions[0].Permanents.Count >= 1 && blastDNAConditions[0].CardSources.Count == 0)
-                blastDNAConditions[1].Permanents.Clear();
+            foreach (var condition in blastDNAConditions)
+            {
+                if (condition.Permanents.Count > 0)
+                {
+                    bool hasMatchingPartner = blastDNAConditions
+                        .Where(partner => partner != condition)
+                        .Any(partner => partner.CardSources.Count > 0);
 
-            if (blastDNAConditions[1].Permanents.Count >= 1 && blastDNAConditions[1].CardSources.Count == 0)
-                blastDNAConditions[0].Permanents.Clear();
+                    if (!hasMatchingPartner)
+                    {
+                        condition.Permanents.Clear();
+                    }
+                }
+            }
         }
 
         void FilterDNAHandSources()
         {
-            if (blastDNAConditions[0].CardSources.Count >= 1 && blastDNAConditions[0].CardSources.Count == 0)
-                blastDNAConditions[1].CardSources.Clear();
+            foreach (var condition in blastDNAConditions)
+            {
+                if (condition.CardSources.Count > 0)
+                {
+                    bool hasMatchingPartner = blastDNAConditions
+                        .Where(partner => partner != condition)
+                        .Any(partner => partner.Permanents.Count > 0);
 
-            if (blastDNAConditions[1].CardSources.Count >= 1 && blastDNAConditions[1].CardSources.Count == 0)
-                blastDNAConditions[0].CardSources.Clear();
+                    if (!hasMatchingPartner)
+                    {
+                        foreach (var partner in blastDNAConditions.Where(partner => partner != condition))
+                        {
+                            partner.CardSources.Clear();
+                        }
+                    }
+                }
+            }
+        }
+
+        void KeepValidDNAPairs()
+        {
+            FilterDNAPermanents();
+            FilterDNAHandSources();
+
+            if (permanentSources != null && handSources != null)
+            {
+                permanentSources = permanentSources.Filter(p =>
+                    p != null &&
+                    p.TopCard != null &&
+                    handSources.Any(handSource =>
+                        handSource != null &&
+                        p.TopCard.name != handSource.name &&
+                        (
+                            CardEffectCommons.BlastDNAFulfillsRequirement(owner, new Permanent(new List<CardSource> { handSource }), card, p, true) ||
+                            CardEffectCommons.BlastDNAFulfillsRequirement(owner, p, card, new Permanent(new List<CardSource> { handSource }), true)
+                        )
+                    )
+                );
+
+                handSources = handSources.Filter(handSource =>
+                    handSource != null &&
+                    permanentSources.Any(p =>
+                        p != null &&
+                        p.TopCard != null &&
+                        p.TopCard.name != handSource.name &&
+                        (
+                            CardEffectCommons.BlastDNAFulfillsRequirement(owner, new Permanent(new List<CardSource> { handSource }), card, p, true) ||
+                            CardEffectCommons.BlastDNAFulfillsRequirement(owner, p, card, new Permanent(new List<CardSource> { handSource }), true)
+                        )
+                    )
+                );
+            }
         }
 
         bool HasValidDNATargets()
         {
-            fieldPermanents = card.Owner.GetBattleAreaDigimons();
+            fieldPermanents = owner.GetBattleAreaDigimons();
 
-            foreach (BlastDNACondition DNACondition in blastDNAConditions)
+            var namesOnField = blastDNAConditions
+                .Where(c => fieldPermanents.Any(p => p.TopCard.EqualsCardName(c.Name)))
+                .Select(c => c.Name)
+                .ToList();
+
+            var namesInHand = blastDNAConditions
+                .Where(c => owner.HandCards.Any(h => h.EqualsCardName(c.Name)))
+                .Select(c => c.Name)
+                .ToList();
+
+            foreach (var condition in blastDNAConditions)
             {
-                DNACondition.Permanents = fieldPermanents.Filter(permanent => permanent.TopCard.EqualsCardName(DNACondition.Name));
-                DNACondition.CardSources = card.Owner.HandCards.Filter(cardSource => cardSource.EqualsCardName(DNACondition.Name));
+                bool isValidForField = namesOnField.Contains(condition.Name) &&
+                                    namesInHand.Any(handName => handName != condition.Name);
 
-                permanentSources.AddRange(DNACondition.Permanents);
-                handSources.AddRange(DNACondition.CardSources);
+                bool isValidForHand = namesInHand.Contains(condition.Name) &&
+                                    namesOnField.Any(fieldName => fieldName != condition.Name);
+
+                if (isValidForField)
+                {
+                    condition.Permanents = fieldPermanents.Filter(p => p.TopCard.EqualsCardName(condition.Name));
+                    permanentSources.AddRange(condition.Permanents);
+                }
+
+                if (isValidForHand)
+                {
+                    condition.CardSources = owner.HandCards.Filter(c => c.EqualsCardName(condition.Name));
+                    handSources.AddRange(condition.CardSources);
+                }
             }
 
-            FilterDNAPermanents();
-            FilterDNAHandSources();
+            KeepValidDNAPairs();
 
             if (blastDNAConditions[0].Permanents.Count(permanent => !permanent.TopCard.CanNotEvolve(permanent)) > 0 && blastDNAConditions[1].CardSources.Count > 0)
                 return true;
@@ -78,12 +154,12 @@ public partial class CardEffectFactory
 
         ActivateClass activateClass = new ActivateClass();
         activateClass.SetUpICardEffect("Blast DNA Digivolve", CanUseCondition, card);
-        activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, DataBase.BlastDNADigivolveEffectDiscription());
+        activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, DataBase.BlastDNADigivolveEffectDescription());
         activateClass.SetIsCounterEffect(true);
 
         bool CanSelectPermanent(Permanent permanent)
         {
-            if(CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
+            if (CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card))
             {
                 foreach (BlastDNACondition DNACondition in blastDNAConditions)
                 {
@@ -142,7 +218,7 @@ public partial class CardEffectFactory
             SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
 
             selectPermanentEffect.SetUp(
-                selectPlayer: card.Owner,
+                selectPlayer: owner,
                 canTargetCondition: CanSelectPermanent,
                 canTargetCondition_ByPreSelecetedList: null,
                 canEndSelectCondition: null,
@@ -162,9 +238,13 @@ public partial class CardEffectFactory
             {
                 selectedPermanent = permanent;
 
-                foreach(string name in selectedPermanent.TopCard.CardNames)
+                foreach (string name in selectedPermanent.TopCard.CardNames)
                 {
-                    handSources = handSources.Filter(source => !source.ContainsCardName(name));
+                    handSources = handSources.Filter(handSource => !handSource.ContainsCardName(name) &&
+                    (
+                        CardEffectCommons.BlastDNAFulfillsRequirement(owner, new Permanent(new List<CardSource> { handSource }), card, selectedPermanent, true) ||
+                        CardEffectCommons.BlastDNAFulfillsRequirement(owner, selectedPermanent, card, new Permanent(new List<CardSource> { handSource }), true)
+                    ));
                 }
 
                 maxCount = Math.Min(1, handSources.Count);
@@ -172,7 +252,7 @@ public partial class CardEffectFactory
                 SelectHandEffect selectHandEffect = GManager.instance.GetComponent<SelectHandEffect>();
 
                 selectHandEffect.SetUp(
-                    selectPlayer: card.Owner,
+                    selectPlayer: owner,
                     canTargetCondition: CanSelectHandSource,
                     canTargetCondition_ByPreSelecetedList: null,
                     canEndSelectCondition: null,
@@ -188,6 +268,7 @@ public partial class CardEffectFactory
                 selectHandEffect.SetUpCustomMessage("Select 1 Digimon to DNA digivolve.", "The opponent is selecting 1 Digimon to DNA digivolve.");
 
                 yield return ContinuousController.instance.StartCoroutine(selectHandEffect.Activate());
+
             }
 
             IEnumerator SelectCardCoroutine(CardSource cardSource)
@@ -204,7 +285,7 @@ public partial class CardEffectFactory
                     frameID = preferredFrame.FrameID;
                 }
 
-                if (0 <= frameID && frameID < card.Owner.fieldCardFrames.Count)
+                if (0 <= frameID && frameID < owner.fieldCardFrames.Count)
                 {
                     playedPermanent = new Permanent(new List<CardSource>() { selectedCardSource }) { IsSuspended = false };
 
@@ -212,8 +293,12 @@ public partial class CardEffectFactory
                 }
 
                 int[] JogressEvoRootsFrameIDs = { 0, 0 };
-
-                if (selectedPermanent.TopCard.EqualsCardName(blastDNAConditions[0].Name))
+                if (CardEffectCommons.BlastDNAFulfillsRequirement(owner, selectedPermanent, card, new Permanent(new List<CardSource> { selectedCardSource }), true) ||
+                CardEffectCommons.BlastDNAFulfillsRequirement(owner, new Permanent(new List<CardSource> { selectedCardSource }), card, selectedPermanent, true))
+                {
+                    // TO-DO: Select cards effect routine to sort how they will be placed under commutative conditions
+                }
+                else if (CardEffectCommons.BlastDNAFulfillsRequirement(owner, new Permanent(new List<CardSource> { selectedCardSource }), card, selectedPermanent, true))
                 {
                     JogressEvoRootsFrameIDs[0] = selectedPermanent.PermanentFrame.FrameID;
                     JogressEvoRootsFrameIDs[1] = selectedCardSource.PermanentOfThisCard().PermanentFrame.FrameID;
@@ -249,7 +334,7 @@ public partial class CardEffectFactory
                 {
                     yield return ContinuousController.instance.StartCoroutine(CardObjectController.AddHandCard(selectedCardSource, false));
                 }
-                
+
             }
         }
 

--- a/Assets/Scripts/Script/DataBase.cs
+++ b/Assets/Scripts/Script/DataBase.cs
@@ -497,7 +497,7 @@ public class DataBase : MonoBehaviour
         return "[Hand] [Counter] <Blast Digivolve> (Your Digimon may digivolve into this card without paying the cost.)";
     }
 
-    public static string BlastDNADigivolveEffectDiscription()
+    public static string BlastDNADigivolveEffectDescription()
     {
         return "[Hand] [Counter] <Blast DNA Digivolve> (One of your specified Digimon and 1 of the specified card in the hand may DNA Digivolve into this card.)";
     }


### PR DESCRIPTION
- Refactor PermanentFulfillsRequirement and introduce BlastDNAFulfillsRequirement to reject invalid evaluations where both component cards originate from hand.
- Update HasValidDNATargets and add KeepValidDNAPairs in BlastDNADigivolution.cs to ensure selected field permanents and hand cards form valid DNA pairs.
- Check both commutative orderings during target selection filtering.
- Fix typo in BlastDNADigivolveEffectDescription in DataBase.cs

---

Continuation of #1701