### PR TITLE
Add EX13_047 Gotsumon

### DIFF
--- a/Assets/Scripts/CardEffect/EX13/Black/EX13_047.cs
+++ b/Assets/Scripts/CardEffect/EX13/Black/EX13_047.cs
@@ -1,0 +1,119 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects
+{
+    public class EX13_047 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region On Play
+            if (timing == EffectTiming.OnEnterFieldAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Reveal the top 3 cards of deck", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[On Play] Reveal the top 3 cards of your deck. Add 1 card with the [Royal Knight] trait and 1 card with <Blocker> among them to the hand. Return the rest to the bottom of the deck.";
+                }
+
+                bool CanSelectCardCondition(CardSource cardSource) => cardSource.CardTraits.Contains("Royal Knight");
+
+                bool CanSelectCardCondition1(CardSource cardSource) => cardSource.HasBlocker;
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnPlay(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                IEnumerator ActivateCoroutine(Hashtable _hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SimplifiedRevealDeckTopCardsAndSelect(
+                        revealCount: 3,
+                        simplifiedSelectCardConditions:
+                        new SimplifiedSelectCardConditionClass[]
+                        {
+                            new SimplifiedSelectCardConditionClass(
+                                canTargetCondition: CanSelectCardCondition,
+                                message: "Select 1 card with the [Royal Knight] trait.",
+                                mode: SelectCardEffect.Mode.AddHand,
+                                maxCount: 1,
+                                selectCardCoroutine: null),
+                            new SimplifiedSelectCardConditionClass(
+                                canTargetCondition: CanSelectCardCondition1,
+                                message: "Select 1 card with <Blocker>.",
+                                mode: SelectCardEffect.Mode.AddHand,
+                                maxCount: 1,
+                                selectCardCoroutine: null),
+                        },
+                        remainingCardsPlace: RemainingCardsPlace.DeckBottom,
+                        activateClass: activateClass
+                    ));
+                }
+            }
+            #endregion
+
+            #region When Attacking
+            if (timing == EffectTiming.OnAllyAttack)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Memory -2", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
+                cardEffects.Add(activateClass);
+
+                string EffectDiscription()
+                {
+                    return "[When Attacking] Lose 2 memory.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerOnAttack(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    yield return ContinuousController.instance.StartCoroutine(card.Owner.AddMemory(-2, activateClass));
+                }
+            }
+            #endregion
+
+            #region Opponent's Turn - ESS
+            if (timing == EffectTiming.None)
+            {
+                bool Condition()
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaDigimon(card)
+                        && CardEffectCommons.IsOpponentTurn(card);
+                }
+
+                cardEffects.Add(CardEffectFactory.ChangeSelfDPStaticEffect(
+                    changeValue: 2000,
+                    isInheritedEffect: true,
+                    card: card,
+                    condition: Condition));
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}

--- a/Assets/Scripts/CardEffect/EX13/Black/EX13_047.cs
+++ b/Assets/Scripts/CardEffect/EX13/Black/EX13_047.cs
@@ -73,10 +73,10 @@ namespace DCGO.CardEffects
             {
                 ActivateClass activateClass = new ActivateClass();
                 activateClass.SetUpICardEffect("Memory -2", CanUseCondition, card);
-                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDiscription());
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, -1, false, EffectDescription());
                 cardEffects.Add(activateClass);
 
-                string EffectDiscription()
+                string EffectDescription()
                 {
                     return "[When Attacking] Lose 2 memory.";
                 }


### PR DESCRIPTION
Adds the card effect script for EX13-047 Gotsumon #1891.

[On Play] Reveal the top 3 cards of your deck. Add 1 card with the [Royal Knight] trait and 1 card with ＜Blocker＞ among them to the hand. Return the rest to the bottom of the deck.
[When Attacking] Lose 2 memory.

Inherited Effect
[Opponent's Turn] This Digimon gets +2000 DP.

Closes #1891