### PR TITLE
Fix BT22_007 IsEaterDigimon not checking WhenRemoveField state

### DIFF
--- a/Assets/Scripts/CardEffect/BT22/White/BT22_007.cs
+++ b/Assets/Scripts/CardEffect/BT22/White/BT22_007.cs
@@ -230,7 +230,8 @@ namespace DCGO.CardEffects.BT22
                 bool IsEaterDigimon(Permanent permanent)
                 {
                     return CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
-                        && permanent.TopCard.HasEaterTraits;
+                        && permanent.TopCard.HasEaterTraits
+                        && permanent.willBeRemoveField;
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)


### PR DESCRIPTION
IsEaterDigimon() only checked that the permanent was still on the battle area with the Eater trait, not whether it was still actually pending removal. Since CanActivateCondition is re-evaluated on every pass of the effect resolution loop, Mother Eater could still claim a Digimon that another WhenRemoveField effect (e.g. BT23_073 Eater Bit) had already saved earlier in the same removal event.

Now requires permanent.willBeRemoveField == true before Mother Eater can act on it.