### PR TITLE
Add EX13_024 Slayerdramon

### DIFF
--- a/Assets/Scripts/CardEffect/EX13/Blue/EX13_024.cs
+++ b/Assets/Scripts/CardEffect/EX13/Blue/EX13_024.cs
@@ -1,0 +1,246 @@
+using System.Collections;
+using System.Collections.Generic;
+
+// Slayerdramon
+namespace DCGO.CardEffects.EX13
+{
+    public class EX13_024 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Alternate Digivolution Requirement
+            if (timing == EffectTiming.None)
+            {
+                static bool PermanentCondition(Permanent targetPermanent)
+                    => targetPermanent.TopCard.EqualsCardName("Wingdramon") || targetPermanent.TopCard.EqualsCardName("Groundramon");
+
+                cardEffects.Add(CardEffectFactory.AddSelfDigivolutionRequirementStaticEffect(
+                    permanentCondition: PermanentCondition, digivolutionCost: 3, ignoreDigivolutionRequirement: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Raid
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                cardEffects.Add(CardEffectFactory.RaidSelfEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Assembly
+            if (timing == EffectTiming.None)
+            {
+                AddAssemblyConditionClass addAssemblyConditionClass = new AddAssemblyConditionClass();
+                addAssemblyConditionClass.SetUpICardEffect("Assembly", CanUseCondition, card);
+                addAssemblyConditionClass.SetUpAddAssemblyConditionClass(getAssemblyCondition: GetAssembly);
+                addAssemblyConditionClass.SetNotShowUI(true);
+                cardEffects.Add(addAssemblyConditionClass);
+
+                bool CanUseCondition(Hashtable hashtable)
+                    => true;
+
+                bool IsAssemblyCard(CardSource assemblyCard)
+                    => assemblyCard != null
+                        && assemblyCard.Owner == card.Owner
+                        && (assemblyCard.HasText("Dracomon") || assemblyCard.HasText("Examon"));
+
+                AssemblyCondition GetAssembly(CardSource cardSource)
+                {
+                    if (cardSource != card) return null;
+
+                    AssemblyConditionElement level5Element = new AssemblyConditionElement(assemblyCard => IsAssemblyCard(assemblyCard) && assemblyCard.IsLevel5, elementCount: 1);
+                    AssemblyConditionElement level4Element = new AssemblyConditionElement(assemblyCard => IsAssemblyCard(assemblyCard) && assemblyCard.IsLevel4, elementCount: 1);
+                    AssemblyConditionElement level3Element = new AssemblyConditionElement(assemblyCard => IsAssemblyCard(assemblyCard) && assemblyCard.IsLevel3, elementCount: 1);
+
+                    return new AssemblyCondition(
+                        elements: new List<AssemblyConditionElement>() { level5Element, level4Element, level3Element },
+                        reduceCost: 5);
+                }
+            }
+            #endregion
+
+            #region Shared On Play / When Digivolving
+
+            string SharedEffectName = "Trash 1 opponent's digivolution card per this Digimon's digivolution card, then may bottom deck their fewest-source Digimon";
+
+            string SharedEffectDescription(string tag)
+                => $"[{tag}] For each of this Digimon's digivolution cards, trash any 1 digivolution card from your opponent's Digimon. Then, you may return all of their Digimon with the fewest digivolution cards to the bottom of the deck.";
+
+            bool IsOpponentDigimon(Permanent permanent)
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+
+            bool IsFewestSourcesOpponentDigimon(Permanent permanent)
+                => IsOpponentDigimon(permanent)
+                    && CardEffectCommons.IsMinDigivolutionCards(permanent, card.Owner.Enemy);
+
+            IEnumerator SharedActivateCoroutine(Hashtable hashtable, ActivateClass activateClass)
+            {
+                Permanent thisPermanent = card.PermanentOfThisCard();
+                int trashCount = thisPermanent != null ? thisPermanent.DigivolutionCards.Count : 0;
+
+                if (trashCount > 0 && CardEffectCommons.HasMatchConditionPermanent(IsOpponentDigimon))
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SelectTrashDigivolutionCards(
+                        permanentCondition: IsOpponentDigimon,
+                        cardCondition: null,
+                        maxCount: trashCount,
+                        canNoTrash: false,
+                        isFromOnly1Permanent: false,
+                        activateClass: activateClass,
+                        canEndNotMax: false,
+                        afterSelectionCoroutine: AfterTrashSelectionCoroutine));
+
+                    IEnumerator AfterTrashSelectionCoroutine(Permanent permanent, List<CardSource> cardSources)
+                    {
+                        yield return null;
+                    }
+                }
+
+                List<Permanent> bounceTargetPermanents = card.Owner.Enemy.GetBattleAreaDigimons().Filter(IsFewestSourcesOpponentDigimon);
+
+                if (bounceTargetPermanents.Count > 0)
+                {
+                    List<SelectionElement<bool>> selectionElements = new List<SelectionElement<bool>>()
+                    {
+                        new SelectionElement<bool>(message: "Yes", value: true, spriteIndex: 0),
+                        new SelectionElement<bool>(message: "No", value: false, spriteIndex: 1),
+                    };
+
+                    GManager.instance.userSelectionManager.SetBoolSelection(
+                        selectionElements: selectionElements,
+                        selectPlayer: card.Owner,
+                        selectPlayerMessage: "Return all of your opponent's Digimon with the fewest digivolution cards to the bottom of the deck?",
+                        notSelectPlayerMessage: "The opponent is choosing whether to return Digimon to the bottom of the deck.");
+
+                    yield return ContinuousController.instance.StartCoroutine(GManager.instance.userSelectionManager.WaitForEndSelect());
+
+                    if (GManager.instance.userSelectionManager.SelectedBoolValue)
+                    {
+                        yield return ContinuousController.instance.StartCoroutine(
+                            new DeckBottomBounceClass(bounceTargetPermanents, CardEffectCommons.CardEffectHashtable(activateClass)).DeckBounce());
+                    }
+                }
+            }
+
+            CardEffectFactory.ActivateClassesForSharedEffects(
+                ref cardEffects, timing, card,
+                SharedEffectName,
+                SharedActivateCoroutine,
+                SharedEffectDescription,
+                optional: false,
+                onPlay: true,
+                whenDigivolving: true);
+
+            #endregion
+
+            #region All Turns / All Turns - ESS
+            if (timing == EffectTiming.WhenRemoveField)
+            {
+                foreach (bool isInheritedEffect in new[] { false, true })
+                {
+                    List<Permanent> removedPermanents = new List<Permanent>();
+
+                    ActivateClass activateClass = new ActivateClass();
+                    activateClass.SetUpICardEffect("Suspend 1 [Dracomon]/[Examon] text Digimon to prevent leaving", CanUseCondition, card);
+                    activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                    activateClass.SetIsSkippable(true);
+                    activateClass.SetIsInheritedEffect(isInheritedEffect);
+                    activateClass.SetHashString(isInheritedEffect ? "EX13_024_ESS_AT" : "EX13_024_AT");
+                    cardEffects.Add(activateClass);
+
+                    string EffectDescription()
+                        => "[All Turns] [Once Per Turn] When any of your [Dracomon] or [Examon] text Digimon would leave the battle area, by suspending 1 of your such Digimon, they don't leave.";
+
+                    bool IsDracomonOrExamonDigimon(Permanent permanent)
+                        => CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card)
+                            && (permanent.TopCard.HasText("Dracomon") || permanent.TopCard.HasText("Examon"));
+
+                    bool CanSuspendForCostCondition(Permanent permanent)
+                        => IsDracomonOrExamonDigimon(permanent)
+                            && !permanent.IsSuspended
+                            && permanent.CanSuspend;
+
+                    bool CanUseCondition(Hashtable hashtable)
+                        => CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                            && CardEffectCommons.CanTriggerWhenPermanentRemoveField(hashtable, IsDracomonOrExamonDigimon);
+
+                    bool CanActivateCondition(Hashtable hashtable)
+                    {
+                        removedPermanents = CardEffectCommons.GetPermanentsFromHashtable(hashtable).Filter(IsDracomonOrExamonDigimon);
+
+                        return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                            && removedPermanents.Count > 0
+                            && CardEffectCommons.HasMatchConditionPermanent(CanSuspendForCostCondition);
+                    }
+
+                    IEnumerator ActivateCoroutine(Hashtable hashtable)
+                    {
+                        Permanent suspendPermanent = null;
+
+                        SelectPermanentEffect selectPermanentEffect = GManager.instance.GetComponent<SelectPermanentEffect>();
+
+                        selectPermanentEffect.SetUp(
+                            selectPlayer: card.Owner,
+                            canTargetCondition: CanSuspendForCostCondition,
+                            canTargetCondition_ByPreSelecetedList: null,
+                            canEndSelectCondition: null,
+                            maxCount: 1,
+                            canNoSelect: true,
+                            canEndNotMax: false,
+                            selectPermanentCoroutine: SelectPermanentCoroutine,
+                            afterSelectPermanentCoroutine: null,
+                            mode: SelectPermanentEffect.Mode.Custom,
+                            cardEffect: activateClass);
+
+                        selectPermanentEffect.SetUpCustomMessage(
+                            "Select 1 [Dracomon]/[Examon] text Digimon to suspend.",
+                            "The opponent is selecting 1 Digimon to suspend.");
+
+                        yield return ContinuousController.instance.StartCoroutine(selectPermanentEffect.Activate());
+
+                        IEnumerator SelectPermanentCoroutine(Permanent permanent)
+                        {
+                            suspendPermanent = permanent;
+                            yield return null;
+                        }
+
+                        if (suspendPermanent != null)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(new SuspendPermanentsClass(
+                                new List<Permanent>() { suspendPermanent },
+                                CardEffectCommons.CardEffectHashtable(activateClass)).Tap());
+                        }
+
+                        if (suspendPermanent != null && suspendPermanent.IsSuspended)
+                        {
+                            foreach (Permanent removedPermanent in removedPermanents)
+                            {
+                                removedPermanent.willBeRemoveField = false;
+
+                                removedPermanent.HideHandBounceEffect();
+                                removedPermanent.HideDeckBounceEffect();
+                                removedPermanent.HideDeleteEffect();
+                                removedPermanent.HideWillRemoveFieldEffect();
+                            }
+                        }
+                        else
+                        {
+                            activateClass.RemoveUse();
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/EX13/Blue/EX13_024.cs
+++ b/Assets/Scripts/CardEffect/EX13/Blue/EX13_024.cs
@@ -237,7 +237,6 @@ namespace DCGO.CardEffects.EX13
 
                         IEnumerator FailureProcess()
                         {
-                            activateClass.RemoveUse();
                             yield return null;
                         }
                     }

--- a/Assets/Scripts/CardEffect/EX13/Blue/EX13_024.cs
+++ b/Assets/Scripts/CardEffect/EX13/Blue/EX13_024.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 // Slayerdramon
 namespace DCGO.CardEffects.EX13
@@ -75,7 +76,7 @@ namespace DCGO.CardEffects.EX13
                 => $"[{tag}] For each of this Digimon's digivolution cards, trash any 1 digivolution card from your opponent's Digimon. Then, you may return all of their Digimon with the fewest digivolution cards to the bottom of the deck.";
 
             bool IsOpponentDigimon(Permanent permanent)
-                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card);
+                => CardEffectCommons.IsPermanentExistsOnOpponentBattleAreaDigimon(permanent, card) && permanent.DigivolutionCards.Any();
 
             bool IsFewestSourcesOpponentDigimon(Permanent permanent)
                 => IsOpponentDigimon(permanent)
@@ -95,13 +96,7 @@ namespace DCGO.CardEffects.EX13
                         canNoTrash: false,
                         isFromOnly1Permanent: false,
                         activateClass: activateClass,
-                        canEndNotMax: false,
-                        afterSelectionCoroutine: AfterTrashSelectionCoroutine));
-
-                    IEnumerator AfterTrashSelectionCoroutine(Permanent permanent, List<CardSource> cardSources)
-                    {
-                        yield return null;
-                    }
+                        canEndNotMax: false));
                 }
 
                 List<Permanent> bounceTargetPermanents = card.Owner.Enemy.GetBattleAreaDigimons().Filter(IsFewestSourcesOpponentDigimon);
