### PR TITLE
Add EX13_008 Dracomon

### DIFF
--- a/Assets/Scripts/CardEffect/EX13/Red/EX13_008.cs
+++ b/Assets/Scripts/CardEffect/EX13/Red/EX13_008.cs
@@ -67,7 +67,8 @@ namespace DCGO.CardEffects.EX13
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("This Digimon and 1 other Digimon may DNA digivolve", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 activateClass.SetIsInheritedEffect(true);
                 cardEffects.Add(activateClass);
 
@@ -83,28 +84,25 @@ namespace DCGO.CardEffects.EX13
                         && cardSource.CanJogressFromTargetPermanent(card.PermanentOfThisCard(), true);
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card)
-                        && card.Owner.HandCards.Count >= 1
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectDNACardCondition)
                         && CardEffectCommons.HasMatchConditionOwnersPermanent(card, permanent => permanent.IsDigimon && permanent != card.PermanentOfThisCard());
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)
                 {
-                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
-                    {
-                        yield return ContinuousController.instance.StartCoroutine(
-                            CardEffectCommons.DNADigivolvePermanentsIntoHandOrTrashCard(
-                                CanSelectDNACardCondition,
-                                payCost: true,
-                                isHand: true,
-                                activateClass,
-                                permanentConditions: new Func<Permanent, bool>[] { permanent => permanent == card.PermanentOfThisCard() }
-                            ));
-                    }
+                    yield return ContinuousController.instance.StartCoroutine(
+                        CardEffectCommons.DNADigivolvePermanentsIntoHandOrTrashCard(
+                            CanSelectDNACardCondition,
+                            payCost: true,
+                            isHand: true,
+                            activateClass,
+                            permanentConditions: new Func<Permanent, bool>[] { permanent => permanent == card.PermanentOfThisCard() }
+                        ));
                 }
             }
             #endregion

--- a/Assets/Scripts/CardEffect/EX13/Red/EX13_008.cs
+++ b/Assets/Scripts/CardEffect/EX13/Red/EX13_008.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// Dracomon
+namespace DCGO.CardEffects.EX13
+{
+    public class EX13_008 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                    => targetPermanent.TopCard.EqualsCardName("Bebydomon");
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition, digivolutionCost: 0, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared When Moving / On Play
+
+            string SharedEffectName = "Reveal the top 3 cards of deck, add 1 [Dracomon]/[Examon] text card to hand";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] Reveal the top 3 cards of your deck. Add 1 card with [Dracomon] or [Examon] in its text among them to the hand. Return the rest to the bottom of the deck.";
+
+            bool CanSelectCardCondition(CardSource cardSource)
+                => cardSource.HasText("Dracomon") || cardSource.HasText("Examon");
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SimplifiedRevealDeckTopCardsAndSelect(
+                    revealCount: 3,
+                    simplifiedSelectCardConditions:
+                    new SimplifiedSelectCardConditionClass[]
+                    {
+                        new SimplifiedSelectCardConditionClass(
+                            canTargetCondition: CanSelectCardCondition,
+                            message: "Select 1 card with [Dracomon] or [Examon] in its text.",
+                            mode: SelectCardEffect.Mode.AddHand,
+                            maxCount: 1,
+                            selectCardCoroutine: null),
+                    },
+                    remainingCardsPlace: RemainingCardsPlace.DeckBottom,
+                    activateClass: activateClass
+                ));
+            }
+
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName,
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                whenMoving: true,
+                onPlay: true);
+
+            #endregion
+
+            #region End of Your Turn - ESS
+            if (timing == EffectTiming.OnEndTurn)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("This Digimon and 1 other Digimon may DNA digivolve", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetIsInheritedEffect(true);
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[End of Your Turn] This Digimon and any of your other Digimon may DNA digivolve into a Digimon card in the hand.";
+
+                bool CanSelectDNACardCondition(CardSource cardSource)
+                    => cardSource != null
+                        && cardSource.IsDigimon
+                        && cardSource.Owner == card.Owner
+                        && cardSource.CanPlayJogress(true)
+                        && CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                        && cardSource.CanJogressFromTargetPermanent(card.PermanentOfThisCard(), true);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                        && CardEffectCommons.IsOwnerTurn(card);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                        && CardEffectCommons.IsOwnerTurn(card)
+                        && card.Owner.HandCards.Count >= 1
+                        && CardEffectCommons.HasMatchConditionOwnersPermanent(card, permanent => permanent.IsDigimon && permanent != card.PermanentOfThisCard());
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    if (CardEffectCommons.IsExistOnBattleAreaDigimon(card))
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(
+                            CardEffectCommons.DNADigivolvePermanentsIntoHandOrTrashCard(
+                                CanSelectDNACardCondition,
+                                payCost: true,
+                                isHand: true,
+                                activateClass,
+                                permanentConditions: new Func<Permanent, bool>[] { permanent => permanent == card.PermanentOfThisCard() }
+                            ));
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
Adds the card effect script for **EX13-008 Dracomon** (#1852).

- Alternate digivolution: [Bebydomon] for cost 0
- [When Moving] / [On Play]: reveal the top 3 cards, add 1 card with [Dracomon] or [Examon] in its text to the hand, return the rest to the bottom of the deck
- Inherited [End of Your Turn]: this Digimon and 1 of your other Digimon may DNA digivolve into a Digimon card in the hand

Not yet tested in Unity. The card also needs its CardBaseEntity asset and the CardList entries in ContinuousControllerScene before it is playable; those are not included in this PR.

Closes #1852