### PR TITLE
Permanent play cost change should not affect digivolution

### DIFF
--- a/Assets/Scripts/Script/CardEffectFactory/ChangePlayCost.cs
+++ b/Assets/Scripts/Script/CardEffectFactory/ChangePlayCost.cs
@@ -40,7 +40,7 @@ public partial class CardEffectFactory
         changeCostClass.SetUpICardEffect(effectName(), CanUseCondition, card);
         changeCostClass.SetUpChangeCostClass(
             changeCostFunc: ChangeCost,
-            cardSourceCondition: (card) => true,
+            cardSourceCondition: CardCondition,
             rootCondition: (card) => true,
             isUpDown: isUpDown,
             isCheckAvailability: () => false,
@@ -92,6 +92,12 @@ public partial class CardEffectFactory
             }
 
             return false;
+        }
+
+        bool CardCondition(CardSource cardSource)
+        {
+            return CardEffectCommons.IsExistOnBattleArea(cardSource)
+                && cardSource.PermanentOfThisCard().TopCard == cardSource;
         }
 
         bool PermanentCondition(Permanent targetPermanent)


### PR DESCRIPTION
We can try post BT26, but fairly confident the reason these effects were hitting digivolution is because we weren't using the cardCondition to limit the reduction only to cards that were the top cards of the stack, and so the cost reduction validly applied to the card in hand when digivolving