### PR TITLE
Add EX13_056 Giromon

### DIFF
--- a/Assets/Scripts/CardEffect/EX13/Black/EX13_056.cs
+++ b/Assets/Scripts/CardEffect/EX13/Black/EX13_056.cs
@@ -1,0 +1,157 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace DCGO.CardEffects
+{
+    public class EX13_056 : CEntity_Effect
+    {
+        public override List<ICardEffect> CardEffects(EffectTiming timing, CardSource card)
+        {
+            List<ICardEffect> cardEffects = new List<ICardEffect>();
+
+            #region Collision
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.CollisionSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region Blocker
+            if (timing == EffectTiming.None)
+            {
+                cardEffects.Add(CardEffectFactory.BlockerSelfStaticEffect(isInheritedEffect: false, card: card, condition: null));
+            }
+            #endregion
+
+            #region All Turns - OPT
+            if (timing == EffectTiming.OnTappedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Reveal top 3, Play level 4 or lower digimon with <Blocker> for free", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[All Turns] [Once Per Turn] When this Digimon suspends, reveal the top 3 cards of your deck. You may play 1 level 4 or lower black Digimon card with <Blocker> among them without paying the cost. Trash the rest.";
+                }
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenSelfPermanentSuspends(hashtable, card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable) => CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass);
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool CanSelectCardCondition(CardSource cardSource)
+                    {
+                        return cardSource.IsDigimon
+                            && cardSource.Level <= 4
+                            && cardSource.HasBlocker
+                            && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
+                    }
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.SimplifiedRevealDeckTopCardsAndSelect(
+                        revealCount: 3,
+                        simplifiedSelectCardConditions:
+                            new SimplifiedSelectCardConditionClass[]
+                            {
+                                new SimplifiedSelectCardConditionClass(
+                                    canTargetCondition:CanSelectCardCondition,
+                                    message: "Select 1 Digimon card to play for free.",
+                                    mode: SelectCardEffect.Mode.Custom,
+                                    maxCount: 1,
+                                    selectCardCoroutine: SelectCardCoroutine),
+                            },
+                        remainingCardsPlace: RemainingCardsPlace.Trash,
+                        activateClass: activateClass,
+                        canNoSelect: true
+                    ));
+
+                    IEnumerator SelectCardCoroutine(CardSource cardSource)
+                    {
+                        if (cardSource != null)
+                        {
+                            yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayPermanentCards(
+                                cardSources: new List<CardSource> { cardSource },
+                                activateClass: activateClass,
+                                payCost: false,
+                                isTapped: false,
+                                root: SelectCardEffect.Root.Library,
+                                activateETB: true
+                            ));
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Opponents Turn - OPT - ESS
+            if (timing == EffectTiming.OnTappedAnyone)
+            {
+                ActivateClass activateClass = new ActivateClass();
+                activateClass.SetUpICardEffect("Play level 5 or lower digimon with <Blocker> for free from hand", CanUseCondition, card);
+                activateClass.SetUpActivateClass(CanActivateCondition, ActivateCoroutine, 1, false, EffectDescription());
+                activateClass.SetIsSkippable(true);
+                activateClass.SetIsInheritedEffect(true);
+                activateClass.SetHashString("EX13_056_Inherited");
+                cardEffects.Add(activateClass);
+
+                string EffectDescription()
+                {
+                    return "[Opponent's Turn] [Once Per Turn] When any of your Digimon suspend, you may play 1 level 5 or lower black Digimon card with <Blocker> from your hand without paying the cost.";
+                }
+
+                bool PermanentCondition(Permanent permanent) =>  CardEffectCommons.IsPermanentExistsOnOwnerBattleAreaDigimon(permanent, card);
+
+                bool CanUseCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaTrigger(card, activateClass)
+                        && CardEffectCommons.CanTriggerWhenPermanentSuspends(hashtable, PermanentCondition)
+                        && CardEffectCommons.IsOpponentTurn(card);
+                }
+
+                bool CanActivateCondition(Hashtable hashtable)
+                {
+                    return CardEffectCommons.IsExistOnBattleAreaActivate(card, activateClass)
+                        && CardEffectCommons.HasMatchConditionOwnersHand(card, CanSelectCardCondition);
+                }
+
+                bool CanSelectCardCondition(CardSource cardSource)
+                {
+                    return cardSource.IsDigimon
+                        && cardSource.Level <= 5
+                        && cardSource.HasBlocker
+                        && CardEffectCommons.CanPlayAsNewPermanent(cardSource, false, activateClass);
+                }
+
+                IEnumerator ActivateCoroutine(Hashtable hashtable)
+                {
+                    bool isUsed = false;
+
+                    yield return ContinuousController.instance.StartCoroutine(CardEffectCommons.PlayByEffect(
+                        canTargetCondition: CanSelectCardCondition,
+                        root: SelectCardEffect.Root.Hand,
+                        cardEffect: activateClass,
+                        payCost: false,
+                        afterSelectCardCoroutine: AfterSelectCardCoroutine
+                    ));
+
+                    IEnumerator AfterSelectCardCoroutine(List<CardSource> cardSources)
+                    {
+                        if (cardSources != null && cardSources.Count > 0) isUsed = true;
+                        yield return null;
+                    }
+
+                    if (!isUsed) activateClass.RemoveUse();
+                }
+            }
+            #endregion
+
+            return cardEffects;
+        }
+    }
+}


### PR DESCRIPTION
Adds the card effect script for EX13-056 Giromon #1900 

[All Turns] [Once Per Turn] When this Digimon suspends, reveal the top 3 cards of your deck. You may play 1 level 4 or lower black Digimon card with ＜Blocker＞ among them without paying the cost. Trash the rest.

Inherited Effect
[Opponent's Turn] [Once Per Turn] When any of your Digimon suspend, you may play 1 level 5 or lower black Digimon card with ＜Blocker＞ from your hand without paying the cost.

Closes #1900