@@ -214,12 +209,18 @@ namespace DCGO.CardEffects.EX13
 
                         if (suspendPermanent != null)
                         {
-                            yield return ContinuousController.instance.StartCoroutine(new SuspendPermanentsClass(
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SuspendPeremanentAndProcessAccordingToResult(
                                 new List<Permanent>() { suspendPermanent },
-                                CardEffectCommons.CardEffectHashtable(activateClass)).Tap());
+                                activateClass,
+                                SuccessProcess,
+                                FailureProcess));
+                        }
+                        else
+                        {
+                            activateClass.RemoveUse();
                         }
 
-                        if (suspendPermanent != null && suspendPermanent.IsSuspended)
+                        IEnumerator SuccessProcess(List<Permanent> suspendedPermanents)
                         {
                             foreach (Permanent removedPermanent in removedPermanents)
                             {
@@ -230,10 +231,14 @@ namespace DCGO.CardEffects.EX13
                                 removedPermanent.HideDeleteEffect();
                                 removedPermanent.HideWillRemoveFieldEffect();
                             }
+
+                            yield return null;
                         }
-                        else
+
+                        IEnumerator FailureProcess()
                         {
                             activateClass.RemoveUse();
+                            yield return null;
                         }
                     }
                 }

--- a/Assets/Scripts/CardEffect/EX13/Blue/EX13_024.cs
+++ b/Assets/Scripts/CardEffect/EX13/Blue/EX13_024.cs
@@ -213,7 +213,7 @@ namespace DCGO.CardEffects.EX13
                                 new List<Permanent>() { suspendPermanent },
                                 activateClass,
                                 SuccessProcess,
-                                FailureProcess));
+                                null));
                         }
                         else
                         {
@@ -232,11 +232,6 @@ namespace DCGO.CardEffects.EX13
                                 removedPermanent.HideWillRemoveFieldEffect();
                             }
 
-                            yield return null;
-                        }
-
-                        IEnumerator FailureProcess()
-                        {
                             yield return null;
                         }
                     }


### PR DESCRIPTION
Adds the card effect script for **EX13-024 Slayerdramon** (#1868).

- Alternate digivolution: [Wingdramon] or [Groundramon] for cost 3
- <Raid>, <Blocker>
- Assembly -5: Lv.5 x Lv.4 x Lv.3, all with [Dracomon] or [Examon] in their text
- [On Play] / [When Digivolving]: for each of this Digimon's digivolution cards, trash any 1 digivolution card from your opponent's Digimon. Then, you may return all of their Digimon with the fewest digivolution cards to the bottom of the deck
- [All Turns] [Once Per Turn] (also inherited): when any of your [Dracomon] or [Examon] text Digimon would leave the battle area, by suspending 1 of your such Digimon, they don't leave
Closes #1868