### PR TITLE
Fix stale "Effect Waiting" tag and add "Trashed Card" indicator on 3M option select prompts

### DIFF
--- a/Assets/Scripts/CardEffect/BT25/Purple/BT25_083.cs
+++ b/Assets/Scripts/CardEffect/BT25/Purple/BT25_083.cs
@@ -295,6 +295,7 @@ namespace DCGO.CardEffects.BT25
 
                                 selectCardEffect1.SetUpCustomMessage("Select 1 [Three Musketeers] option to use.", "The opponent is selecting 1 [Three Musketeers] option to use.");
                                 selectCardEffect1.SetUpCustomMessage_ShowCard("Selected Card");
+                                selectCardEffect1.SetHighlightCard(selectedCard, "Trashed Card");
 
                                 yield return ContinuousController.instance.StartCoroutine(selectCardEffect1.Activate());
 

--- a/Assets/Scripts/CardEffect/EX7/Red/EX7_008.cs
+++ b/Assets/Scripts/CardEffect/EX7/Red/EX7_008.cs
@@ -82,7 +82,7 @@ namespace DCGO.CardEffects.EX7
                         {
                         new SimplifiedSelectCardConditionClass(
                             canTargetCondition:CanSelectCardCondition,
-                            message: "Select 1 Digimon card with [Three Musketeers] in its Text.",
+                            message: "Select 1 card with [Three Musketeers] in its Text.",
                             mode: SelectCardEffect.Mode.AddHand,
                             maxCount: 1,
                             selectCardCoroutine: null),

--- a/Assets/Scripts/Script/SelectCardEffect.cs
+++ b/Assets/Scripts/Script/SelectCardEffect.cs
@@ -58,8 +58,18 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
         _allowFaceDown = false;
 
         _skillInfos = new List<SkillInfo>();
+        _highlightCards = new Dictionary<CardSource, string>();
 
         _afterSelectIndexCoroutine = null;
+    }
+
+    // Tags a specific candidate card instance with a custom label (e.g. "Trashed Card") independent of the
+    // reactive-effect-waiting detection below - useful when a card's own coroutine already knows exactly which
+    // instance it just moved (e.g. trashed) and wants to distinguish it from other copies of the same card.
+    public void SetHighlightCard(CardSource card, string label)
+    {
+        if (card == null) return;
+        _highlightCards[card] = label;
     }
 
     public void SetIsLocal()
@@ -217,6 +227,7 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
     List<SkillInfo> _skillInfos = new List<SkillInfo>();
     List<int> _slectedInexesInList = new List<int>();
     Func<List<int>, IEnumerator> _afterSelectIndexCoroutine = null;
+    Dictionary<CardSource, string> _highlightCards = new Dictionary<CardSource, string>();
 
     public void SetUpAfterSelectIndexCoroutine(Func<List<int>, IEnumerator> AfterSelectIndexCoroutine)
     {
@@ -491,7 +502,14 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
                                             }
                                             else
                                             {
-                                                if (GManager.instance.autoProcessing.executingMultipleSkills != null)
+                                                bool isCandidateActiveOnField(CardSource candidate)
+                                                {
+                                                    Permanent permanent = candidate.PermanentOfThisCard();
+                                                    return permanent != null && permanent.TopCard == candidate;
+                                                }
+
+                                                if (GManager.instance.autoProcessing.executingMultipleSkills != null
+                                                    && (CardEffectCommons.IsExistOnTrash(RootCards[i]) || isCandidateActiveOnField(RootCards[i])))
                                                 {
                                                     bool isEffectWaiting(SkillInfo skillInfo)
                                                     {
@@ -526,6 +544,29 @@ public class SelectCardEffect : MonoBehaviourPunCallbacks
 
                                     _skillInfos = skillInfoArray.ToList();
                                 }
+                            }
+                        }
+                    }
+
+                    #endregion
+
+                    #region Caller-specified card highlight (e.g. "Trashed Card")
+
+                    if (_highlightCards != null && _highlightCards.Count > 0)
+                    {
+                        if (_skillInfos.Count != RootCards.Count)
+                        {
+                            _skillInfos = new List<SkillInfo>(new SkillInfo[RootCards.Count]);
+                        }
+
+                        for (int i = 0; i < RootCards.Count; i++)
+                        {
+                            if (_highlightCards.TryGetValue(RootCards[i], out string highlightLabel))
+                            {
+                                ICardEffect highlightCardEffect = new ChangeBaseDPClass();
+                                highlightCardEffect.SetUpICardEffect(highlightLabel, null, RootCards[i]);
+
+                                _skillInfos[i] = new SkillInfo(highlightCardEffect, null, EffectTiming.None);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- `SelectCardEffect`'s "Effect Waiting" detection used `IsExistOnField(candidate)` as part of its gate, but that check only verifies `PermanentOfThisCard() != null` — which is also true for a card buried as digivolution/link material under a *different* permanent (`Permanent.cardSources` includes the whole stack, not just the active top card). A card that had already left trash (e.g. re-buried elsewhere by a later effect) kept showing a stale "Effect Waiting" tag from an unrelated, already-resolved queued trigger. Narrowed the check to `permanent.TopCard == candidate`, so the tag only applies while a candidate is genuinely still in trash or is itself an active field permanent. This is shared engine code, so it applies to every "when trashed"-style reactive ability, not just the [Three Musketeers] cards used to find it.
- Added a generic `SetHighlightCard(card, label)` method on `SelectCardEffect` so a card's own coroutine can tag a specific `CardSource` instance it already knows about, independent of the reactive-skill-queue detection above. Used on BT25_083 (LadyDevimon)'s "trash 1 Option card, use 1 [Three Musketeers] Option from trash for -3" ability to mark the just-trashed card as "Trashed Card" in the follow-up trash-selection prompt, so the player can tell it apart from other copies of the same card sitting in trash.
- Fixed EX7_008's reveal-effect prompt text ("Select 1 Digimon card with [Three Musketeers] in its Text") which didn't match its own selection condition (`cardSource.HasText("Three Musketeers")`, no Digimon-type restriction) or its printed effect text ("Add 1 card with [Three Musketeers] in its text") — removed the misleading "Digimon" qualifier.

## Test plan
- [ ] Digivolve into LadyDevimon (BT25_083), use her "trash 1 Option, use 1 [Three Musketeers] Option from trash for -3" ability on a card that gets returned to trash (e.g. Hurricane Screw Shot with no valid placement target) — confirm the trashed card shows "Trashed Card" in the reduced-cost selection prompt.
- [ ] Place that same card as a digivolution card under a different Digimon via LadyDevimon's other ability, then use her second ability again — confirm the "1 option digivolution card to trash" selection no longer shows a stale "Effect Waiting" tag on it.
- [ ] Play EX7_008 and confirm the reveal-selection prompt no longer says "Digimon card".

🤖 Generated with [Claude Code](https://claude.com/claude-code)