### PR TITLE
Fix bot AI stuck when choosing targets for cost-limited effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@
 ExportedObj/
 .consulo/
 *.csproj
+# Test projects are committed, not Unity-generated.
+!tests/**/*.csproj
 *.unityproj
 *.sln
 *.suo
@@ -101,3 +103,7 @@ crashlytics-build.properties
 /Assets/Effect/KTK_Effect_Samples.meta
 /Assets/SCI-FI UI Components.meta
 /Assets/Sound.meta
+
+# .NET test project build output
+tests/**/[Bb]in/
+tests/**/[Oo]bj/

--- a/Assets/Scripts/Script/AISelectionUtility.cs
+++ b/Assets/Scripts/Script/AISelectionUtility.cs
@@ -9,20 +9,14 @@ public static class AISelectionUtility
     public const int MaxRandomAttempts = 200;
     public const int MaxExhaustiveCombinations = 60000;
 
-    // totalCount:   number of eligible candidates (indexes 0 .. totalCount-1)
-    // canEndSelect: validates a complete selection against the effect's own end condition
-    // canAdd:       incremental validation when building the selection (may be null)
-    // maxCount:     the effect's maximum selectable count
-    // canNoSelect:  whether the effect allows declining to choose nothing
-    // canEndNotMax: whether the effect allows ending with fewer than maxCount
     // Returns the chosen indexes, or null when the AI should decline (no selection).
     public static List<int> Choose(
-        int totalCount,
-        Func<List<int>, bool> canEndSelect,
-        Func<List<int>, int, bool> canAdd,
-        int maxCount,
-        bool canNoSelect,
-        bool canEndNotMax)
+        int totalCount,                         // number of eligible candidates (indexes 0..totalCount-1)
+        Func<List<int>, bool> canEndSelect,     // validates a complete selection (e.g. total-cost cap)
+        Func<List<int>, int, bool> canAdd,      // incremental validation as the selection grows (nullable)
+        int maxCount,                           // maximum selectable targets
+        bool canNoSelect,                       // declining (returning null) is allowed
+        bool canEndNotMax)                      // ending with fewer than maxCount is allowed
     {
         if (totalCount <= 0)
         {

--- a/Assets/Scripts/Script/AISelectionUtility.cs
+++ b/Assets/Scripts/Script/AISelectionUtility.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+// Pure selection logic (no UnityEngine references) so it can be unit-tested
+// without a running Unity instance.
+public static class AISelectionUtility
+{
+    public const int MaxRandomAttempts = 200;
+    public const int MaxExhaustiveCombinations = 60000;
+
+    // totalCount:   number of eligible candidates (indexes 0 .. totalCount-1)
+    // canEndSelect: validates a complete selection against the effect's own end condition
+    // canAdd:       incremental validation when building the selection (may be null)
+    // maxCount:     the effect's maximum selectable count
+    // canNoSelect:  whether the effect allows declining to choose nothing
+    // canEndNotMax: whether the effect allows ending with fewer than maxCount
+    // Returns the chosen indexes, or null when the AI should decline (no selection).
+    public static List<int> Choose(
+        int totalCount,
+        Func<List<int>, bool> canEndSelect,
+        Func<List<int>, int, bool> canAdd,
+        int maxCount,
+        bool canNoSelect,
+        bool canEndNotMax)
+    {
+        if (totalCount <= 0)
+        {
+            return null;
+        }
+
+        // Try from the largest possible selection down to the smallest.
+        for (int selectCount = Math.Min(maxCount, totalCount); selectCount >= 1; selectCount--)
+        {
+            // Only sizes the ending rule allows may be sent.
+            if (!(selectCount == maxCount || (selectCount <= maxCount && canEndNotMax)))
+            {
+                continue;
+            }
+
+            // Random sampling.
+            for (int attempt = 0; attempt < MaxRandomAttempts; attempt++)
+            {
+                List<int> candidate = RandomSample(totalCount, selectCount);
+
+                if (IsValid(candidate, canEndSelect, canAdd))
+                {
+                    return candidate;
+                }
+            }
+
+            // Exhaustive scan as a fallback.
+            foreach (List<int> candidate in EnumerateCombinations(totalCount, selectCount, MaxExhaustiveCombinations))
+            {
+                if (IsValid(candidate, canEndSelect, canAdd))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        if (canNoSelect)
+        {
+            return null;
+        }
+
+        // Last resort: pick the first target rather than hanging.
+        return new List<int>() { 0 };
+    }
+
+    static bool IsValid(List<int> candidate, Func<List<int>, bool> canEndSelect, Func<List<int>, int, bool> canAdd)
+    {
+        if (canEndSelect != null)
+        {
+            if (!canEndSelect(candidate))
+            {
+                return false;
+            }
+        }
+
+        if (canAdd != null)
+        {
+            List<int> prefix = new List<int>();
+
+            foreach (int index in candidate)
+            {
+                if (!canAdd(prefix, index))
+                {
+                    return false;
+                }
+
+                prefix.Add(index);
+            }
+        }
+
+        return true;
+    }
+
+    static List<int> RandomSample(int totalCount, int count)
+    {
+        Random random = new Random();
+        List<int> pool = Enumerable.Range(0, totalCount).ToList();
+        List<int> result = new List<int>();
+
+        for (int i = 0; i < count && pool.Count > 0; i++)
+        {
+            int draw = random.Next(0, pool.Count);
+            result.Add(pool[draw]);
+            pool.RemoveAt(draw);
+        }
+
+        return result;
+    }
+
+    // Enumerates C(n,k) index combinations, yielding at most maxResults.
+    static IEnumerable<List<int>> EnumerateCombinations(int n, int k, int maxResults)
+    {
+        int[] indexes = new int[k];
+        int yielded = 0;
+
+        return Enumerate(0, 0);
+
+        IEnumerable<List<int>> Enumerate(int start, int depth)
+        {
+            if (yielded >= maxResults)
+            {
+                yield break;
+            }
+
+            if (depth == k)
+            {
+                yielded++;
+                yield return indexes.ToList();
+                yield break;
+            }
+
+            for (int i = start; i < n; i++)
+            {
+                indexes[depth] = i;
+
+                foreach (List<int> combo in Enumerate(i + 1, depth + 1))
+                {
+                    yield return combo;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Script/SelectPermanentEffect.cs
+++ b/Assets/Scripts/Script/SelectPermanentEffect.cs
@@ -641,44 +641,45 @@ public class SelectPermanentEffect : MonoBehaviourPunCallbacks
                         }
                     }
 
-                    IList<int> indexList = Enumerable.Range(0, ValidCharas.Count).ToList();
-
-                    if (ValidCharas.Count >= _maxCount)
-                    {
-                        for (int i = 0; i < 200; i++)
+                    List<int> selectedIndexes = AISelectionUtility.Choose(
+                        ValidCharas.Count,
+                        canEndSelect: (List<int> indexes) =>
                         {
-                            List<int> GetIndexes = indexList.GetRandom(_maxCount).ToList();
-
-                            List<Permanent> GetCharas = new List<Permanent>();
-
-                            foreach (int index in GetIndexes)
+                            return CanEndSelect(indexes.Select((index) => ValidCharas[index]).ToList());
+                        },
+                        canAdd: _canTargetCondition_ByPreSelecetedList == null
+                            ? (Func<List<int>, int, bool>)null
+                            : (List<int> prefixIndexes, int index) =>
                             {
-                                GetCharas.Add(ValidCharas[index]);
-                            }
+                                return _canTargetCondition_ByPreSelecetedList(prefixIndexes.Select((prefixIndex) => ValidCharas[prefixIndex]).ToList(), ValidCharas[index]);
+                            },
+                        maxCount: _maxCount,
+                        canNoSelect: _canNoSelect,
+                        canEndNotMax: _canEndNotMax);
 
-                            if (_canEndSelectCondition != null)
+                    if (selectedIndexes != null)
+                    {
+                        List<bool> isTurnPlayer = new List<bool>();
+                        List<int> UnitIDs = new List<int>();
+
+                        foreach (int index in selectedIndexes)
+                        {
+                            Permanent chara = ValidCharas[index];
+
+                            if (chara.TopCard != null)
                             {
-                                if (!_canEndSelectCondition(GetCharas))
-                                {
-                                    continue;
-                                }
+                                isTurnPlayer.Add(chara.TopCard.Owner == GManager.instance.turnStateMachine.gameContext.TurnPlayer);
+                                UnitIDs.Add(chara.TopCard.Owner.GetFieldPermanents().IndexOf(chara));
                             }
-
-                            List<bool> isTurnPlayer = new List<bool>();
-                            List<int> UnitIDs = new List<int>();
-
-                            foreach (Permanent chara in GetCharas)
-                            {
-                                if (chara.TopCard != null)
-                                {
-                                    isTurnPlayer.Add(chara.TopCard.Owner == GManager.instance.turnStateMachine.gameContext.TurnPlayer);
-                                    UnitIDs.Add(chara.TopCard.Owner.GetFieldPermanents().IndexOf(chara));
-                                }
-                            }
-
-                            SetTargetFrames(_selectPlayer.PlayerID, isTurnPlayer.ToArray(), UnitIDs.ToArray());
-                            break;
                         }
+
+                        SetTargetFrames(_selectPlayer.PlayerID, isTurnPlayer.ToArray(), UnitIDs.ToArray());
+                    }
+
+                    else if (_canNoSelect)
+                    {
+                        // Decline when choosing nothing is allowed.
+                        SetTargetFrames(_selectPlayer.PlayerID, null, null);
                     }
                 }
                 #endregion

--- a/tests/AISelection.Tests/AISelection.Tests.csproj
+++ b/tests/AISelection.Tests/AISelection.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>AISelection.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../Assets/Scripts/Script/AISelectionUtility.cs" Link="AISelectionUtility.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AISelection.Tests/AISelectionUtilityTests.cs
+++ b/tests/AISelection.Tests/AISelectionUtilityTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace AISelection.Tests
+{
+    public class AISelectionUtilityTests
+    {
+        static List<int> Ints(params int[] values) => values.ToList();
+
+        // 1. Exact-count selection (maxCount must be met, cannot end early).
+        [Fact]
+        public void Choose_SelectsExactlyMaxCount_WhenCanEndNotMaxIsFalse()
+        {
+            List<int> chosen = AISelectionUtility.Choose(
+                totalCount: 5,
+                canEndSelect: (indexes) => indexes.Count == 3,
+                canAdd: null,
+                maxCount: 3,
+                canNoSelect: false,
+                canEndNotMax: false);
+
+            Assert.NotNull(chosen);
+            Assert.Equal(3, chosen.Count);
+            Assert.Equal(chosen.Count, chosen.Distinct().Count());
+            Assert.All(chosen, (index) => Assert.InRange(index, 0, 4));
+        }
+
+        // 2. P-094 Destromon regression: maxCount equals ALL eligible permanents but the
+        //    effect only allows deleting up to a total play cost (3 + Vemmon count).
+        //    The old bot always selected maxCount targets, whose total cost always
+        //    exceeded the cap, so it deadlocked. The selection must be able to end early.
+        [Fact]
+        public void Choose_P094CostCapped_EndsEarlyWithinTotalCostCap()
+        {
+            int[] costs = { 4, 4, 1, 1, 1 };
+            const int totalCostLimit = 3;
+
+            List<int> chosen = AISelectionUtility.Choose(
+                totalCount: costs.Length,
+                canEndSelect: (indexes) => indexes.Sum((i) => costs[i]) <= totalCostLimit,
+                canAdd: null,
+                maxCount: costs.Length,
+                canNoSelect: false,
+                canEndNotMax: true);
+
+            Assert.NotNull(chosen);
+            Assert.NotEmpty(chosen);
+            Assert.True(chosen.All((i) => i >= 0 && i < costs.Length));
+            Assert.Equal(chosen.Count, chosen.Distinct().Count());
+            Assert.True(chosen.Sum((i) => costs[i]) <= totalCostLimit);
+        }
+
+        // 3. BT19-096 Hornet Eraser shape: "choose up to X play cost total" against a list
+        //    of enemy Digimon; the bot may select fewer targets than the count allows.
+        [Fact]
+        public void Choose_DeleteUpToTotalCost_MaySelectFewerThanMaxCount()
+        {
+            int[] costs = { 6, 6, 5, 2, 2 };
+            const int totalCostLimit = 8;
+
+            List<int> chosen = AISelectionUtility.Choose(
+                totalCount: costs.Length,
+                canEndSelect: (indexes) => indexes.Sum((i) => costs[i]) <= totalCostLimit,
+                canAdd: null,
+                maxCount: costs.Length,
+                canNoSelect: false,
+                canEndNotMax: true);
+
+            Assert.NotNull(chosen);
+            Assert.NotEmpty(chosen);
+            Assert.True(chosen.Sum((i) => costs[i]) <= totalCostLimit);
+        }
+
+        // 4. Declining: when nothing satisfies the end condition and the effect allows
+        //    choosing nothing, the AI returns null (mirrors the human "No Selection" path).
+        [Fact]
+        public void Choose_ReturnsNull_WhenNothingValidAndCanNoSelect()
+        {
+            List<int> chosen = AISelectionUtility.Choose(
+                totalCount: 3,
+                canEndSelect: (indexes) => false,
+                canAdd: null,
+                maxCount: 2,
+                canNoSelect: true,
+                canEndNotMax: true);
+
+            Assert.Null(chosen);
+        }
+
+        // 5. No valid set and declining is not allowed: best-effort single target so the
+        //    game never hangs (the effect fizzles instead of freezing).
+        [Fact]
+        public void Choose_FallsBackToSingleTarget_WhenNothingValidAndCannotDecline()
+        {
+            List<int> chosen = AISelectionUtility.Choose(
+                totalCount: 3,
+                canEndSelect: (indexes) => false,
+                canAdd: null,
+                maxCount: 2,
+                canNoSelect: false,
+                canEndNotMax: true);
+
+            Assert.NotNull(chosen);
+            Assert.Equal(new List<int>() { 0 }, chosen);
+        }
+
+        // 6. Empty candidate list: no targets at all, decline (do not fabricate targets).
+        [Fact]
+        public void Choose_ReturnsNull_WhenNoCandidates()
+        {
+            List<int> chosen = AISelectionUtility.Choose(
+                totalCount: 0,
+                canEndSelect: (indexes) => indexes.Count == 1,
+                canAdd: null,
+                maxCount: 1,
+                canNoSelect: false,
+                canEndNotMax: true);
+
+            Assert.Null(chosen);
+        }
+
+        // 7. Incremental canAdd validation is applied while building the selection.
+        //    Index 1 is never acceptable, so the largest valid set is drawn from {0,2}.
+        [Fact]
+        public void Choose_RespectsIncrementalCanAddValidation()
+        {
+            List<int> chosen = AISelectionUtility.Choose(
+                totalCount: 3,
+                canEndSelect: (indexes) => indexes.Count == 2,
+                canAdd: (prefix, index) => index != 1,
+                maxCount: 2,
+                canNoSelect: false,
+                canEndNotMax: false);
+
+            Assert.NotNull(chosen);
+            Assert.Equal(2, chosen.Count);
+            Assert.DoesNotContain(1, chosen);
+        }
+    }
+}


### PR DESCRIPTION
## Problem
The bot freezes the match when activating effects that delete/destroy targets up to a **total play cost** cap, e.g.:
- **P-094 Destromon** [When Digivolving] — delete up to total play cost 3 + Vemmon count
- **BT19-096 Hornet Eraser** — delete up to total play cost 8

These effects set `maxCount` to **all eligible** enemy permanents while only allowing selections whose combined cost fits the cap (`canEndNotMax: true`).

The old AI drew exactly `maxCount` targets and rejected any batch that failed the end condition. When the cap could never be met by selecting *everything*, all 200 retry attempts failed, `SetTargetFrames` was never sent, and `WaitUntil(HasPlayerSelection)` hung the game (manual surrender required).

## Change
- Extracted the AI target-selection logic into a pure C# class `AISelectionUtility.Choose(...)` (no UnityEngine references) so it can be unit-tested without a Unity instance.
  - Iterates selection sizes from `maxCount` down to 1, random sampling with an exhaustive combination fallback.
  - Respects `canEndNotMax` and the incremental `_canTargetCondition_ByPreSelecetedList` validation.
  - Returns `null` to decline when `canNoSelect` is allowed; otherwise falls back to a single target rather than hanging.
- `SelectPermanentEffect` (AI branch) now delegates to `AISelectionUtility.Choose(...)` and declines via `SetTargetFrames(null, null)` when choosing nothing is allowed. Human/`isYou` flow untouched.
- Added `tests/AISelection.Tests` (xUnit, .NET 10): 7 tests covering exact-count selection, the P-094 cost-cap regression, the BT19-096 "up-to-cost" shape, decline, single-target fallback, empty candidates, and `canAdd` validation.

## Verification
- `dotnet test tests/AISelection.Tests/AISelection.Tests.csproj` → 7/7 passing.
- Standalone simulation confirms the pre-fix algorithm selects nothing (deadlock) for P-094's shape, while `AISelectionUtility.Choose` finds a valid subset (total cost ≤ cap).

## Notes
- `.gitignore` additions: `!tests/**/*.csproj` (keep the test project trackable), `tests/**/[Bb]in/`, `tests/**/[Oo]bj/`. Unity-generated `*.csproj` remain ignored.