### PR TITLE
Fix AI hand selection queue desync looping Siriusmon

### DIFF
--- a/Assets/Scripts/CardEffect/AD1/Red/AD1_007.cs
+++ b/Assets/Scripts/CardEffect/AD1/Red/AD1_007.cs
@@ -117,6 +117,12 @@ namespace DCGO.CardEffects.AD1
                         selectionElements.Add(new(message: $"from Trash", value: 2, spriteIndex: 0));
                     }
 
+                    // Not enough cards left to finish the cost (e.g. they left hand/trash before resolving)
+                    if (validHandCardCount + validTrashCardCount < 3 - selectedCards.Count)
+                    {
+                        yield break;
+                    }
+
                     string selectPlayerMessage = "From which area will you select a card to place under as digivolution cards?";
                     string notSelectPlayerMessage = "The opponent is choosing from which area to select a card to place under as digivolution cards.";
 

--- a/Assets/Scripts/Script/SelectHandEffect.cs
+++ b/Assets/Scripts/Script/SelectHandEffect.cs
@@ -484,41 +484,41 @@ public class SelectHandEffect : MonoBehaviourPunCallbacks
                     {
                         _noSelect = true;
 
-                        for (int maxCount = 0; maxCount < _maxCount; maxCount++)
+                        // Queue exactly one selection (the largest valid count). Queuing one per count
+                        // left stale selections in the player's queue that later selections dequeued,
+                        // e.g. a "select until 3" loop always received an empty pick and never ended.
+                        List<int> CardIDs = null;
+
+                        for (int maxCount = 0; maxCount <= _maxCount && maxCount <= ValidCards.Count; maxCount++)
                         {
                             IList<int> indexList = Enumerable.Range(0, ValidCards.Count).ToList();
 
-                            List<int> CardIDs = null;
-
-                            if (ValidCards.Count >= maxCount)
+                            for (int i = 0; i < 1000; i++)
                             {
-                                for (int i = 0; i < 1000; i++)
+                                List<int> GetIndexes = indexList.GetRandom(maxCount).ToList();
+
+                                List<CardSource> GetCards = new List<CardSource>();
+
+                                foreach (int index in GetIndexes)
                                 {
-                                    List<int> GetIndexes = indexList.GetRandom(maxCount).ToList();
+                                    GetCards.Add(ValidCards[index]);
+                                }
 
-                                    List<CardSource> GetCards = new List<CardSource>();
+                                if (CanEndSelect(GetCards))
+                                {
+                                    CardIDs = new List<int>();
 
-                                    foreach (int index in GetIndexes)
+                                    foreach (CardSource cardSource in GetCards)
                                     {
-                                        GetCards.Add(ValidCards[index]);
+                                        CardIDs.Add(cardSource.CardIndex);
                                     }
 
-                                    if (CanEndSelect(GetCards))
-                                    {
-                                        CardIDs = new List<int>();
-
-                                        foreach (CardSource cardSource in GetCards)
-                                        {
-                                            CardIDs.Add(cardSource.CardIndex);
-                                        }
-
-                                        break;
-                                    }
+                                    break;
                                 }
                             }
+                        }
 
-                            SetTargetHandCards(_selectPlayer.PlayerID, CardIDs != null ? CardIDs.ToArray() : null);
-                        }  
+                        SetTargetHandCards(_selectPlayer.PlayerID, CardIDs != null ? CardIDs.ToArray() : null);
                     }
 
                     else


### PR DESCRIPTION
## Summary
When the AI resolves AD1-007 Siriusmon's [When Digivolving] / [When Attacking] effect (e.g. after digivolving over Canoweissmon), the game soft-locks. The effect keeps asking the AI where to take cards from, never places any, and the game can't progress. The console repeats `Selection Elements Count: 1` and `Unexpected Player Selection`.

## Cause
- `SelectHandEffect`'s AI branch for `canEndNotMax` selections loops over pick sizes `0..max-1`. Since the player selection queue was introduced (bc93ac0b90), `SetTargetHandCards` is called inside that loop, so it queues one `CardSelection` per size instead of one in total.
- The current prompt dequeues the first (empty) pick. The remaining picks stay in the player's queue and are dequeued by later prompts of any type. `UserSelectionManager.WaitForEndSelect` then receives a `CardSelection`, logs `Unexpected Player Selection` and falls back to value 0.
- AD1-007 places cards in a `while (selectedCards.Count < 3)` loop. The AI only ever receives empty or mismatched selections (and never tries picking the max count), so the loop never ends.

## Changes
- `SelectHandEffect.cs`: the AI queues exactly one selection for `canEndNotMax`, using the largest valid pick size up to and including `max`.
- `AD1_007.cs`: exit the placement loop if hand + trash can no longer supply the remaining cards, instead of looping with no options.

## Behaviour change
For "select up to N cards from hand" prompts, the AI now selects as many valid cards as it can. Previously it effectively selected none and left stale selections in its queue.

## Testing
- [ ] Bot game: AI digivolves Siriusmon over Canoweissmon with 3+ Digimon with [Gammamon] in text in hand and an empty trash. The AI places 3 cards, the delete resolves, and the game continues.
- [ ] No `Unexpected Player Selection` warnings during the effect.
- [ ] Player-controlled Siriusmon still allows choosing hand/trash and top/bottom placement.
