### PR TITLE
EX1-043-bug

### DIFF
--- a/Assets/Scripts/Script/CardController.cs
+++ b/Assets/Scripts/Script/CardController.cs
@@ -4731,11 +4731,16 @@ public class IBattle
                 List<Permanent> _WinnerPermanents = new List<Permanent>();
                 List<Permanent> _LoserPermanents = new List<Permanent>();
 
+                // Permanent's constructor rebuilds cardSources via AddCardSource, which inserts
+                // each source at index 0 - replaying an already top-first ordered list through it
+                // reverses the stack, so TopCard ends up wrong. Reverse here first to cancel that out.
                 foreach (Permanent permanent in WinnerPermanents)
                 {
                     if (permanent.TopCard != null)
                     {
-                        _WinnerPermanents.Add(new Permanent(permanent.cardSources));
+                        List<CardSource> reversedCardSources = permanent.cardSources.Clone();
+                        reversedCardSources.Reverse();
+                        _WinnerPermanents.Add(new Permanent(reversedCardSources));
                     }
                 }
 
@@ -4743,7 +4748,9 @@ public class IBattle
                 {
                     if (permanent.TopCard != null)
                     {
-                        _LoserPermanents.Add(new Permanent(permanent.cardSources));
+                        List<CardSource> reversedCardSources = permanent.cardSources.Clone();
+                        reversedCardSources.Reverse();
+                        _LoserPermanents.Add(new Permanent(reversedCardSources));
                     }
                 }
 


### PR DESCRIPTION
Summary of the EX1_043 fix: the real bug was an order-reversal error in Permanent's constructor, used by IBattle.Battle() when cloning the winning/losing Digimon for the battle hashtable — this caused TopCard to report the wrong digivolution stage (the oldest one instead of the current one) whenever an evolved Digimon took part in a battle. I fixed it by reversing the order before cloning, only inside IBattle.Battle() (without touching the shared Permanent class, as you asked). You already confirmed it works, and I left EX1_043.cs's code clean, without the debug logs.

It's was code using claude, not trying to hit other functions or mechanic, this maybe resolve another effects that chekcs on trait of the top card digimon.