### PR TITLE
Fix Tsunomon (BT24-007) and BT26-059: pass root: Trash to legality check

### DIFF
--- a/Assets/Scripts/CardEffect/BT24/Purple/BT24_007.cs
+++ b/Assets/Scripts/CardEffect/BT24/Purple/BT24_007.cs
@@ -44,7 +44,7 @@ namespace DCGO.CardEffects.BT24
                     return cardSource.IsDigimon
                         && cardSource.HasLevel && cardSource.Level >= 4
                         && (cardSource.EqualsTraits("Demon") || cardSource.EqualsTraits("Titan"))
-                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: cardSource.GetCostItself-2);
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, root: SelectCardEffect.Root.Trash, fixedCost: cardSource.GetCostItself-2);
                 }
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/BT26/Purple/BT26_059.cs
+++ b/Assets/Scripts/CardEffect/BT26/Purple/BT26_059.cs
@@ -47,7 +47,7 @@ namespace DCGO.CardEffects.BT26
                 => cardSource.IsDigimon
                     && cardSource.EqualsTraits("Titan")
                     && !cardSource.EqualsCardName("Plutomon")
-                    && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, fixedCost: Math.Max(0, cardSource.GetCostItself - 7));
+                    && CardEffectCommons.CanPlayAsNewPermanent(cardSource, true, activateClass, root: SelectCardEffect.Root.Trash, fixedCost: Math.Max(0, cardSource.GetCostItself - 7));
 
             bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
                 => card.Owner.HandCards.Count >= 1;


### PR DESCRIPTION
## Summary
Both abilities play a Digimon card from trash with a reduced fixed cost (`payCost: true`), but their `CanPlayAsNewPermanent` legality check omitted the `root` parameter, defaulting to `SelectCardEffect.Root.Hand` even though the card is played from `Root.Trash` — a mismatch against the real play call (`PlayPermanentCards(..., root: SelectCardEffect.Root.Trash, ...)`) a few lines below in both files. Root scoping can affect the final computed cost via `GetChangedCostItselef`/`GetChangedPayingCost`'s `rootCondition` checks, so the selection-time legality check could disagree with the real cost paid at play time. Passed `root: SelectCardEffect.Root.Trash` explicitly to both calls so the legality check matches the actual play.

Context: investigating a report that Tsunomon's "play from trash" ability let the player select a target they couldn't actually afford. Live debug-logging on the specific reported case (ZombiePlutomon, cost 12, fixed cost 10, `MaxMemoryCost` 12) showed the engine's memory check was already correctly evaluating it as legal at that moment — so this fix addresses a real, separate inconsistency found in the same code path while investigating, not a confirmed fix for the originally reported symptom, which still needs further live testing to pin down.

## Test plan
- [ ] Further live testing needed to find a scenario where the root mismatch actually changes the outcome (e.g. with another active root-scoped cost modifier in play).

🤖 Generated with [Claude Code](https://claude.com/claude-code)