### PR TITLE
Add EX13_039 Coredramon

### DIFF
--- a/Assets/Scripts/CardEffect/EX13/Green/EX13_039.cs
+++ b/Assets/Scripts/CardEffect/EX13/Green/EX13_039.cs
@@ -14,10 +14,10 @@ namespace DCGO.CardEffects.EX13
             if (timing == EffectTiming.None)
             {
                 static bool PermanentCondition(Permanent targetPermanent)
-                    => targetPermanent.TopCard.IsLevel3 && targetPermanent.TopCard.ContainsCardName("Dracomon");
+                    => targetPermanent.TopCard.ContainsCardName("Dracomon");
 
                 cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
-                    permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null));
+                    permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null, level: 3));
             }
             #endregion
 
@@ -81,7 +81,8 @@ namespace DCGO.CardEffects.EX13
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Digivolve into [Examon] text Digimon for reduced cost", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
                 cardEffects.Add(activateClass);
 
                 string EffectDescription()
@@ -98,12 +99,12 @@ namespace DCGO.CardEffects.EX13
                         && cardSource.CanPlayCardTargetFrame(card.PermanentOfThisCard().PermanentFrame, true, activateClass);
 
                 bool CanUseCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                    => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
                         && CardEffectCommons.IsOwnerTurn(card)
                         && CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, PlayedPermanentCondition);
 
                 bool CanActivateCondition(Hashtable hashtable)
-                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                    => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
                         && CardEffectCommons.HasMatchConditionOwnersHand(card, DigivolveCardCondition);
 
                 IEnumerator ActivateCoroutine(Hashtable hashtable)

--- a/Assets/Scripts/CardEffect/EX13/Green/EX13_039.cs
+++ b/Assets/Scripts/CardEffect/EX13/Green/EX13_039.cs
@@ -1,0 +1,140 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Coredramon
+namespace DCGO.CardEffects.EX13
+{
+    public class EX13_039 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                    => targetPermanent.TopCard.IsLevel3 && targetPermanent.TopCard.ContainsCardName("Dracomon");
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition, digivolutionCost: 2, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving
+
+            string SharedEffectName = "May return 1 non-Digi-Egg [Dracomon]/[Examon] text card from trash to hand";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] You may return 1 non-Digi-Egg card with [Dracomon] or [Examon] in its text from your trash to the hand.";
+
+            bool CanSelectTrashCardCondition(CardSource cardSource)
+                => !cardSource.IsDigiEgg
+                    && (cardSource.HasText("Dracomon") || cardSource.HasText("Examon"));
+
+            bool SharedAdditionalActivateCondition(Hashtable hashtable, ActivateClass activateClass)
+                => CardEffectCommons.HasMatchConditionOwnersCardInTrash(card, CanSelectTrashCardCondition);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                SelectCardEffect selectCardEffect = GManager.instance.GetComponent<SelectCardEffect>();
+
+                selectCardEffect.SetUp(
+                    canTargetCondition: CanSelectTrashCardCondition,
+                    canTargetCondition_ByPreSelecetedList: null,
+                    canEndSelectCondition: null,
+                    canNoSelect: () => true,
+                    selectCardCoroutine: null,
+                    afterSelectCardCoroutine: null,
+                    message: "Select 1 card to add to your hand.",
+                    maxCount: 1,
+                    canEndNotMax: false,
+                    isShowOpponent: true,
+                    mode: SelectCardEffect.Mode.AddHand,
+                    root: SelectCardEffect.Root.Trash,
+                    customRootCardList: null,
+                    canLookReverseCard: true,
+                    selectPlayer: card.Owner,
+                    cardEffect: activateClass);
+
+                selectCardEffect.SetUpCustomMessage("Select 1 card to add to your hand.", "The opponent is selecting 1 card to add to their hand.");
+                selectCardEffect.SetUpCustomMessage_ShowCard("Selected Card");
+
+                yield return ContinuousController.instance.StartCoroutine(selectCardEffect.Activate());
+            }
+
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName,
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                isSkippable: true,
+                additionalActivateCondition: SharedAdditionalActivateCondition,
+                onPlay: true,
+                whenDigivolving: true);
+
+            #endregion
+
+            #region Your Turn
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Digivolve into [Examon] text Digimon for reduced cost", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, true, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                    => "[Your Turn] When any of your other Digimon with [Dracomon] or [Examon] in their texts are played, this Digimon may digivolve into a Digimon card with [Examon] in its text in the hand with the cost reduced by 2.";
+
+                bool PlayedPermanentCondition(Permanent permanent)
+                    => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                        && permanent != card.PermanentOfThisCard()
+                        && (permanent.TopCard.HasText("Dracomon") || permanent.TopCard.HasText("Examon"));
+
+                bool DigivolveCardCondition(CardSource cardSource)
+                    => cardSource.IsDigimon
+                        && cardSource.HasText("Examon")
+                        && cardSource.CanPlayCardTargetFrame(card.PermanentOfThisCard().PermanentFrame, true, activateClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                        && CardEffectCommons.IsOwnerTurn(card)
+                        && CardEffectCommons.CanTriggerOnPermanentPlay(hashtable, PlayedPermanentCondition);
+
+                bool CanActivateCondition(Hashtable hashtable)
+                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, DigivolveCardCondition);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.DigivolveIntoHandOrTrashCard(
+                        targetPermanent: card.PermanentOfThisCard(),
+                        cardCondition: DigivolveCardCondition,
+                        payCost: true,
+                        reduceCostTuple: (reduceCost: 2, reduceCostCardCondition: null),
+                        fixedCostTuple: null,
+                        ignoreDigivolutionRequirementFixedCost: -1,
+                        isHand: true,
+                        activateClass: activateClass,
+                        successProcess: null));
+                }
+            }
+            #endregion
+
+            #region Your Turn - ESS
+            if (timing == EffectTiming.None)
+            {
+                bool Condition()
+                    => CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                        && CardEffectCommons.IsOwnerTurn(card);
+
+                cardEffects.Add(CardEffectFactory.ChangeSelfDPStaticEffect(
+                    changeValue: 2000, isInheritedEffect: true, card: card, condition: Condition));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
Adds the card effect script for **EX13-039 Coredramon** (#1883).

- Alternate digivolution: Lv.3 with [Dracomon] in its name for cost 2
- [On Play] / [When Digivolving]: you may return 1 non-Digi-Egg card with [Dracomon] or [Examon] in its text from your trash to the hand
- [Your Turn]: when any of your other Digimon with [Dracomon] or [Examon] in their texts are played, this Digimon may digivolve into a Digimon card with [Examon] in its text in the hand with the cost reduced by 2
- Inherited [Your Turn]: this Digimon gets +2000 DP

The card also needs its CardBaseEntity asset and the CardList entries in ContinuousControllerScene before it is playable; those are not included in this PR.

Closes #1883