### PR TITLE
Fix BT26-045 GranKuwagamon: Alliance/Pierce never granted (closure variable bug from #1954)

### DIFF
--- a/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
+++ b/Assets/Scripts/CardEffect/BT26/Green/BT26_045.cs
@@ -111,16 +111,16 @@ namespace DCGO.CardEffects.BT26
 
                 List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
                 {
-                    if (timing == EffectTiming.OnAllyAttack)
+                    if (_timing == EffectTiming.OnAllyAttack)
                     {
                         cardEffects.Add(CardEffectFactory.AllianceSelfEffect(false, cardSource, GrantCondition));
                     }
 
-                    if (timing == EffectTiming.OnDetermineDoSecurityCheck)
+                    if (_timing == EffectTiming.OnDetermineDoSecurityCheck)
                     {
                         cardEffects.Add(CardEffectFactory.PierceSelfEffect(isInheritedEffect: false, condition: GrantCondition, card: cardSource));
                     }
-                    
+
                     if (_timing == EffectTiming.OnEndTurn)
                     {
                         cardEffects.Add(CardEffectFactory.VortexSelfEffect(isInheritedEffect: false, card: cardSource, condition: GrantCondition));


### PR DESCRIPTION
## Summary
Reported bug (Discord): "Given effects don't all fully work and don't show up in right click menu" — live testing confirmed Alliance and Pierce were never granted to any [Insectoid]/[Titan] Digimon (including GranKuwagamon herself), while Vortex worked correctly.

Root cause: PR #1954 moved Alliance and Pierce from direct registration into an `AddSkillClass`'s `GetEffects` callback, but gated them on the outer method's `timing` parameter instead of the callback's own `_timing` parameter:

```csharp
List<ICardEffect> GetEffects(CardSource cardSource, List<ICardEffect> cardEffects, EffectTiming _timing)
{
    if (timing == EffectTiming.OnAllyAttack)   // bug: `timing`, not `_timing`
    { ... }
    if (timing == EffectTiming.OnDetermineDoSecurityCheck)   // same bug
    { ... }
    if (_timing == EffectTiming.OnEndTurn)   // correct - already used `_timing`
    { ... }
}
```

`timing` is captured by closure from the enclosing `if (timing == EffectTiming.None) { ... }` block, so it's always `EffectTiming.None` inside `GetEffects` — the two conditions were unconditionally false, and neither keyword was ever granted. Only Vortex (already using `_timing`) worked.

Fixed both conditions to check `_timing`, matching the Vortex grant in the same function.

This also likely explains the reported "Piercing picture shows as GranKuwaga instead of the piercing digimon" symptom — `PierceSelfEffect(card: cardSource)` was already correctly set up (by #1954) to source its icon from the Digimon actually gaining Pierce; the timing bug was just preventing it from ever running at all.

## Test plan
- [x] Attack with an [Insectoid]/[Titan] Digimon while GranKuwagamon is in play — confirmed Alliance now triggers.
- [x] Confirm Pierce is granted during security checks and shows the correct Digimon's icon (not GranKuwagamon's).
- [ ] Two remaining items from the original report need further live-testing to confirm whether they're separate issues: a card left in hand/trash still showing the granted effect, and a specific interaction involving a BT1 Babydomon in the digivolution stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)