### PR TITLE
Fix BT26-081 Mervamon: Iliad Digimon not gaining Blocker/Reboot/+2000 DP

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_081.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_081.cs
@@ -256,59 +256,24 @@ namespace DCGO.CardEffects.BT26
             #endregion
 
             #region All Turns - Grant to Iliad Digimon
-            if (timing == EffectTiming.None)
-            {
-                AddSkillClass addSkillClass = new AddSkillClass();
-                addSkillClass.SetUpICardEffect("All of your [Iliad] trait Digimon gain <Alliance>, <Reboot>, <Blocker> and +2K DP", CanUseCondition, card);
-                addSkillClass.SetUpAddSkillClass(cardSourceCondition: CardSourceCondition, getEffects: GetEffects);
-                cardEffects.Add(addSkillClass);
-
-                bool CanUseCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleArea(card);
-
-                bool CardSourceCondition(CardSource cardSource)
-                    => IsOwnIliadDigimon(cardSource.PermanentOfThisCard())
-                        && cardSource == cardSource.PermanentOfThisCard().TopCard;
-
-                bool IsOwnIliadDigimon(Permanent permanent)
+            bool IsOwnIliadDigimon(Permanent permanent)
                 => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
                     && permanent.TopCard.EqualsTraits("Iliad");
 
-                List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
-                {
-                    bool Condition() => CardSourceCondition(cardSource);
+            bool CanGrantIliadKeywords() => CardEffectCommons.IsExistOnBattleArea(card);
 
-                    #region Alliance
-                    if (_timing == EffectTiming.OnAllyAttack)
-                    {
-                        cardEffects.Add(CardEffectFactory.AllianceStaticEffect(IsOwnIliadDigimon, false, card, Condition));
-                    }
-                    #endregion
-
-                    #region Reboot
-                    if (_timing == EffectTiming.None)
-                    {
-                        cardEffects.Add(CardEffectFactory.RebootStaticEffect(IsOwnIliadDigimon, false, card, Condition));
-                    }
-                    #endregion
-
-                    #region Blocker
-                    if (_timing == EffectTiming.None)
-                    {
-                        cardEffects.Add(CardEffectFactory.BlockerStaticEffect(IsOwnIliadDigimon, false, card, Condition));
-                    }
-                    #endregion
-
-                    #region DP +2000
-                    if (_timing == EffectTiming.None)
-                    {
-                        cardEffects.Add(CardEffectFactory.ChangeDPStaticEffect(IsOwnIliadDigimon, 2000, false, card, Condition, effectName: () => "All of your [Iliad] trait Digimon get +2000 DP."));
-                    }
-                    #endregion
-
-                    return cardEffects;
-                }
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.RebootStaticEffect(IsOwnIliadDigimon, false, card, CanGrantIliadKeywords));
+                cardEffects.Add(CardEffectFactory.BlockerStaticEffect(IsOwnIliadDigimon, false, card, CanGrantIliadKeywords));
+                cardEffects.Add(CardEffectFactory.ChangeDPStaticEffect(IsOwnIliadDigimon, 2000, false, card, CanGrantIliadKeywords, effectName: () => "All of your [Iliad] trait Digimon get +2000 DP."));
             }
-            #endregion          
+
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                cardEffects.Add(CardEffectFactory.AllianceStaticEffect(IsOwnIliadDigimon, false, card, CanGrantIliadKeywords));
+            }
+            #endregion
 
             #region Assembly
             if (timing == EffectTiming.None)


### PR DESCRIPTION
## Summary
Reported bug: "Causing all iliad trait digi to have 2000dp / Always try to play digimon from trash + Can't select any digimon - reworked entire OP/WD" — after the OP/WD rework, live testing showed the +2000 DP, Blocker, and Reboot grants to [Iliad] trait Digimon simply didn't apply at all (Alliance not yet tested).

Root cause: Reboot, Blocker, and the +2000 DP grant were all registered under `EffectTiming.None` inside an `AddSkillClass`'s dynamically-generated `getEffects` callback. `CEntity_EffectController.GetCardEffects` only runs its cross-permanent `AddSkillClass` expansion when `timing != EffectTiming.None` — so these three effects never actually reached any Iliad Digimon on the field, including Mervamon herself.

`BlockerStaticEffect`, `RebootStaticEffect`, and `ChangeDPStaticEffect` already accept a `permanentCondition` that can match any number of permanents, so none of the four grants (Alliance, Reboot, Blocker, DP+2000) actually need `AddSkillClass` — registered each directly on Mervamon's own card entry instead, matching the working pattern already used for this exact "all of your [X] Digimon get [keyword]" shape elsewhere (BT24_102 Homeros's +1000 DP, BT24_094 Central Town's Alliance). Alliance was already registered under `EffectTiming.OnAllyAttack` (unaffected by the `None`-only gap) and keeps the same shape, just moved out of the `AddSkillClass` wrapper for consistency.

## Test plan
- [x] Play/have an [Iliad] trait Digimon on the field with Mervamon in play — confirmed it now gains +2000 DP, Blocker, and Reboot.
- [ ] Attack with an [Iliad] trait Digimon while another matching Digimon is also on the field — confirm Alliance triggers correctly (not yet tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)